### PR TITLE
fix(security+api): notification refactor, Zod validation, rate limiting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "127.0.0.1:5433:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       POSTGRES_DB: ${POSTGRES_DB:-roomshare}
     volumes:
       - db_data:/var/lib/postgresql/data

--- a/next.config.ts
+++ b/next.config.ts
@@ -71,6 +71,15 @@ const nextConfig: NextConfig = {
 
   // Headers for security and performance
   async headers() {
+    const isDev = process.env.NODE_ENV !== 'production';
+    const scriptSrc = [
+      "script-src 'self'",
+      "'unsafe-inline'",
+      ...(isDev ? ["'unsafe-eval'"] : []),
+      "https://maps.googleapis.com",
+      "https://api.mapbox.com",
+    ].join(' ');
+
     return [
       {
         source: "/(.*)",
@@ -79,9 +88,10 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://api.mapbox.com",
+              scriptSrc,
               "style-src 'self' 'unsafe-inline' https://api.mapbox.com",
-              "img-src 'self' data: blob: https: http:",
+              "img-src 'self' data: blob: https:",
+              "object-src 'none'",
               "font-src 'self' https://fonts.mapbox.com",
               "connect-src 'self' https://api.mapbox.com https://events.mapbox.com https://tiles.mapbox.com https://*.tiles.mapbox.com https://fonts.mapbox.com https://maps.googleapis.com https://places.googleapis.com https://*.supabase.co https://api.groq.com wss://*.supabase.co https://api.radar.io https://tiles.stadiamaps.com https://api.stadiamaps.com",
               "worker-src 'self' blob: https://api.mapbox.com",

--- a/src/__tests__/actions/booking.test.ts
+++ b/src/__tests__/actions/booking.test.ts
@@ -34,8 +34,8 @@ jest.mock('next/cache', () => ({
   revalidatePath: jest.fn(),
 }))
 
-jest.mock('@/app/actions/notifications', () => ({
-  createNotification: jest.fn(),
+jest.mock('@/lib/notifications', () => ({
+  createInternalNotification: jest.fn(),
 }))
 
 jest.mock('@/lib/email', () => ({
@@ -50,7 +50,7 @@ import { createBooking } from '@/app/actions/booking'
 import { prisma } from '@/lib/prisma'
 import { auth } from '@/auth'
 import { revalidatePath } from 'next/cache'
-import { createNotification } from '@/app/actions/notifications'
+import { createInternalNotification } from '@/lib/notifications'
 import { sendNotificationEmailWithPreference } from '@/lib/email'
 
 describe('createBooking', () => {
@@ -127,7 +127,7 @@ describe('createBooking', () => {
         }
         return callback(tx)
       })
-      ; (createNotification as jest.Mock).mockResolvedValue({ success: true })
+      ; (createInternalNotification as jest.Mock).mockResolvedValue({ success: true })
       ; (sendNotificationEmailWithPreference as jest.Mock).mockResolvedValue({ success: true })
   })
 
@@ -186,7 +186,7 @@ describe('createBooking', () => {
     it('creates in-app notification for host', async () => {
       await createBooking('listing-123', futureStart, futureEnd, 800)
 
-      expect(createNotification).toHaveBeenCalledWith({
+      expect(createInternalNotification).toHaveBeenCalledWith({
         userId: 'owner-123',
         type: 'BOOKING_REQUEST',
         title: 'New Booking Request',

--- a/src/__tests__/actions/chat.test.ts
+++ b/src/__tests__/actions/chat.test.ts
@@ -47,8 +47,8 @@ jest.mock('@/auth', () => ({
   auth: jest.fn(),
 }))
 
-jest.mock('@/app/actions/notifications', () => ({
-  createNotification: jest.fn().mockResolvedValue({ success: true }),
+jest.mock('@/lib/notifications', () => ({
+  createInternalNotification: jest.fn().mockResolvedValue({ success: true }),
 }))
 
 jest.mock('@/lib/email', () => ({

--- a/src/__tests__/actions/manage-booking.test.ts
+++ b/src/__tests__/actions/manage-booking.test.ts
@@ -31,8 +31,8 @@ jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
 }));
 
-jest.mock("@/app/actions/notifications", () => ({
-  createNotification: jest.fn(),
+jest.mock("@/lib/notifications", () => ({
+  createInternalNotification: jest.fn(),
 }));
 
 jest.mock("@/lib/email", () => ({
@@ -82,7 +82,7 @@ import {
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { revalidatePath } from "next/cache";
-import { createNotification } from "@/app/actions/notifications";
+import { createInternalNotification } from "@/lib/notifications";
 import { sendNotificationEmailWithPreference } from "@/lib/email";
 import { checkSuspension } from "@/app/actions/suspension";
 import { validateTransition } from "@/lib/booking-state-machine";
@@ -145,7 +145,7 @@ describe("manage-booking actions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (auth as jest.Mock).mockResolvedValue(mockSession);
-    (createNotification as jest.Mock).mockResolvedValue({ success: true });
+    (createInternalNotification as jest.Mock).mockResolvedValue({ success: true });
     (sendNotificationEmailWithPreference as jest.Mock).mockResolvedValue({
       success: true,
     });
@@ -377,7 +377,7 @@ describe("manage-booking actions", () => {
 
         await updateBookingStatus("booking-123", "ACCEPTED");
 
-        expect(createNotification).toHaveBeenCalledWith({
+        expect(createInternalNotification).toHaveBeenCalledWith({
           userId: "tenant-123",
           type: "BOOKING_ACCEPTED",
           title: "Booking Accepted!",
@@ -468,7 +468,7 @@ describe("manage-booking actions", () => {
       it("creates notification for tenant on rejection", async () => {
         await updateBookingStatus("booking-123", "REJECTED");
 
-        expect(createNotification).toHaveBeenCalledWith({
+        expect(createInternalNotification).toHaveBeenCalledWith({
           userId: "tenant-123",
           type: "BOOKING_REJECTED",
           title: "Booking Not Accepted",
@@ -546,7 +546,7 @@ describe("manage-booking actions", () => {
 
         await updateBookingStatus("booking-123", "CANCELLED");
 
-        expect(createNotification).toHaveBeenCalledWith({
+        expect(createInternalNotification).toHaveBeenCalledWith({
           userId: "owner-123",
           type: "BOOKING_CANCELLED",
           title: "Booking Cancelled",

--- a/src/__tests__/api/reviews-pagination.test.ts
+++ b/src/__tests__/api/reviews-pagination.test.ts
@@ -24,6 +24,9 @@ jest.mock('@/lib/prisma', () => ({
     listing: {
       findUnique: jest.fn(),
     },
+    notification: {
+      create: jest.fn(),
+    },
   },
 }));
 
@@ -35,8 +38,8 @@ jest.mock('@/app/actions/suspension', () => ({
   checkSuspension: jest.fn().mockResolvedValue({ suspended: false }),
 }));
 
-jest.mock('@/app/actions/notifications', () => ({
-  createNotification: jest.fn().mockResolvedValue({}),
+jest.mock('@/lib/notifications', () => ({
+  createInternalNotification: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('@/lib/email', () => ({

--- a/src/__tests__/api/reviews.test.ts
+++ b/src/__tests__/api/reviews.test.ts
@@ -40,8 +40,8 @@ jest.mock('@/auth', () => ({
   auth: jest.fn(),
 }))
 
-jest.mock('@/app/actions/notifications', () => ({
-  createNotification: jest.fn(),
+jest.mock('@/lib/notifications', () => ({
+  createInternalNotification: jest.fn(),
 }))
 
 jest.mock('@/lib/email', () => ({
@@ -56,7 +56,7 @@ jest.mock('@/lib/with-rate-limit', () => ({
 import { POST, GET } from '@/app/api/reviews/route'
 import { prisma } from '@/lib/prisma'
 import { auth } from '@/auth'
-import { createNotification } from '@/app/actions/notifications'
+import { createInternalNotification } from '@/lib/notifications'
 import { sendNotificationEmailWithPreference } from '@/lib/email'
 
 describe('/api/reviews', () => {
@@ -233,7 +233,7 @@ describe('/api/reviews', () => {
         // Wait for fire-and-forget notification to execute
         await flushPromises()
 
-        expect(createNotification).toHaveBeenCalledWith({
+        expect(createInternalNotification).toHaveBeenCalledWith({
           userId: 'owner-456',
           type: 'NEW_REVIEW',
           title: 'New Review',
@@ -280,7 +280,7 @@ describe('/api/reviews', () => {
         // Wait for fire-and-forget notification to complete
         await flushPromises()
 
-        expect(createNotification).not.toHaveBeenCalled()
+        expect(createInternalNotification).not.toHaveBeenCalled()
         expect(sendNotificationEmailWithPreference).not.toHaveBeenCalled()
       })
     })

--- a/src/__tests__/api/verify.test.ts
+++ b/src/__tests__/api/verify.test.ts
@@ -22,12 +22,19 @@ jest.mock('next/server', () => ({
   },
 }))
 
+jest.mock('next/headers', () => ({
+  headers: jest.fn(async () => ({
+    get: (key: string) => (key === 'x-dev-verify-key' ? 'test-secret' : null),
+  })),
+}))
+
 import { GET } from '@/app/api/verify/route'
 import { prisma } from '@/lib/prisma'
 
 describe('Verify API', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env.NEXTAUTH_SECRET = 'test-secret'
   })
 
   describe('GET', () => {

--- a/src/__tests__/booking/race-condition.test.ts
+++ b/src/__tests__/booking/race-condition.test.ts
@@ -52,8 +52,8 @@ jest.mock('next/cache', () => ({
   revalidatePath: jest.fn(),
 }));
 
-jest.mock('@/app/actions/notifications', () => ({
-  createNotification: jest.fn(),
+jest.mock('@/lib/notifications', () => ({
+  createInternalNotification: jest.fn(),
 }));
 
 jest.mock('@/lib/email', () => ({
@@ -82,7 +82,7 @@ jest.mock('@/lib/logger', () => ({
 import { createBooking } from '@/app/actions/booking';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
-import { createNotification } from '@/app/actions/notifications';
+import { createInternalNotification } from '@/lib/notifications';
 import { sendNotificationEmailWithPreference } from '@/lib/email';
 import { Prisma } from '@prisma/client';
 
@@ -135,7 +135,7 @@ describe('Booking Race Condition Prevention', () => {
       isSuspended: false,
       emailVerified: new Date(),
     });
-    (createNotification as jest.Mock).mockResolvedValue({ success: true });
+    (createInternalNotification as jest.Mock).mockResolvedValue({ success: true });
     (sendNotificationEmailWithPreference as jest.Mock).mockResolvedValue({ success: true });
   });
 

--- a/src/__tests__/edge-cases/bookings-edge-cases.test.ts
+++ b/src/__tests__/edge-cases/bookings-edge-cases.test.ts
@@ -41,8 +41,8 @@ jest.mock("@/auth", () => ({
   auth: jest.fn(),
 }));
 
-jest.mock("@/app/actions/notifications", () => ({
-  createNotification: jest.fn().mockResolvedValue({ success: true }),
+jest.mock("@/lib/notifications", () => ({
+  createInternalNotification: jest.fn().mockResolvedValue({ success: true }),
 }));
 
 jest.mock("@/lib/email", () => ({

--- a/src/__tests__/edge-cases/messaging-edge-cases.test.ts
+++ b/src/__tests__/edge-cases/messaging-edge-cases.test.ts
@@ -47,8 +47,8 @@ jest.mock("@/app/actions/block", () => ({
   checkBlockBeforeAction: jest.fn().mockResolvedValue({ allowed: true }),
 }));
 
-jest.mock("@/app/actions/notifications", () => ({
-  createNotification: jest.fn().mockResolvedValue({ success: true }),
+jest.mock("@/lib/notifications", () => ({
+  createInternalNotification: jest.fn().mockResolvedValue({ success: true }),
 }));
 
 jest.mock("@/lib/email", () => ({

--- a/src/__tests__/lib/rate-limit-redis.test.ts
+++ b/src/__tests__/lib/rate-limit-redis.test.ts
@@ -157,7 +157,7 @@ describe('rate-limit-redis', () => {
       expect(result.retryAfter).toBeGreaterThan(0);
     });
 
-    it('fails closed in production when Redis not configured', async () => {
+    it('uses in-memory fallback in production when Redis is not configured', async () => {
       process.env.UPSTASH_REDIS_REST_URL = '';
       process.env.UPSTASH_REDIS_REST_TOKEN = '';
       Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', writable: true });
@@ -167,8 +167,8 @@ describe('rate-limit-redis', () => {
 
       const result = await rateLimitModule.checkChatRateLimit('127.0.0.1');
 
-      expect(result.success).toBe(false);
-      expect(result.retryAfter).toBe(60);
+      expect(result.success).toBe(true);
+      expect(result.retryAfter).toBeUndefined();
     });
 
     it('allows requests in development when Redis not configured', async () => {

--- a/src/__tests__/security/idor-comprehensive.test.ts
+++ b/src/__tests__/security/idor-comprehensive.test.ts
@@ -82,8 +82,8 @@ jest.mock('@/lib/email', () => ({
   sendNotificationEmailWithPreference: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('@/app/actions/notifications', () => ({
-  createNotification: jest.fn().mockResolvedValue({ success: true }),
+jest.mock('@/lib/notifications', () => ({
+  createInternalNotification: jest.fn().mockResolvedValue({ success: true }),
 }));
 
 jest.mock('@/app/actions/suspension', () => ({

--- a/src/app/actions/booking.ts
+++ b/src/app/actions/booking.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { auth } from '@/auth';
 import { revalidatePath } from 'next/cache';
-import { createNotification } from './notifications';
+import { createInternalNotification } from '@/lib/notifications';
 import { sendNotificationEmailWithPreference } from '@/lib/email';
 import { createBookingSchema } from '@/lib/schemas';
 import { z } from 'zod';
@@ -208,10 +208,10 @@ async function runBookingSideEffects(
     endDate: Date
 ): Promise<void> {
     // Create in-app notification for host
-    await createNotification({
-        userId: result.listingOwnerId,
-        type: 'BOOKING_REQUEST',
-        title: 'New Booking Request',
+    await createInternalNotification({
+      userId: result.listingOwnerId,
+      type: 'BOOKING_REQUEST',
+      title: 'New Booking Request',
         message: `${result.tenantName || 'Someone'} requested to book "${result.listingTitle}"`,
         link: '/bookings'
     });

--- a/src/app/actions/manage-booking.ts
+++ b/src/app/actions/manage-booking.ts
@@ -3,7 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import { revalidatePath } from 'next/cache';
-import { createNotification } from './notifications';
+import { createInternalNotification } from '@/lib/notifications';
 import { sendNotificationEmailWithPreference } from '@/lib/email';
 import { checkSuspension } from './suspension';
 import { logger } from '@/lib/logger';
@@ -160,7 +160,7 @@ export async function updateBookingStatus(
             }
 
             // Notify tenant of acceptance (outside transaction for performance)
-            await createNotification({
+            await createInternalNotification({
                 userId: booking.tenant.id,
                 type: 'BOOKING_ACCEPTED',
                 title: 'Booking Accepted!',
@@ -208,7 +208,7 @@ export async function updateBookingStatus(
                 : '';
 
             // Notify tenant of rejection
-            await createNotification({
+            await createInternalNotification({
                 userId: booking.tenant.id,
                 type: 'BOOKING_REJECTED',
                 title: 'Booking Not Accepted',
@@ -285,7 +285,7 @@ export async function updateBookingStatus(
 
 
             // Notify host of cancellation
-            await createNotification({
+            await createInternalNotification({
                 userId: booking.listing.ownerId,
                 type: 'BOOKING_CANCELLED',
                 title: 'Booking Cancelled',

--- a/src/app/api/auth/suspension-status/route.ts
+++ b/src/app/api/auth/suspension-status/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Internal endpoint for middleware live suspension checks.
+ * Protected by shared secret header to prevent public abuse.
+ */
+export async function GET(request: NextRequest) {
+    const expectedSecret = process.env.SUSPENSION_CHECK_SECRET || process.env.NEXTAUTH_SECRET;
+    const providedSecret = request.headers.get('x-suspension-check-secret');
+
+    if (!expectedSecret || providedSecret !== expectedSecret) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userId = request.nextUrl.searchParams.get('userId');
+    if (!userId) {
+        return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+    }
+
+    try {
+        const user = await prisma.user.findUnique({
+            where: { id: userId },
+            select: { isSuspended: true },
+        });
+
+        return NextResponse.json({
+            isSuspended: Boolean(user?.isSuspended),
+        });
+    } catch {
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}
+
+export const runtime = 'nodejs';

--- a/src/app/api/verify/route.ts
+++ b/src/app/api/verify/route.ts
@@ -1,11 +1,24 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { headers } from 'next/headers';
 
 // P1-10 FIX: Development-only test endpoint
 export async function GET() {
     // Block access in production
     if (process.env.NODE_ENV === 'production') {
         return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const internalKey = process.env.NEXTAUTH_SECRET;
+    const headersList = await headers();
+    const providedKey = headersList.get('x-dev-verify-key');
+
+    if (!internalKey) {
+        return NextResponse.json({ error: 'Verify endpoint not configured' }, { status: 503 });
+    }
+
+    if (providedKey !== internalKey) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     try {

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -7,7 +7,7 @@ export const authConfig = {
   },
   session: {
     strategy: "jwt",
-    maxAge: 30 * 24 * 60 * 60, // 30 days
+    maxAge: 14 * 24 * 60 * 60, // 14 days (aligned with src/auth.ts)
     updateAge: 24 * 60 * 60, // Refresh token once per day
   },
   callbacks: {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+
+export type NotificationType =
+  | "BOOKING_REQUEST"
+  | "BOOKING_ACCEPTED"
+  | "BOOKING_REJECTED"
+  | "BOOKING_CANCELLED"
+  | "NEW_MESSAGE"
+  | "NEW_REVIEW"
+  | "LISTING_SAVED"
+  | "SEARCH_ALERT";
+
+export interface CreateNotificationInput {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  link?: string;
+}
+
+/**
+ * Internal-only notification creation helper.
+ * Callers are responsible for authorization checks in their own flow.
+ */
+export async function createInternalNotification(input: CreateNotificationInput) {
+  try {
+    await prisma.notification.create({
+      data: {
+        userId: input.userId,
+        type: input.type,
+        title: input.title,
+        message: input.message,
+        link: input.link,
+      },
+    });
+    return { success: true as const };
+  } catch (error) {
+    logger.sync.error("Failed to create notification", {
+      action: "createInternalNotification",
+      userId: input.userId,
+      type: input.type,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    return { error: "Failed to create notification" as const };
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -17,12 +17,13 @@ const FALLBACK_DATABASE_URL =
 const getDatasourceUrl = () => {
     const baseUrl = process.env.DATABASE_URL;
     if (!baseUrl) {
-        if (process.env.NODE_ENV !== 'test') {
-            logger.sync.warn(
-                'DATABASE_URL is not configured. Prisma is using a placeholder datasource URL; DB operations will fail until DATABASE_URL is set.',
-            );
+        if (process.env.NODE_ENV === 'test') {
+            return FALLBACK_DATABASE_URL;
         }
-        return FALLBACK_DATABASE_URL;
+
+        const message = 'DATABASE_URL is not configured. Refusing to start Prisma outside test environment.';
+        logger.sync.error(message);
+        throw new Error(message);
     }
 
     // Only add connection params if not already present

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -285,13 +285,8 @@ export async function checkChatRateLimit(ip: string): Promise<RateLimitResult> {
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
   ) {
-    // Skip rate limiting in development without Redis
-    if (process.env.NODE_ENV === "development") {
-      return { success: true };
-    }
-    // In production, fail closed (deny requests if Redis not configured)
-    console.error("[RateLimit] Redis not configured in production");
-    return { success: false, retryAfter: 60 };
+    console.warn("[RateLimit] Redis not configured, using in-memory fallback");
+    return checkInMemoryRateLimits("chat", ip);
   }
 
   try {
@@ -356,13 +351,8 @@ export async function checkMetricsRateLimit(
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
   ) {
-    // Skip rate limiting in development without Redis
-    if (process.env.NODE_ENV === "development") {
-      return { success: true };
-    }
-    // In production, fail closed
-    console.error("[RateLimit] Redis not configured in production");
-    return { success: false, retryAfter: 60 };
+    console.warn("[RateLimit] Redis not configured, using in-memory fallback");
+    return checkInMemoryRateLimits("metrics", ip);
   }
 
   try {
@@ -425,13 +415,8 @@ export async function checkMapRateLimit(ip: string): Promise<RateLimitResult> {
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
   ) {
-    // Skip rate limiting in development without Redis
-    if (process.env.NODE_ENV === "development") {
-      return { success: true };
-    }
-    // In production, fail closed
-    console.error("[RateLimit] Redis not configured in production");
-    return { success: false, retryAfter: 60 };
+    console.warn("[RateLimit] Redis not configured, using in-memory fallback");
+    return checkInMemoryRateLimits("map", ip);
   }
 
   try {
@@ -496,13 +481,8 @@ export async function checkSearchCountRateLimit(
     !process.env.UPSTASH_REDIS_REST_URL ||
     !process.env.UPSTASH_REDIS_REST_TOKEN
   ) {
-    // Skip rate limiting in development without Redis
-    if (process.env.NODE_ENV === "development") {
-      return { success: true };
-    }
-    // In production, fail closed
-    console.error("[RateLimit] Redis not configured in production");
-    return { success: false, retryAfter: 60 };
+    console.warn("[RateLimit] Redis not configured, using in-memory fallback");
+    return checkInMemoryRateLimits("searchCount", ip);
   }
 
   try {

--- a/src/lib/with-rate-limit-redis.ts
+++ b/src/lib/with-rate-limit-redis.ts
@@ -1,8 +1,8 @@
 /**
  * Redis-backed rate limiting wrapper for API routes.
  *
- * Uses Upstash Redis for distributed rate limiting with fail-closed behavior.
- * On Redis errors in production, requests are denied to prevent abuse.
+ * Uses Upstash Redis for distributed rate limiting with in-memory fallback.
+ * On Redis errors, requests are limited by a local fallback limiter.
  */
 
 import { NextResponse } from "next/server";
@@ -38,7 +38,7 @@ const RATE_LIMIT_CONFIGS: Record<
 /**
  * Wrapper function to add Redis-backed rate limiting to API route handlers.
  *
- * FAIL-CLOSED: On Redis errors in production, returns 429 to prevent abuse.
+ * Uses fallback-limited behavior when Redis is unavailable.
  *
  * @example
  * export async function GET(request: Request) {


### PR DESCRIPTION
## Summary

- **Notification refactor**: Migrated internal notification calls from public `createNotification` (server action with auth) to `createInternalNotification` (direct DB write via `server-only` module). Public action now wraps internal with admin-or-self authorization.
- **Zod validation**: Added input sanitization schemas to `chat.ts` (sendMessage), `review-response.ts`, `saved-search.ts`, `listings/[id]/route.ts`, `upload/route.ts`, and `verify/route.ts`.
- **Rate limiting**: Extended `withRateLimit` to previously unprotected endpoints: reviews PUT/DELETE, listings DELETE/PATCH, upload DELETE.
- **Auth hardening**: OAuth token clearing after linkAccount, live suspension check endpoint (`/api/auth/suspension-status`), CSP tightened (removed `unsafe-eval` in prod, added `object-src 'none'`).
- **Rate-limit resilience**: Redis rate limiter changed from fail-closed to in-memory fallback with circuit breaker.
- **Test updates**: Fixed 5 test files with stale notification mocks, updated 12 test suites total.

## Changes

- 32 files changed, 682 insertions, 382 deletions
- 2 new files: `src/lib/notifications.ts`, `src/app/api/auth/suspension-status/route.ts`

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] 5 fixed test files pass (128/128 tests)
- [x] chat.test.ts, reviews.test.ts, verify.test.ts pass (36/36 tests)
- [x] booking.test.ts, manage-booking.test.ts, notifications.test.ts, rate-limit-redis.test.ts pass (68/68 tests)
- [x] **232/232 tests passing across 12 suites**
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)