### PR TITLE
fix: production-readiness hardening (auth, logging, map perf)

### DIFF
--- a/prisma/migrations/20260206000000_hash_auth_tokens/migration.sql
+++ b/prisma/migrations/20260206000000_hash_auth_tokens/migration.sql
@@ -1,0 +1,38 @@
+-- Store auth tokens as SHA-256 hashes instead of plaintext.
+-- Keeps existing active tokens usable by migrating current values.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE "VerificationToken" ADD COLUMN "token_hash" TEXT;
+UPDATE "VerificationToken"
+SET "token_hash" = encode(digest(token, 'sha256'), 'hex')
+WHERE "token_hash" IS NULL;
+ALTER TABLE "VerificationToken" ALTER COLUMN "token_hash" SET NOT NULL;
+
+DROP INDEX IF EXISTS "VerificationToken_token_key";
+DROP INDEX IF EXISTS "VerificationToken_identifier_token_key";
+ALTER TABLE "VerificationToken" DROP COLUMN token;
+
+CREATE UNIQUE INDEX "VerificationToken_token_hash_key"
+ON "VerificationToken"("token_hash");
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_hash_key"
+ON "VerificationToken"("identifier", "token_hash");
+CREATE INDEX "VerificationToken_expires_idx"
+ON "VerificationToken"("expires");
+
+ALTER TABLE "PasswordResetToken" ADD COLUMN "token_hash" TEXT;
+UPDATE "PasswordResetToken"
+SET "token_hash" = encode(digest(token, 'sha256'), 'hex')
+WHERE "token_hash" IS NULL;
+ALTER TABLE "PasswordResetToken" ALTER COLUMN "token_hash" SET NOT NULL;
+
+DROP INDEX IF EXISTS "PasswordResetToken_token_key";
+DROP INDEX IF EXISTS "PasswordResetToken_email_token_key";
+ALTER TABLE "PasswordResetToken" DROP COLUMN token;
+
+CREATE UNIQUE INDEX "PasswordResetToken_token_hash_key"
+ON "PasswordResetToken"("token_hash");
+CREATE UNIQUE INDEX "PasswordResetToken_email_token_hash_key"
+ON "PasswordResetToken"("email", "token_hash");
+CREATE INDEX "PasswordResetToken_expires_idx"
+ON "PasswordResetToken"("expires");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,20 +75,22 @@ model User {
 
 model VerificationToken {
   identifier String
-  token      String   @unique
+  tokenHash  String   @unique @map("token_hash")
   expires    DateTime
 
-  @@unique([identifier, token])
+  @@unique([identifier, tokenHash])
+  @@index([expires])
 }
 
 model PasswordResetToken {
   id        String   @id @default(cuid())
   email     String
-  token     String   @unique
+  tokenHash String   @unique @map("token_hash")
   expires   DateTime
   createdAt DateTime @default(now())
 
-  @@unique([email, token])
+  @@unique([email, tokenHash])
+  @@index([expires])
 }
 
 model Listing {

--- a/src/__tests__/api/auth/forgot-password.test.ts
+++ b/src/__tests__/api/auth/forgot-password.test.ts
@@ -140,7 +140,7 @@ describe('Forgot Password API', () => {
     expect(prisma.passwordResetToken.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         email: 'test@example.com',
-        token: expect.any(String),
+        tokenHash: expect.any(String),
         expires: expect.any(Date),
       }),
     })

--- a/src/__tests__/api/auth/resend-verification.test.ts
+++ b/src/__tests__/api/auth/resend-verification.test.ts
@@ -61,7 +61,7 @@ describe('Resend Verification API', () => {
     ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
     ;(prisma.verificationToken.deleteMany as jest.Mock).mockResolvedValue({})
     ;(prisma.verificationToken.create as jest.Mock).mockResolvedValue({})
-    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({})
+    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({ success: true })
 
     const request = createRequest()
     const response = await POST(request)
@@ -136,7 +136,7 @@ describe('Resend Verification API', () => {
     ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
     ;(prisma.verificationToken.deleteMany as jest.Mock).mockResolvedValue({})
     ;(prisma.verificationToken.create as jest.Mock).mockResolvedValue({})
-    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({})
+    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({ success: true })
 
     const request = createRequest()
     await POST(request)
@@ -154,7 +154,7 @@ describe('Resend Verification API', () => {
     ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
     ;(prisma.verificationToken.deleteMany as jest.Mock).mockResolvedValue({})
     ;(prisma.verificationToken.create as jest.Mock).mockResolvedValue({})
-    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({})
+    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({ success: true })
 
     const request = createRequest()
     await POST(request)
@@ -162,7 +162,7 @@ describe('Resend Verification API', () => {
     expect(prisma.verificationToken.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         identifier: 'test@example.com',
-        token: expect.any(String),
+        tokenHash: expect.any(String),
         expires: expect.any(Date),
       }),
     })
@@ -184,7 +184,7 @@ describe('Resend Verification API', () => {
     ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
     ;(prisma.verificationToken.deleteMany as jest.Mock).mockResolvedValue({})
     ;(prisma.verificationToken.create as jest.Mock).mockResolvedValue({})
-    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({})
+    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({ success: true })
 
     const request = createRequest()
     await POST(request)
@@ -203,7 +203,7 @@ describe('Resend Verification API', () => {
     ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-123', email: 'test@example.com', emailVerified: null })
     ;(prisma.verificationToken.deleteMany as jest.Mock).mockResolvedValue({})
     ;(prisma.verificationToken.create as jest.Mock).mockResolvedValue({})
-    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({})
+    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({ success: true })
 
     const request = createRequest()
     await POST(request)
@@ -246,13 +246,13 @@ describe('Resend Verification API', () => {
     ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
     ;(prisma.verificationToken.deleteMany as jest.Mock).mockResolvedValue({})
     ;(prisma.verificationToken.create as jest.Mock).mockResolvedValue({})
-    ;(sendNotificationEmail as jest.Mock).mockRejectedValue(new Error('Email Error'))
+    ;(sendNotificationEmail as jest.Mock).mockResolvedValue({ success: false, error: 'Email Error' })
 
     const request = createRequest()
     const response = await POST(request)
     const data = await response.json()
 
-    expect(response.status).toBe(500)
-    expect(data.error).toBe('Failed to send verification email')
+    expect(response.status).toBe(503)
+    expect(data.error).toBe('Email service temporarily unavailable')
   })
 })

--- a/src/__tests__/api/register.test.ts
+++ b/src/__tests__/api/register.test.ts
@@ -18,6 +18,10 @@ jest.mock("crypto", () => ({
   randomBytes: jest.fn().mockReturnValue({
     toString: jest.fn().mockReturnValue("mock-verification-token"),
   }),
+  createHash: jest.fn().mockReturnValue({
+    update: jest.fn().mockReturnThis(),
+    digest: jest.fn().mockReturnValue("mock-verification-token-hash"),
+  }),
 }));
 
 jest.mock("@/lib/with-rate-limit", () => ({

--- a/src/__tests__/api/search/v2/route.test.ts
+++ b/src/__tests__/api/search/v2/route.test.ts
@@ -593,11 +593,8 @@ describe("Search API v2 route", () => {
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(data.list.items).toHaveLength(0);
-      expect(data.list.total).toBe(0);
-      expect(data.list.nextCursor).toBeNull();
-      expect(data.map.geojson.features).toHaveLength(1);
+      expect(response.status).toBe(503);
+      expect(data.error).toBe("Search temporarily unavailable");
     });
 
     it("should return fully empty response when both queries fail", async () => {
@@ -612,9 +609,8 @@ describe("Search API v2 route", () => {
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(data.list.items).toHaveLength(0);
-      expect(data.map.geojson.features).toHaveLength(0);
+      expect(response.status).toBe(503);
+      expect(data.error).toBe("Search temporarily unavailable");
     });
   });
 

--- a/src/__tests__/edge-cases/auth-edge-cases.test.ts
+++ b/src/__tests__/edge-cases/auth-edge-cases.test.ts
@@ -322,7 +322,7 @@ describe("Auth Edge Cases - Category A", () => {
       });
 
       const foundToken = await prisma.verificationToken.findUnique({
-        where: { token: "valid-token" },
+        where: { tokenHash: "valid-token" },
       });
 
       // Email matching should be case-insensitive
@@ -333,13 +333,13 @@ describe("Auth Edge Cases - Category A", () => {
       const mixedCaseEmail = "TeSt@ExAmPlE.CoM";
 
       (prisma.verificationToken.create as jest.Mock).mockResolvedValue({
-        token: "new-token",
+        tokenHash: "new-token-hash",
         identifier: mixedCaseEmail.toLowerCase(),
       });
 
       const token = await prisma.verificationToken.create({
         data: {
-          token: "new-token",
+          tokenHash: "new-token-hash",
           identifier: mixedCaseEmail.toLowerCase(),
           expires: new Date(),
         },
@@ -370,7 +370,7 @@ describe("Auth Edge Cases - Category A", () => {
       (prisma.user.findUnique as jest.Mock).mockResolvedValue(user);
 
       const foundToken = await prisma.passwordResetToken.findUnique({
-        where: { token: "reset-token" },
+        where: { tokenHash: "reset-token" },
       });
       // PasswordResetToken uses email, not userId - cast for test mocking
       const foundUser = await prisma.user.findUnique({
@@ -393,16 +393,16 @@ describe("Auth Edge Cases - Category A", () => {
       (prisma.passwordResetToken.delete as jest.Mock).mockResolvedValue({});
 
       const firstAttempt = await prisma.passwordResetToken.findUnique({
-        where: { token: "reset-token" },
+        where: { tokenHash: "reset-token" },
       });
       expect(firstAttempt).not.toBeNull();
 
       await prisma.passwordResetToken.delete({
-        where: { token: "reset-token" },
+        where: { tokenHash: "reset-token" },
       });
 
       const secondAttempt = await prisma.passwordResetToken.findUnique({
-        where: { token: "reset-token" },
+        where: { tokenHash: "reset-token" },
       });
       expect(secondAttempt).toBeNull();
     });
@@ -597,7 +597,7 @@ describe("Auth Edge Cases - Category A", () => {
       // Mock email change verification - in real impl would need custom fields
       const pendingEmailChange = {
         identifier: "user-123",
-        token: "change-token",
+        tokenHash: "change-token-hash",
         expires: new Date(Date.now() + 3600000),
       };
       // Extended mock with email change metadata

--- a/src/__tests__/lib/rate-limit.test.ts
+++ b/src/__tests__/lib/rate-limit.test.ts
@@ -368,7 +368,7 @@ describe("rate-limit", () => {
 
       const ip = getClientIP(request);
 
-      expect(ip).toBe("unknown");
+      expect(ip).toMatch(/^anon-[a-f0-9]{16}$/);
     });
 
     it("trims whitespace from IP in development mode", () => {

--- a/src/lib/geocoding.ts
+++ b/src/lib/geocoding.ts
@@ -1,14 +1,15 @@
 import { fetchWithTimeout, FetchTimeoutError } from './fetch-with-timeout';
 import { circuitBreakers, isCircuitOpenError } from './circuit-breaker';
+import { logger } from './logger';
 
 // Timeout for geocoding requests (10 seconds)
 const GEOCODING_TIMEOUT_MS = 10000;
 
 export async function geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {
-    const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+    const token = process.env.MAPBOX_ACCESS_TOKEN || process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 
     if (!token) {
-        console.error("Mapbox token is missing");
+        logger.sync.error("Mapbox token is missing");
         return null;
     }
 
@@ -17,36 +18,40 @@ export async function geocodeAddress(address: string): Promise<{ lat: number; ln
             const encodedAddress = encodeURIComponent(address);
             const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodedAddress}.json?access_token=${token}&limit=1`;
 
-            console.log("Attempting to geocode address:", address);
             const response = await fetchWithTimeout(url, { timeout: GEOCODING_TIMEOUT_MS });
 
             if (!response.ok) {
-                console.error(`Geocoding API error: ${response.status} ${response.statusText}`);
+                logger.sync.error("Geocoding API error", {
+                    status: response.status,
+                    statusText: response.statusText,
+                });
                 return null;
             }
 
             const data = await response.json();
-            // console.log("Mapbox response:", JSON.stringify(data, null, 2));
 
             if (data.features && data.features.length > 0) {
                 const [lng, lat] = data.features[0].center;
-                console.log(`Successfully geocoded to: lat=${lat}, lng=${lng}`);
                 return { lat, lng };
             }
 
             // No results found
-            console.warn("No geocoding results found for address:", address);
+            logger.sync.warn("No geocoding results found");
             return null;
         });
     } catch (error) {
         if (isCircuitOpenError(error)) {
-            console.warn('[Geocoding] Circuit breaker open, skipping geocode request');
+            logger.sync.warn('[Geocoding] Circuit breaker open, skipping geocode request');
             return null;
         }
         if (error instanceof FetchTimeoutError) {
-            console.error(`Geocoding request timed out after ${GEOCODING_TIMEOUT_MS}ms for address:`, address);
+            logger.sync.error('Geocoding request timed out', {
+                timeoutMs: GEOCODING_TIMEOUT_MS,
+            });
         } else {
-            console.error("Error geocoding address:", error);
+            logger.sync.error("Error geocoding address", {
+                error: error instanceof Error ? error.message : String(error),
+            });
         }
         return null;
     }

--- a/src/lib/token-security.ts
+++ b/src/lib/token-security.ts
@@ -1,0 +1,17 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const TOKEN_BYTES = 32;
+const TOKEN_PATTERN = /^[a-f0-9]{64}$/i;
+
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function createTokenPair(): { token: string; tokenHash: string } {
+  const token = randomBytes(TOKEN_BYTES).toString("hex");
+  return { token, tokenHash: hashToken(token) };
+}
+
+export function isValidTokenFormat(token: string): boolean {
+  return TOKEN_PATTERN.test(token);
+}


### PR DESCRIPTION
## Summary

- **Hash all auth tokens (SHA-256)**: Register, verify-email, forgot-password, reset-password, and resend-verification flows now store only SHA-256 hashes in the database. Plaintext tokens are sent to users via email only. Includes Prisma migration with in-place backfill for existing rows, `@map("token_hash")` column rename, and `expires` indexes on both token tables.
- **Structured logging for Supabase realtime**: Replace silent catch blocks with `logWarn`/`logError` helpers so typing broadcast and presence failures are visible in production instead of swallowed.
- **Map performance**: Precompute `imagesByListingId` lookup to avoid repeated `JSON.parse` on every map move. Add `ClusterFeatureProperties` interface, replace `any` types with `MapSourceDataEvent`, and fix 10 React hook dependency arrays (2 real missing deps, dead `internalViewState` removal).
- **Search alerts hardening**: Add safe `isSearchAlertsEnabled()` preference parser, replace `as any` price filter casts with `Prisma.FloatFilter`, migrate ad-hoc `console.log` to structured `logger.sync.*` calls.
- **Logger + geocoding hardening**: Handle edge-runtime context unavailability in logger, defensive geocoding token access.
- **Test alignment**: Update auth and search tests to match hardened behavior (503 on unbounded queries, token-hash assertions, PII leak prevention).

## Test plan

- [x] ESLint passes on all changed files
- [x] TypeScript `--noEmit` passes
- [x] 241 auth/register/rate-limit tests pass
- [x] Full suite: 1,164 tests passed, 0 failures
- [x] `npm audit --omit=dev` shows 0 vulnerabilities
- [x] `npm run build` passes (with expected DB-unreachable sitemap fallback)
- [ ] Verify migration on staging DB (`prisma migrate deploy`)
- [ ] Smoke-test register → verify-email → login flow end-to-end
- [ ] Smoke-test forgot-password → reset-password flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)