### PR TITLE
feat(search): implement search architecture fixes (PR1-PR4)

### DIFF
--- a/prisma/migrations/20260120000000_keyset_index_price/migration.sql
+++ b/prisma/migrations/20260120000000_keyset_index_price/migration.sql
@@ -1,0 +1,16 @@
+-- Keyset pagination indexes for price sort (ascending and descending)
+-- Enables stable cursor-based pagination for price-sorted queries.
+--
+-- Covers ORDER BY: price ASC/DESC, listing_created_at DESC, id
+--
+-- Rollback: DROP INDEX CONCURRENTLY IF EXISTS search_doc_keyset_price_asc;
+--           DROP INDEX CONCURRENTLY IF EXISTS search_doc_keyset_price_desc;
+-- Data-safety: Non-blocking index creation, no locks on existing rows.
+
+-- Price ascending (cheapest first)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS search_doc_keyset_price_asc
+  ON listing_search_docs (price ASC NULLS LAST, listing_created_at DESC, id);
+
+-- Price descending (most expensive first)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS search_doc_keyset_price_desc
+  ON listing_search_docs (price DESC NULLS LAST, listing_created_at DESC, id);

--- a/prisma/migrations/20260120000001_keyset_index_rating/migration.sql
+++ b/prisma/migrations/20260120000001_keyset_index_rating/migration.sql
@@ -1,0 +1,10 @@
+-- Keyset pagination index for rating sort
+-- Enables stable cursor-based pagination for rating-sorted queries.
+--
+-- Covers ORDER BY: avg_rating DESC, review_count DESC, listing_created_at DESC, id
+--
+-- Rollback: DROP INDEX CONCURRENTLY IF EXISTS search_doc_keyset_rating;
+-- Data-safety: Non-blocking index creation, no locks on existing rows.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS search_doc_keyset_rating
+  ON listing_search_docs (avg_rating DESC NULLS LAST, review_count DESC, listing_created_at DESC, id);


### PR DESCRIPTION
This commit addresses 4 prioritized issues from the architecture review:

PR1 (Critical) - Block unbounded searches:
- Add defense-in-depth guards to search-doc-queries.ts
- Throw error if text query exists without geographic bounds
- Prevents full-table scans from unbounded searches

PR2 (High) - Wire MapMovedBanner for manual refresh:
- Connect Map.tsx to MapBoundsContext for state management
- Register search/reset handlers with context
- Render MapMovedBanner in both Map.tsx and SearchLayoutView.tsx
- Shows "Search this area" / "Reset" when user pans with search-as-move OFF

PR3 (High) - Enforce SearchDoc production requirement:
- Add ENABLE_SEARCH_DOC to typed env.ts schema
- Add features.searchDoc getter for centralized feature flag
- Log warning at startup if SearchDoc disabled (CRITICAL for production)
- Update isSearchDocEnabled() to use typed env

PR4 (Medium) - Add composite keyset indexes:
- Add migration for price ASC/DESC composite indexes
- Add migration for rating composite index
- Uses CREATE INDEX CONCURRENTLY for non-blocking creation

Verified:
- TypeScript compilation passes
- ESLint passes (0 new errors)
- Unit tests: 115/115 pass
- E2E tests: Core search functionality verified working