### PR TITLE
fix(search): improve UX with bounds preservation, transitions, and a11y

### DIFF
--- a/src/components/LocationSearchInput.tsx
+++ b/src/components/LocationSearchInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useId } from 'react';
 import { MapPin, Loader2, X, AlertCircle, SearchX } from 'lucide-react';
 import { useDebounce } from 'use-debounce';
 
@@ -45,6 +45,7 @@ export default function LocationSearchInput({
     const suggestionsRef = useRef<HTMLDivElement>(null);
     const requestIdRef = useRef(0);
     const abortRef = useRef<AbortController | null>(null);
+    const listboxId = useId();
 
     const [debouncedValue] = useDebounce(value, 300);
 
@@ -224,6 +225,13 @@ export default function LocationSearchInput({
                     placeholder={placeholder}
                     className="w-full bg-transparent border-none p-0 text-zinc-900 dark:text-white placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:ring-0 focus:outline-none text-sm truncate pr-8"
                     autoComplete="off"
+                    // ARIA combobox attributes for screen reader accessibility
+                    role="combobox"
+                    aria-expanded={showSuggestions && suggestions.length > 0}
+                    aria-controls={`${listboxId}-listbox`}
+                    aria-activedescendant={selectedIndex >= 0 ? `${listboxId}-option-${selectedIndex}` : undefined}
+                    aria-autocomplete="list"
+                    aria-haspopup="listbox"
                 />
 
                 {/* Loading/Clear indicator */}
@@ -248,9 +256,19 @@ export default function LocationSearchInput({
                     ref={suggestionsRef}
                     className="absolute top-full left-0 right-0 mt-2 bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.4)] border border-zinc-200/80 dark:border-zinc-700/80 overflow-hidden z-dropdown min-w-[300px] animate-in fade-in-0 slide-in-from-top-2"
                 >
-                    <ul className="p-2">
+                    <ul
+                        className="p-2"
+                        role="listbox"
+                        id={`${listboxId}-listbox`}
+                        aria-label="Location suggestions"
+                    >
                         {suggestions.map((suggestion, index) => (
-                            <li key={suggestion.id}>
+                            <li
+                                key={suggestion.id}
+                                role="option"
+                                id={`${listboxId}-option-${index}`}
+                                aria-selected={index === selectedIndex}
+                            >
                                 <button
                                     type="button"
                                     onClick={() => handleSelectSuggestion(suggestion)}
@@ -258,6 +276,7 @@ export default function LocationSearchInput({
                                         ? 'bg-zinc-100 dark:bg-zinc-800'
                                         : 'hover:bg-zinc-100/80 dark:hover:bg-zinc-800/80'
                                         }`}
+                                    tabIndex={-1}
                                 >
                                     <MapPin className={`w-5 h-5 mt-0.5 flex-shrink-0 ${getPlaceTypeIcon(suggestion.place_type)}`} />
                                     <div className="flex-1 min-w-0">

--- a/src/contexts/SearchTransitionContext.tsx
+++ b/src/contexts/SearchTransitionContext.tsx
@@ -35,6 +35,8 @@ interface SearchTransitionContextValue {
   isSlowTransition: boolean;
   /** Navigate to a URL within a transition (keeps old UI visible) */
   navigateWithTransition: (url: string, options?: { scroll?: boolean }) => void;
+  /** Navigate with replace (for map - avoids history pollution) */
+  replaceWithTransition: (url: string, options?: { scroll?: boolean }) => void;
   /** Raw startTransition for custom transition logic */
   startTransition: TransitionStartFunction;
 }
@@ -77,12 +79,23 @@ export function SearchTransitionProvider({
     [router, startTransition],
   );
 
+  const replaceWithTransition = useCallback(
+    (url: string, options?: { scroll?: boolean }) => {
+      startTransition(() => {
+        // Use replace to avoid history pollution (e.g., map panning)
+        router.replace(url, { scroll: options?.scroll ?? false });
+      });
+    },
+    [router, startTransition],
+  );
+
   return (
     <SearchTransitionContext.Provider
       value={{
         isPending,
         isSlowTransition,
         navigateWithTransition,
+        replaceWithTransition,
         startTransition,
       }}
     >

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -264,6 +264,15 @@ export const features = {
   searchV2: true as const,
   searchKeyset: true as const,
   searchRanking: true as const,
+  // Search debug ranking (only allowed in non-production, or with explicit env override)
+  // This gates ?debugRank=1 and ?ranker=1 URL overrides to prevent leaking debug signals
+  get searchDebugRanking() {
+    const e = getServerEnv();
+    // Allow debug in non-production environments
+    if (e.NODE_ENV !== "production") return true;
+    // In production, require explicit env flag (for staging/preview debugging)
+    return process.env.SEARCH_DEBUG_RANKING === "true";
+  },
 };
 
 // P1-25 FIX: Log startup warnings for missing optional services


### PR DESCRIPTION
PR1: Preserve map bounds and nearMatches params on search form submit
- Clone URLSearchParams instead of creating fresh to retain bounds
- Reset only pagination params when filters change

PR2: Add server-side bounds clamping for LIST queries (DoS prevention)
- Export MAX_LAT_SPAN/MAX_LNG_SPAN constants and clampBoundsToMaxSpan()
- Apply 5° cap to search-v2-service for oversized viewport queries

PR3: Centralize navigation transitions for consistent loading UX
- Add replaceWithTransition to SearchTransitionContext for map
- Pagination uses shared context with local fallback
- Map uses replaceWithTransition to avoid history pollution

PR4: Add ARIA combobox semantics to location autocomplete
- Add role="combobox", aria-expanded, aria-controls to input
- Add role="listbox" and role="option" to suggestions
- Use useId() for stable accessible IDs