### PR TITLE
fix(rate-limit): fail-closed with degraded mode fallback

### DIFF
--- a/src/__tests__/lib/rate-limit.test.ts
+++ b/src/__tests__/lib/rate-limit.test.ts
@@ -2,7 +2,7 @@
  * Tests for rate-limit utility functions
  */
 
-jest.mock('@/lib/prisma', () => ({
+jest.mock("@/lib/prisma", () => ({
   prisma: {
     rateLimitEntry: {
       deleteMany: jest.fn(),
@@ -11,171 +11,218 @@ jest.mock('@/lib/prisma', () => ({
       upsert: jest.fn(),
     },
   },
-}))
+}));
 
-import { checkRateLimit, RATE_LIMITS, getClientIP } from '@/lib/rate-limit'
-import { prisma } from '@/lib/prisma'
+import {
+  checkRateLimit,
+  RATE_LIMITS,
+  getClientIP,
+  _clearDegradedModeCache,
+} from "@/lib/rate-limit";
+import { prisma } from "@/lib/prisma";
 
-describe('rate-limit', () => {
+describe("rate-limit", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+    _clearDegradedModeCache();
+  });
 
-  describe('checkRateLimit', () => {
-    const identifier = '127.0.0.1'
-    const endpoint = '/api/register'
-    const config = { limit: 5, windowMs: 60000 }
+  describe("checkRateLimit", () => {
+    const identifier = "127.0.0.1";
+    const endpoint = "/api/register";
+    const config = { limit: 5, windowMs: 60000 };
 
-    describe('successful requests', () => {
-      it('allows first request and creates new entry', async () => {
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(null)
-        ;(prisma.rateLimitEntry.upsert as jest.Mock).mockResolvedValue({})
+    describe("successful requests", () => {
+      it("allows first request and creates new entry", async () => {
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(null);
+        (prisma.rateLimitEntry.upsert as jest.Mock).mockResolvedValue({});
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.success).toBe(true)
-        expect(result.remaining).toBe(4) // limit - 1
-        expect(result.resetAt).toBeInstanceOf(Date)
-      })
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(4); // limit - 1
+        expect(result.resetAt).toBeInstanceOf(Date);
+      });
 
-      it('allows requests within limit', async () => {
-        const now = new Date()
+      it("allows requests within limit", async () => {
+        const now = new Date();
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 2,
           windowStart: now,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
-        ;(prisma.rateLimitEntry.update as jest.Mock).mockResolvedValue({ ...existingEntry, count: 3 })
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
+        (prisma.rateLimitEntry.update as jest.Mock).mockResolvedValue({
+          ...existingEntry,
+          count: 3,
+        });
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.success).toBe(true)
-        expect(result.remaining).toBe(2) // 5 - 3
-      })
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(2); // 5 - 3
+      });
 
-      it('increments count for existing entry', async () => {
-        const now = new Date()
+      it("increments count for existing entry", async () => {
+        const now = new Date();
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 1,
           windowStart: now,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
-        ;(prisma.rateLimitEntry.update as jest.Mock).mockResolvedValue({ ...existingEntry, count: 2 })
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
+        (prisma.rateLimitEntry.update as jest.Mock).mockResolvedValue({
+          ...existingEntry,
+          count: 2,
+        });
 
-        await checkRateLimit(identifier, endpoint, config)
+        await checkRateLimit(identifier, endpoint, config);
 
         expect(prisma.rateLimitEntry.update).toHaveBeenCalledWith({
-          where: { id: 'entry-123' },
+          where: { id: "entry-123" },
           data: { count: 2 },
-        })
-      })
+        });
+      });
 
-      it('returns correct remaining count', async () => {
-        const now = new Date()
+      it("returns correct remaining count", async () => {
+        const now = new Date();
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 3,
           windowStart: now,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
-        ;(prisma.rateLimitEntry.update as jest.Mock).mockResolvedValue({ ...existingEntry, count: 4 })
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
+        (prisma.rateLimitEntry.update as jest.Mock).mockResolvedValue({
+          ...existingEntry,
+          count: 4,
+        });
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.remaining).toBe(1) // 5 - 4
-      })
+        expect(result.remaining).toBe(1); // 5 - 4
+      });
 
-      it('resets window for expired entry', async () => {
-        const oldWindowStart = new Date(Date.now() - 120000) // 2 minutes ago
+      it("resets window for expired entry", async () => {
+        const oldWindowStart = new Date(Date.now() - 120000); // 2 minutes ago
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 5,
           windowStart: oldWindowStart,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
-        ;(prisma.rateLimitEntry.upsert as jest.Mock).mockResolvedValue({})
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
+        (prisma.rateLimitEntry.upsert as jest.Mock).mockResolvedValue({});
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.success).toBe(true)
-        expect(result.remaining).toBe(4) // New window starts
-        expect(prisma.rateLimitEntry.upsert).toHaveBeenCalled()
-      })
-    })
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(4); // New window starts
+        expect(prisma.rateLimitEntry.upsert).toHaveBeenCalled();
+      });
+    });
 
-    describe('blocked requests', () => {
-      it('blocks when limit exceeded', async () => {
-        const now = new Date()
+    describe("blocked requests", () => {
+      it("blocks when limit exceeded", async () => {
+        const now = new Date();
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 5,
           windowStart: now,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.success).toBe(false)
-        expect(result.remaining).toBe(0)
-        expect(result.retryAfter).toBeGreaterThan(0)
-      })
+        expect(result.success).toBe(false);
+        expect(result.remaining).toBe(0);
+        expect(result.retryAfter).toBeGreaterThan(0);
+      });
 
-      it('returns retryAfter in seconds', async () => {
-        const now = new Date()
+      it("returns retryAfter in seconds", async () => {
+        const now = new Date();
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 5,
           windowStart: now,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.retryAfter).toBeDefined()
-        expect(result.retryAfter).toBeGreaterThanOrEqual(1)
-        expect(result.retryAfter).toBeLessThanOrEqual(60) // windowMs / 1000
-      })
+        expect(result.retryAfter).toBeDefined();
+        expect(result.retryAfter).toBeGreaterThanOrEqual(1);
+        expect(result.retryAfter).toBeLessThanOrEqual(60); // windowMs / 1000
+      });
 
-      it('provides resetAt timestamp when blocked', async () => {
-        const now = new Date()
+      it("provides resetAt timestamp when blocked", async () => {
+        const now = new Date();
         const existingEntry = {
-          id: 'entry-123',
+          id: "entry-123",
           count: 5,
           windowStart: now,
-        }
+        };
 
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 0 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(existingEntry)
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 0,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(
+          existingEntry,
+        );
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.resetAt).toBeInstanceOf(Date)
-        expect(result.resetAt.getTime()).toBeGreaterThan(now.getTime())
-      })
-    })
+        expect(result.resetAt).toBeInstanceOf(Date);
+        expect(result.resetAt.getTime()).toBeGreaterThan(now.getTime());
+      });
+    });
 
-    describe('cleanup', () => {
-      it('cleans up expired entries', async () => {
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 2 })
-        ;(prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(null)
-        ;(prisma.rateLimitEntry.upsert as jest.Mock).mockResolvedValue({})
+    describe("cleanup", () => {
+      it("cleans up expired entries", async () => {
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({
+          count: 2,
+        });
+        (prisma.rateLimitEntry.findUnique as jest.Mock).mockResolvedValue(null);
+        (prisma.rateLimitEntry.upsert as jest.Mock).mockResolvedValue({});
 
-        await checkRateLimit(identifier, endpoint, config)
+        await checkRateLimit(identifier, endpoint, config);
 
         expect(prisma.rateLimitEntry.deleteMany).toHaveBeenCalledWith({
           where: {
@@ -183,115 +230,153 @@ describe('rate-limit', () => {
             endpoint,
             expiresAt: { lt: expect.any(Date) },
           },
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('error handling', () => {
-      it('allows request on database error', async () => {
-        ;(prisma.rateLimitEntry.deleteMany as jest.Mock).mockRejectedValue(new Error('DB Error'))
+    describe("error handling", () => {
+      it("allows first request in degraded mode on database error", async () => {
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockRejectedValue(
+          new Error("DB Error"),
+        );
 
-        const result = await checkRateLimit(identifier, endpoint, config)
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-        expect(result.success).toBe(true)
-        expect(result.remaining).toBe(config.limit)
-      })
-    })
-  })
+        // First call in degraded mode should still allow (best-effort fallback)
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(1); // Degraded mode indicator
+      });
 
-  describe('RATE_LIMITS', () => {
-    it('has register limit of 5 per hour', () => {
-      expect(RATE_LIMITS.register.limit).toBe(5)
-      expect(RATE_LIMITS.register.windowMs).toBe(60 * 60 * 1000)
-    })
+      it("denies after degraded mode limit exceeded", async () => {
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockRejectedValue(
+          new Error("DB Error"),
+        );
 
-    it('has forgotPassword limit of 3 per hour', () => {
-      expect(RATE_LIMITS.forgotPassword.limit).toBe(3)
-      expect(RATE_LIMITS.forgotPassword.windowMs).toBe(60 * 60 * 1000)
-    })
+        // Exhaust degraded mode limit (10 calls)
+        for (let i = 0; i < 10; i++) {
+          await checkRateLimit(identifier, endpoint, config);
+        }
 
-    it('has resendVerification limit of 3 per hour', () => {
-      expect(RATE_LIMITS.resendVerification.limit).toBe(3)
-      expect(RATE_LIMITS.resendVerification.windowMs).toBe(60 * 60 * 1000)
-    })
+        // 11th call should be denied
+        const result = await checkRateLimit(identifier, endpoint, config);
 
-    it('has upload limit of 20 per hour', () => {
-      expect(RATE_LIMITS.upload.limit).toBe(20)
-      expect(RATE_LIMITS.upload.windowMs).toBe(60 * 60 * 1000)
-    })
+        expect(result.success).toBe(false);
+        expect(result.remaining).toBe(0);
+        expect(result.retryAfter).toBe(60);
+      });
 
-    it('has messages limit of 60 per hour', () => {
-      expect(RATE_LIMITS.messages.limit).toBe(60)
-      expect(RATE_LIMITS.messages.windowMs).toBe(60 * 60 * 1000)
-    })
+      it("does not log PII on database error", async () => {
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+        (prisma.rateLimitEntry.deleteMany as jest.Mock).mockRejectedValue(
+          new Error("DB Error"),
+        );
 
-    it('has listings limit of 10 per day', () => {
-      expect(RATE_LIMITS.listings.limit).toBe(10)
-      expect(RATE_LIMITS.listings.windowMs).toBe(24 * 60 * 60 * 1000)
-    })
-  })
+        await checkRateLimit("192.168.1.100", endpoint, config);
 
-  describe('getClientIP', () => {
-    const originalNodeEnv = process.env.NODE_ENV
+        // Verify no IP address in logs
+        expect(consoleSpy).toHaveBeenCalled();
+        const logMessage = consoleSpy.mock.calls[0][0];
+        expect(logMessage).not.toContain("192.168.1.100");
+        expect(logMessage).toContain("RL_DB_ERR");
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  describe("RATE_LIMITS", () => {
+    it("has register limit of 5 per hour", () => {
+      expect(RATE_LIMITS.register.limit).toBe(5);
+      expect(RATE_LIMITS.register.windowMs).toBe(60 * 60 * 1000);
+    });
+
+    it("has forgotPassword limit of 3 per hour", () => {
+      expect(RATE_LIMITS.forgotPassword.limit).toBe(3);
+      expect(RATE_LIMITS.forgotPassword.windowMs).toBe(60 * 60 * 1000);
+    });
+
+    it("has resendVerification limit of 3 per hour", () => {
+      expect(RATE_LIMITS.resendVerification.limit).toBe(3);
+      expect(RATE_LIMITS.resendVerification.windowMs).toBe(60 * 60 * 1000);
+    });
+
+    it("has upload limit of 20 per hour", () => {
+      expect(RATE_LIMITS.upload.limit).toBe(20);
+      expect(RATE_LIMITS.upload.windowMs).toBe(60 * 60 * 1000);
+    });
+
+    it("has messages limit of 60 per hour", () => {
+      expect(RATE_LIMITS.messages.limit).toBe(60);
+      expect(RATE_LIMITS.messages.windowMs).toBe(60 * 60 * 1000);
+    });
+
+    it("has listings limit of 10 per day", () => {
+      expect(RATE_LIMITS.listings.limit).toBe(10);
+      expect(RATE_LIMITS.listings.windowMs).toBe(24 * 60 * 60 * 1000);
+    });
+  });
+
+  describe("getClientIP", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
 
     afterEach(() => {
       // Restore original NODE_ENV using delete + assign pattern
-      delete (process.env as { NODE_ENV?: string }).NODE_ENV
-      ;(process.env as { NODE_ENV?: string }).NODE_ENV = originalNodeEnv
-    })
+      delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+      (process.env as { NODE_ENV?: string }).NODE_ENV = originalNodeEnv;
+    });
 
-    it('extracts IP from x-forwarded-for header in development mode', () => {
-      delete (process.env as { NODE_ENV?: string }).NODE_ENV
-      ;(process.env as { NODE_ENV?: string }).NODE_ENV = 'development'
-      const request = new Request('http://localhost', {
-        headers: { 'x-forwarded-for': '192.168.1.1, 10.0.0.1' },
-      })
+    it("extracts IP from x-forwarded-for header in development mode", () => {
+      delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+      (process.env as { NODE_ENV?: string }).NODE_ENV = "development";
+      const request = new Request("http://localhost", {
+        headers: { "x-forwarded-for": "192.168.1.1, 10.0.0.1" },
+      });
 
-      const ip = getClientIP(request)
+      const ip = getClientIP(request);
 
-      expect(ip).toBe('192.168.1.1')
-    })
+      expect(ip).toBe("192.168.1.1");
+    });
 
-    it('extracts first IP from comma-separated list in development mode', () => {
-      delete (process.env as { NODE_ENV?: string }).NODE_ENV
-      ;(process.env as { NODE_ENV?: string }).NODE_ENV = 'development'
-      const request = new Request('http://localhost', {
-        headers: { 'x-forwarded-for': '8.8.8.8, 192.168.1.1, 10.0.0.1' },
-      })
+    it("extracts first IP from comma-separated list in development mode", () => {
+      delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+      (process.env as { NODE_ENV?: string }).NODE_ENV = "development";
+      const request = new Request("http://localhost", {
+        headers: { "x-forwarded-for": "8.8.8.8, 192.168.1.1, 10.0.0.1" },
+      });
 
-      const ip = getClientIP(request)
+      const ip = getClientIP(request);
 
-      expect(ip).toBe('8.8.8.8')
-    })
+      expect(ip).toBe("8.8.8.8");
+    });
 
-    it('uses x-real-ip (Vercel edge header) as primary source', () => {
-      const request = new Request('http://localhost', {
-        headers: { 'x-real-ip': '203.0.113.1' },
-      })
+    it("uses x-real-ip (Vercel edge header) as primary source", () => {
+      const request = new Request("http://localhost", {
+        headers: { "x-real-ip": "203.0.113.1" },
+      });
 
-      const ip = getClientIP(request)
+      const ip = getClientIP(request);
 
-      expect(ip).toBe('203.0.113.1')
-    })
+      expect(ip).toBe("203.0.113.1");
+    });
 
-    it('returns unknown when no headers present', () => {
-      const request = new Request('http://localhost')
+    it("returns unknown when no headers present", () => {
+      const request = new Request("http://localhost");
 
-      const ip = getClientIP(request)
+      const ip = getClientIP(request);
 
-      expect(ip).toBe('unknown')
-    })
+      expect(ip).toBe("unknown");
+    });
 
-    it('trims whitespace from IP in development mode', () => {
-      delete (process.env as { NODE_ENV?: string }).NODE_ENV
-      ;(process.env as { NODE_ENV?: string }).NODE_ENV = 'development'
-      const request = new Request('http://localhost', {
-        headers: { 'x-forwarded-for': '  192.168.1.1  , 10.0.0.1' },
-      })
+    it("trims whitespace from IP in development mode", () => {
+      delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+      (process.env as { NODE_ENV?: string }).NODE_ENV = "development";
+      const request = new Request("http://localhost", {
+        headers: { "x-forwarded-for": "  192.168.1.1  , 10.0.0.1" },
+      });
 
-      const ip = getClientIP(request)
+      const ip = getClientIP(request);
 
-      expect(ip).toBe('192.168.1.1')
-    })
-  })
-})
+      expect(ip).toBe("192.168.1.1");
+    });
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,15 +1,61 @@
-import { prisma } from '@/lib/prisma';
+import { prisma } from "@/lib/prisma";
+
+/**
+ * In-process rate limiter for degraded mode (DB errors).
+ * Non-persistent, best-effort fallback - prevents hard-brick during transient DB blips.
+ * NOT a replacement for DB limiter - just emergency protection.
+ */
+const degradedModeCache = new Map<
+  string,
+  { count: number; windowStart: number }
+>();
+const DEGRADED_MODE_LIMIT = 10;
+const DEGRADED_MODE_WINDOW_MS = 60_000; // 1 minute
+
+/**
+ * Clear degraded mode cache. Exported for testing only.
+ * @internal
+ */
+export function _clearDegradedModeCache(): void {
+  degradedModeCache.clear();
+}
+
+function checkDegradedModeLimit(identifier: string): boolean {
+  const now = Date.now();
+  const entry = degradedModeCache.get(identifier);
+
+  // Cleanup old entries periodically (every 100 calls on average)
+  if (Math.random() < 0.01) {
+    for (const [key, val] of degradedModeCache) {
+      if (now - val.windowStart > DEGRADED_MODE_WINDOW_MS) {
+        degradedModeCache.delete(key);
+      }
+    }
+  }
+
+  if (!entry || now - entry.windowStart > DEGRADED_MODE_WINDOW_MS) {
+    degradedModeCache.set(identifier, { count: 1, windowStart: now });
+    return true; // Allow
+  }
+
+  if (entry.count >= DEGRADED_MODE_LIMIT) {
+    return false; // Deny
+  }
+
+  entry.count++;
+  return true; // Allow
+}
 
 interface RateLimitResult {
-    success: boolean;
-    remaining: number;
-    resetAt: Date;
-    retryAfter?: number; // seconds until reset
+  success: boolean;
+  remaining: number;
+  resetAt: Date;
+  retryAfter?: number; // seconds until reset
 }
 
 interface RateLimitConfig {
-    limit: number;      // max requests allowed
-    windowMs: number;   // time window in milliseconds
+  limit: number; // max requests allowed
+  windowMs: number; // time window in milliseconds
 }
 
 /**
@@ -17,118 +63,137 @@ interface RateLimitConfig {
  * Uses sliding window algorithm with PostgreSQL
  */
 export async function checkRateLimit(
-    identifier: string,
-    endpoint: string,
-    config: RateLimitConfig
+  identifier: string,
+  endpoint: string,
+  config: RateLimitConfig,
 ): Promise<RateLimitResult> {
-    const { limit, windowMs } = config;
-    const now = new Date();
-    const windowStart = new Date(now.getTime() - windowMs);
-    const expiresAt = new Date(now.getTime() + windowMs);
+  const { limit, windowMs } = config;
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowMs);
+  const expiresAt = new Date(now.getTime() + windowMs);
 
-    try {
-        // Clean up expired entries for this identifier/endpoint (opportunistic cleanup)
-        await prisma.rateLimitEntry.deleteMany({
-            where: {
-                identifier,
-                endpoint,
-                expiresAt: { lt: now }
-            }
-        });
+  try {
+    // Clean up expired entries for this identifier/endpoint (opportunistic cleanup)
+    await prisma.rateLimitEntry.deleteMany({
+      where: {
+        identifier,
+        endpoint,
+        expiresAt: { lt: now },
+      },
+    });
 
-        // Try to find existing entry within the current window
-        const existing = await prisma.rateLimitEntry.findUnique({
-            where: {
-                identifier_endpoint: { identifier, endpoint }
-            }
-        });
+    // Try to find existing entry within the current window
+    const existing = await prisma.rateLimitEntry.findUnique({
+      where: {
+        identifier_endpoint: { identifier, endpoint },
+      },
+    });
 
-        if (existing && existing.windowStart > windowStart) {
-            // Entry exists and is within the current window
-            if (existing.count >= limit) {
-                const resetAt = new Date(existing.windowStart.getTime() + windowMs);
-                const retryAfter = Math.ceil((resetAt.getTime() - now.getTime()) / 1000);
-                return {
-                    success: false,
-                    remaining: 0,
-                    resetAt,
-                    retryAfter: Math.max(1, retryAfter)
-                };
-            }
-
-            // Increment the count
-            const updated = await prisma.rateLimitEntry.update({
-                where: { id: existing.id },
-                data: { count: existing.count + 1 }
-            });
-
-            const resetAt = new Date(existing.windowStart.getTime() + windowMs);
-            return {
-                success: true,
-                remaining: Math.max(0, limit - updated.count),
-                resetAt
-            };
-        }
-
-        // Create new entry or reset the window
-        await prisma.rateLimitEntry.upsert({
-            where: {
-                identifier_endpoint: { identifier, endpoint }
-            },
-            create: {
-                identifier,
-                endpoint,
-                count: 1,
-                windowStart: now,
-                expiresAt
-            },
-            update: {
-                count: 1,
-                windowStart: now,
-                expiresAt
-            }
-        });
-
+    if (existing && existing.windowStart > windowStart) {
+      // Entry exists and is within the current window
+      if (existing.count >= limit) {
+        const resetAt = new Date(existing.windowStart.getTime() + windowMs);
+        const retryAfter = Math.ceil(
+          (resetAt.getTime() - now.getTime()) / 1000,
+        );
         return {
-            success: true,
-            remaining: limit - 1,
-            resetAt: expiresAt
+          success: false,
+          remaining: 0,
+          resetAt,
+          retryAfter: Math.max(1, retryAfter),
         };
-    } catch (error) {
-        console.error('Rate limit check error:', error);
-        // On error, allow the request but log it
-        return {
-            success: true,
-            remaining: limit,
-            resetAt: expiresAt
-        };
+      }
+
+      // Increment the count
+      const updated = await prisma.rateLimitEntry.update({
+        where: { id: existing.id },
+        data: { count: existing.count + 1 },
+      });
+
+      const resetAt = new Date(existing.windowStart.getTime() + windowMs);
+      return {
+        success: true,
+        remaining: Math.max(0, limit - updated.count),
+        resetAt,
+      };
     }
+
+    // Create new entry or reset the window
+    await prisma.rateLimitEntry.upsert({
+      where: {
+        identifier_endpoint: { identifier, endpoint },
+      },
+      create: {
+        identifier,
+        endpoint,
+        count: 1,
+        windowStart: now,
+        expiresAt,
+      },
+      update: {
+        count: 1,
+        windowStart: now,
+        expiresAt,
+      },
+    });
+
+    return {
+      success: true,
+      remaining: limit - 1,
+      resetAt: expiresAt,
+    };
+  } catch {
+    // FAIL CLOSED: Deny by default on DB errors (security over availability)
+    // Use degraded mode fallback for availability during transient DB blips
+    console.error("[RateLimit] DB error (code: RL_DB_ERR)");
+
+    // Best-effort in-process fallback (non-persistent, limited protection)
+    const degradedAllowed = checkDegradedModeLimit(identifier);
+
+    if (degradedAllowed) {
+      // Degraded mode: allow with reduced capacity, log for monitoring
+      console.warn("[RateLimit] Degraded mode active (code: RL_DEGRADED)");
+      return {
+        success: true,
+        remaining: 1,
+        resetAt: expiresAt,
+      };
+    }
+
+    // Hard deny: even degraded mode limit exceeded
+    return {
+      success: false,
+      remaining: 0,
+      resetAt: expiresAt,
+      retryAfter: 60,
+    };
+  }
 }
 
 // Predefined rate limit configurations
 export const RATE_LIMITS = {
-    register: { limit: 5, windowMs: 60 * 60 * 1000 },           // 5 per hour
-    forgotPassword: { limit: 3, windowMs: 60 * 60 * 1000 },     // 3 per hour
-    resendVerification: { limit: 3, windowMs: 60 * 60 * 1000 }, // 3 per hour
-    upload: { limit: 20, windowMs: 60 * 60 * 1000 },            // 20 per hour
-    messages: { limit: 60, windowMs: 60 * 60 * 1000 },          // 60 per hour
-    listings: { limit: 10, windowMs: 24 * 60 * 60 * 1000 },     // 10 per day
-    // P1 fixes: Additional rate limits for unprotected endpoints
-    verifyEmail: { limit: 10, windowMs: 60 * 60 * 1000 },       // 10 per hour
-    resetPassword: { limit: 5, windowMs: 60 * 60 * 1000 },      // 5 per hour
-    createListing: { limit: 5, windowMs: 24 * 60 * 60 * 1000 }, // 5 per day
-    sendMessage: { limit: 100, windowMs: 60 * 60 * 1000 },      // 100 per hour
-    createReview: { limit: 10, windowMs: 24 * 60 * 60 * 1000 }, // 10 per day
-    agent: { limit: 20, windowMs: 60 * 60 * 1000 },             // 20 per hour
-    // P2 fixes: Rate limits for scraping protection and abuse prevention
-    listingsRead: { limit: 100, windowMs: 60 * 60 * 1000 },     // 100 per hour (scraping protection)
-    unreadCount: { limit: 60, windowMs: 60 * 1000 },            // 60 per minute (frequent polling)
-    toggleFavorite: { limit: 60, windowMs: 60 * 60 * 1000 },    // 60 per hour
-    createReport: { limit: 10, windowMs: 24 * 60 * 60 * 1000 }, // 10 per day
-    // P0 fix: Search page rate limit to prevent DoS
-    search: { limit: 30, windowMs: 60 * 1000 },                   // 30 per minute
-    // Nearby places search (Radar API)
-    nearbySearch: { limit: 30, windowMs: 60 * 1000 },             // 30 per minute
+  register: { limit: 5, windowMs: 60 * 60 * 1000 }, // 5 per hour
+  forgotPassword: { limit: 3, windowMs: 60 * 60 * 1000 }, // 3 per hour
+  resendVerification: { limit: 3, windowMs: 60 * 60 * 1000 }, // 3 per hour
+  upload: { limit: 20, windowMs: 60 * 60 * 1000 }, // 20 per hour
+  messages: { limit: 60, windowMs: 60 * 60 * 1000 }, // 60 per hour
+  listings: { limit: 10, windowMs: 24 * 60 * 60 * 1000 }, // 10 per day
+  // P1 fixes: Additional rate limits for unprotected endpoints
+  verifyEmail: { limit: 10, windowMs: 60 * 60 * 1000 }, // 10 per hour
+  resetPassword: { limit: 5, windowMs: 60 * 60 * 1000 }, // 5 per hour
+  createListing: { limit: 5, windowMs: 24 * 60 * 60 * 1000 }, // 5 per day
+  sendMessage: { limit: 100, windowMs: 60 * 60 * 1000 }, // 100 per hour
+  createReview: { limit: 10, windowMs: 24 * 60 * 60 * 1000 }, // 10 per day
+  agent: { limit: 20, windowMs: 60 * 60 * 1000 }, // 20 per hour
+  // P2 fixes: Rate limits for scraping protection and abuse prevention
+  listingsRead: { limit: 100, windowMs: 60 * 60 * 1000 }, // 100 per hour (scraping protection)
+  unreadCount: { limit: 60, windowMs: 60 * 1000 }, // 60 per minute (frequent polling)
+  toggleFavorite: { limit: 60, windowMs: 60 * 60 * 1000 }, // 60 per hour
+  createReport: { limit: 10, windowMs: 24 * 60 * 60 * 1000 }, // 10 per day
+  // P0 fix: Search page rate limit to prevent DoS
+  search: { limit: 30, windowMs: 60 * 1000 }, // 30 per minute
+  // Nearby places search (Radar API)
+  nearbySearch: { limit: 30, windowMs: 60 * 1000 }, // 30 per minute
 } as const;
 
 /**
@@ -138,21 +203,21 @@ export const RATE_LIMITS = {
  * x-forwarded-for CAN be spoofed by clients, so only trust it in dev.
  */
 export function getClientIP(request: Request): string {
-    // On Vercel, x-real-ip is set by the edge and cannot be spoofed
-    // ALWAYS prefer it over x-forwarded-for which can be manipulated
-    const realIP = request.headers.get('x-real-ip');
-    if (realIP) {
-        return realIP;
-    }
+  // On Vercel, x-real-ip is set by the edge and cannot be spoofed
+  // ALWAYS prefer it over x-forwarded-for which can be manipulated
+  const realIP = request.headers.get("x-real-ip");
+  if (realIP) {
+    return realIP;
+  }
 
-    // Fallback for non-Vercel environments (local dev only)
-    const forwarded = request.headers.get('x-forwarded-for');
-    if (forwarded && process.env.NODE_ENV === 'development') {
-        return forwarded.split(',')[0].trim();
-    }
+  // Fallback for non-Vercel environments (local dev only)
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded && process.env.NODE_ENV === "development") {
+    return forwarded.split(",")[0].trim();
+  }
 
-    // Fallback
-    return 'unknown';
+  // Fallback
+  return "unknown";
 }
 
 /**
@@ -163,18 +228,18 @@ export function getClientIP(request: Request): string {
  * SECURITY: Same trust model as getClientIP - prefer x-real-ip on Vercel.
  */
 export function getClientIPFromHeaders(headersList: Headers): string {
-    // On Vercel, x-real-ip is set by the edge and cannot be spoofed
-    const realIP = headersList.get('x-real-ip');
-    if (realIP) {
-        return realIP;
-    }
+  // On Vercel, x-real-ip is set by the edge and cannot be spoofed
+  const realIP = headersList.get("x-real-ip");
+  if (realIP) {
+    return realIP;
+  }
 
-    // Fallback for non-Vercel environments (local dev only)
-    const forwarded = headersList.get('x-forwarded-for');
-    if (forwarded && process.env.NODE_ENV === 'development') {
-        return forwarded.split(',')[0].trim();
-    }
+  // Fallback for non-Vercel environments (local dev only)
+  const forwarded = headersList.get("x-forwarded-for");
+  if (forwarded && process.env.NODE_ENV === "development") {
+    return forwarded.split(",")[0].trim();
+  }
 
-    // Fallback
-    return 'unknown';
+  // Fallback
+  return "unknown";
 }


### PR DESCRIPTION
Change DB-backed rate limiter from fail-open to fail-closed behavior for security. Add in-process degraded mode fallback (10 req/min) to maintain availability during transient DB errors.

Changes:
- Add degraded mode cache with 1-minute window and 10-request limit
- Catch block now denies requests by default on DB errors
- Degraded mode allows limited requests during DB outages
- Export _clearDegradedModeCache() for test isolation
- Add tests for degraded mode behavior and PII protection