### PR TITLE
fix(test): add rate limiter mock to reset-password tests

### DIFF
--- a/src/__tests__/api/auth/reset-password.test.ts
+++ b/src/__tests__/api/auth/reset-password.test.ts
@@ -2,7 +2,7 @@
  * Tests for reset password API route
  */
 
-jest.mock('@/lib/prisma', () => ({
+jest.mock("@/lib/prisma", () => ({
   prisma: {
     passwordResetToken: {
       findUnique: jest.fn(),
@@ -13,13 +13,18 @@ jest.mock('@/lib/prisma', () => ({
       update: jest.fn(),
     },
   },
-}))
+}));
 
-jest.mock('bcryptjs', () => ({
-  hash: jest.fn(() => Promise.resolve('hashed_password')),
-}))
+// Mock rate limiter to always allow requests in tests
+jest.mock("@/lib/with-rate-limit", () => ({
+  withRateLimit: jest.fn().mockResolvedValue(null),
+}));
 
-jest.mock('next/server', () => ({
+jest.mock("bcryptjs", () => ({
+  hash: jest.fn(() => Promise.resolve("hashed_password")),
+}));
+
+jest.mock("next/server", () => ({
   NextResponse: {
     json: (data: unknown, init?: { status?: number }) => ({
       status: init?.status || 200,
@@ -27,223 +32,264 @@ jest.mock('next/server', () => ({
       headers: new Map(),
     }),
   },
-}))
+}));
 
-import { POST, GET } from '@/app/api/auth/reset-password/route'
-import { prisma } from '@/lib/prisma'
-import type { NextRequest } from 'next/server'
+import { POST, GET } from "@/app/api/auth/reset-password/route";
+import { prisma } from "@/lib/prisma";
+import type { NextRequest } from "next/server";
 
-describe('Reset Password API', () => {
+describe("Reset Password API", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+  });
 
-  describe('POST /api/auth/reset-password', () => {
+  describe("POST /api/auth/reset-password", () => {
     const createRequest = (body: object) =>
-      new Request('http://localhost:3000/api/auth/reset-password', {
-        method: 'POST',
+      new Request("http://localhost:3000/api/auth/reset-password", {
+        method: "POST",
         body: JSON.stringify(body),
-      }) as unknown as NextRequest
+      }) as unknown as NextRequest;
 
-    it('resets password successfully with valid token', async () => {
+    it("resets password successfully with valid token", async () => {
       const validToken = {
-        id: 'token-123',
-        token: 'valid-token',
-        email: 'test@example.com',
+        id: "token-123",
+        token: "valid-token",
+        email: "test@example.com",
         expires: new Date(Date.now() + 3600000),
-      }
-      const mockUser = { id: 'user-123', email: 'test@example.com' }
+      };
+      const mockUser = { id: "user-123", email: "test@example.com" };
 
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(validToken)
-      ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
-      ;(prisma.user.update as jest.Mock).mockResolvedValue({})
-      ;(prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({})
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        validToken,
+      );
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.update as jest.Mock).mockResolvedValue({});
+      (prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({});
 
-      const request = createRequest({ token: 'valid-token', password: 'newpassword123' })
-      const response = await POST(request)
-      const data = await response.json()
+      const request = createRequest({
+        token: "valid-token",
+        password: "newpassword123",
+      });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(data.message).toBe('Password has been reset successfully')
+      expect(response.status).toBe(200);
+      expect(data.message).toBe("Password has been reset successfully");
       expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-123' },
-        data: { password: 'hashed_password' },
-      })
-      expect(prisma.passwordResetToken.delete).toHaveBeenCalled()
-    })
+        where: { id: "user-123" },
+        data: { password: "hashed_password" },
+      });
+      expect(prisma.passwordResetToken.delete).toHaveBeenCalled();
+    });
 
-    it('returns error for missing token', async () => {
-      const request = createRequest({ password: 'newpassword123' })
-      const response = await POST(request)
-      const data = await response.json()
+    it("returns error for missing token", async () => {
+      const request = createRequest({ password: "newpassword123" });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBeDefined()
-    })
+      expect(response.status).toBe(400);
+      expect(data.error).toBeDefined();
+    });
 
-    it('returns error for missing password', async () => {
-      const request = createRequest({ token: 'valid-token' })
-      const response = await POST(request)
-      const data = await response.json()
+    it("returns error for missing password", async () => {
+      const request = createRequest({ token: "valid-token" });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBeDefined()
-    })
+      expect(response.status).toBe(400);
+      expect(data.error).toBeDefined();
+    });
 
-    it('returns error for short password', async () => {
-      const request = createRequest({ token: 'valid-token', password: '12345' })
-      const response = await POST(request)
-      const data = await response.json()
+    it("returns error for short password", async () => {
+      const request = createRequest({
+        token: "valid-token",
+        password: "12345", // 5 characters, less than 6 required
+      });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBe('Password must be at least 6 characters')
-    })
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Password must be at least 6 characters");
+    });
 
-    it('returns error for invalid token', async () => {
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(null)
+    it("returns error for invalid token", async () => {
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        null,
+      );
 
-      const request = createRequest({ token: 'invalid-token', password: 'newpassword123' })
-      const response = await POST(request)
-      const data = await response.json()
+      const request = createRequest({
+        token: "invalid-token",
+        password: "newpassword123",
+      });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBe('Invalid or expired reset link')
-    })
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid or expired reset link");
+    });
 
-    it('returns error for expired token', async () => {
+    it("returns error for expired token", async () => {
       const expiredToken = {
-        id: 'token-123',
-        token: 'expired-token',
-        email: 'test@example.com',
+        id: "token-123",
+        token: "expired-token",
+        email: "test@example.com",
         expires: new Date(Date.now() - 3600000),
-      }
+      };
 
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(expiredToken)
-      ;(prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({})
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        expiredToken,
+      );
+      (prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({});
 
-      const request = createRequest({ token: 'expired-token', password: 'newpassword123' })
-      const response = await POST(request)
-      const data = await response.json()
+      const request = createRequest({
+        token: "expired-token",
+        password: "newpassword123",
+      });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBe('Reset link has expired. Please request a new one.')
-      expect(prisma.passwordResetToken.delete).toHaveBeenCalled()
-    })
+      expect(response.status).toBe(400);
+      expect(data.error).toBe(
+        "Reset link has expired. Please request a new one.",
+      );
+      expect(prisma.passwordResetToken.delete).toHaveBeenCalled();
+    });
 
-    it('returns error when user not found', async () => {
+    it("returns error when user not found", async () => {
       const validToken = {
-        id: 'token-123',
-        token: 'valid-token',
-        email: 'nonexistent@example.com',
+        id: "token-123",
+        token: "valid-token",
+        email: "nonexistent@example.com",
         expires: new Date(Date.now() + 3600000),
-      }
+      };
 
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(validToken)
-      ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(null)
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        validToken,
+      );
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
 
-      const request = createRequest({ token: 'valid-token', password: 'newpassword123' })
-      const response = await POST(request)
-      const data = await response.json()
+      const request = createRequest({
+        token: "valid-token",
+        password: "newpassword123",
+      });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(404)
-      expect(data.error).toBe('User not found')
-    })
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("User not found");
+    });
 
-    it('handles database errors gracefully', async () => {
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockRejectedValue(new Error('DB Error'))
+    it("handles database errors gracefully", async () => {
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB Error"),
+      );
 
-      const request = createRequest({ token: 'valid-token', password: 'newpassword123' })
-      const response = await POST(request)
-      const data = await response.json()
+      const request = createRequest({
+        token: "valid-token",
+        password: "newpassword123",
+      });
+      const response = await POST(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(500)
-      expect(data.error).toBe('An error occurred. Please try again.')
-    })
+      expect(response.status).toBe(500);
+      expect(data.error).toBe("An error occurred. Please try again.");
+    });
 
-    it('deletes token after successful reset', async () => {
+    it("deletes token after successful reset", async () => {
       const validToken = {
-        id: 'token-123',
-        token: 'valid-token',
-        email: 'test@example.com',
+        id: "token-123",
+        token: "valid-token",
+        email: "test@example.com",
         expires: new Date(Date.now() + 3600000),
-      }
-      const mockUser = { id: 'user-123', email: 'test@example.com' }
+      };
+      const mockUser = { id: "user-123", email: "test@example.com" };
 
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(validToken)
-      ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
-      ;(prisma.user.update as jest.Mock).mockResolvedValue({})
-      ;(prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({})
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        validToken,
+      );
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.update as jest.Mock).mockResolvedValue({});
+      (prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({});
 
-      const request = createRequest({ token: 'valid-token', password: 'newpassword123' })
-      await POST(request)
+      const request = createRequest({
+        token: "valid-token",
+        password: "newpassword123",
+      });
+      await POST(request);
 
       expect(prisma.passwordResetToken.delete).toHaveBeenCalledWith({
-        where: { id: 'token-123' },
-      })
-    })
-  })
+        where: { id: "token-123" },
+      });
+    });
+  });
 
-  describe('GET /api/auth/reset-password', () => {
+  describe("GET /api/auth/reset-password", () => {
     const createRequest = (token: string | null) => {
       const url = token
         ? `http://localhost:3000/api/auth/reset-password?token=${token}`
-        : 'http://localhost:3000/api/auth/reset-password'
-      return new Request(url, { method: 'GET' }) as unknown as NextRequest
-    }
+        : "http://localhost:3000/api/auth/reset-password";
+      return new Request(url, { method: "GET" }) as unknown as NextRequest;
+    };
 
-    it('returns valid true for valid token', async () => {
+    it("returns valid true for valid token", async () => {
       const validToken = {
-        token: 'valid-token',
+        token: "valid-token",
         expires: new Date(Date.now() + 3600000),
-      }
+      };
 
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(validToken)
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        validToken,
+      );
 
-      const request = createRequest('valid-token')
-      const response = await GET(request)
-      const data = await response.json()
+      const request = createRequest("valid-token");
+      const response = await GET(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(200)
-      expect(data.valid).toBe(true)
-    })
+      expect(response.status).toBe(200);
+      expect(data.valid).toBe(true);
+    });
 
-    it('returns error for missing token', async () => {
-      const request = createRequest(null)
-      const response = await GET(request)
-      const data = await response.json()
+    it("returns error for missing token", async () => {
+      const request = createRequest(null);
+      const response = await GET(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.valid).toBe(false)
-      expect(data.error).toBe('Token is required')
-    })
+      expect(response.status).toBe(400);
+      expect(data.valid).toBe(false);
+      expect(data.error).toBe("Token is required");
+    });
 
-    it('returns error for invalid token', async () => {
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(null)
+    it("returns error for invalid token", async () => {
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        null,
+      );
 
-      const request = createRequest('invalid-token')
-      const response = await GET(request)
-      const data = await response.json()
+      const request = createRequest("invalid-token");
+      const response = await GET(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.valid).toBe(false)
-      expect(data.error).toBe('Invalid reset link')
-    })
+      expect(response.status).toBe(400);
+      expect(data.valid).toBe(false);
+      expect(data.error).toBe("Invalid reset link");
+    });
 
-    it('returns error for expired token', async () => {
+    it("returns error for expired token", async () => {
       const expiredToken = {
-        token: 'expired-token',
+        token: "expired-token",
         expires: new Date(Date.now() - 3600000),
-      }
+      };
 
-      ;(prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(expiredToken)
+      (prisma.passwordResetToken.findUnique as jest.Mock).mockResolvedValue(
+        expiredToken,
+      );
 
-      const request = createRequest('expired-token')
-      const response = await GET(request)
-      const data = await response.json()
+      const request = createRequest("expired-token");
+      const response = await GET(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(400)
-      expect(data.valid).toBe(false)
-      expect(data.error).toBe('Reset link has expired')
-    })
-  })
-})
+      expect(response.status).toBe(400);
+      expect(data.valid).toBe(false);
+      expect(data.error).toBe("Reset link has expired");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes flaky tests in `src/__tests__/api/auth/reset-password.test.ts` by mocking the rate limiter. This ensures tests don't fail due to incidental rate limits during execution.

## Changes
- Mocks `withRateLimit` to bypass checks during the test run.

## Implementation details
```javascript
jest.mock("@/lib/with-rate-limit", () => ({
  withRateLimit: jest.fn().mockResolvedValue(null),
}));