### PR TITLE
feat: migrate geocoding from Mapbox to Photon + Nominatim ($0/month)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,7 +74,6 @@ jobs:
       E2E_TEST_PASSWORD: TestPassword123!
       NODE_OPTIONS: '--max-old-space-size=4096'
       CI: 'true'
-      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }} # Used for geocoding API only, not map rendering
       GOOGLE_CLIENT_ID: 'ci-placeholder-not-used-in-tests'
       GOOGLE_CLIENT_SECRET: 'ci-placeholder-not-used-in-tests'
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -92,7 +92,7 @@ const nextConfig: NextConfig = {
               "img-src 'self' data: blob: https:",
               "object-src 'none'",
               "font-src 'self' https://tiles.openfreemap.org",
-              "connect-src 'self' https://api.mapbox.com https://tiles.openfreemap.org https://maps.googleapis.com https://places.googleapis.com https://*.supabase.co https://api.groq.com wss://*.supabase.co https://api.radar.io https://tiles.stadiamaps.com https://api.stadiamaps.com",
+              "connect-src 'self' https://photon.komoot.io https://nominatim.openstreetmap.org https://tiles.openfreemap.org https://maps.googleapis.com https://places.googleapis.com https://*.supabase.co https://api.groq.com wss://*.supabase.co https://api.radar.io https://tiles.stadiamaps.com https://api.stadiamaps.com",
               "worker-src 'self' blob:",
               "child-src blob:",
               "frame-src 'self' https://accounts.google.com",

--- a/src/__tests__/components/LocationSearchInput/LocationSearchInput.ime.test.tsx
+++ b/src/__tests__/components/LocationSearchInput/LocationSearchInput.ime.test.tsx
@@ -20,20 +20,6 @@ jest.mock('@/lib/geocoding-cache', () => ({
   clearCache: jest.fn(),
 }));
 
-// Mock environment variable
-const MOCK_MAPBOX_TOKEN = 'pk.test_token_12345';
-const originalEnv = process.env;
-
-beforeAll(() => {
-  process.env = {
-    ...originalEnv,
-    NEXT_PUBLIC_MAPBOX_TOKEN: MOCK_MAPBOX_TOKEN,
-  };
-});
-
-afterAll(() => {
-  process.env = originalEnv;
-});
 
 // Controlled wrapper component that manages state for the LocationSearchInput
 // This is necessary because the component uses useDebounce(value, 300) where
@@ -76,7 +62,7 @@ describe('LocationSearchInput - IME Composition', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ features: [] }),
+      json: async () => ({ type: 'FeatureCollection', features: [] }),
     });
   });
 

--- a/src/__tests__/components/LocationSearchInput/LocationSearchInput.keyboard.test.tsx
+++ b/src/__tests__/components/LocationSearchInput/LocationSearchInput.keyboard.test.tsx
@@ -14,26 +14,15 @@ import { clearCache } from '@/lib/geocoding-cache';
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-// Mock environment variable
-const MOCK_MAPBOX_TOKEN = 'pk.test_token_12345';
-const originalEnv = process.env;
 
-beforeAll(() => {
-  process.env = {
-    ...originalEnv,
-    NEXT_PUBLIC_MAPBOX_TOKEN: MOCK_MAPBOX_TOKEN,
-  };
-});
-
-afterAll(() => {
-  process.env = originalEnv;
-});
-
-const mockSuggestions = [
-  { id: '1', place_name: 'San Francisco, CA, USA', center: [-122.4194, 37.7749], place_type: ['place'] },
-  { id: '2', place_name: 'San Jose, CA, USA', center: [-121.8863, 37.3382], place_type: ['place'] },
-  { id: '3', place_name: 'San Diego, CA, USA', center: [-117.1611, 32.7157], place_type: ['place'] },
-];
+const mockPhotonSuggestions = {
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [-122.4194, 37.7749] }, properties: { osm_id: 1, osm_type: 'R', name: 'San Francisco', state: 'CA', country: 'USA', type: 'city' } },
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [-121.8863, 37.3382] }, properties: { osm_id: 2, osm_type: 'R', name: 'San Jose', state: 'CA', country: 'USA', type: 'city' } },
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [-117.1611, 32.7157] }, properties: { osm_id: 3, osm_type: 'R', name: 'San Diego', state: 'CA', country: 'USA', type: 'city' } },
+  ],
+};
 
 // Stateful wrapper for controlled component testing
 const ControlledLocationInput = ({
@@ -66,7 +55,7 @@ describe('LocationSearchInput - Keyboard Navigation', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ features: mockSuggestions }),
+      json: async () => mockPhotonSuggestions,
     });
   });
 

--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -377,7 +377,7 @@ describe('Map Component', () => {
     mockQuerySourceFeaturesData = listingsToFeatures(mockListings);
 
     // Set up env
-    process.env.NEXT_PUBLIC_MAPBOX_TOKEN = 'test-token';
+    // No Mapbox token needed — geocoding uses free Photon + Nominatim
   });
 
   afterEach(() => {

--- a/src/__tests__/components/map/touch-gestures.test.tsx
+++ b/src/__tests__/components/map/touch-gestures.test.tsx
@@ -424,7 +424,7 @@ describe('Map Touch Gestures', () => {
     mockIsProgrammaticMoveRef.current = false;
     mockQuerySourceFeaturesData = listingsToFeatures(mockListings);
     capturedMapProps = {};
-    process.env.NEXT_PUBLIC_MAPBOX_TOKEN = 'test-token';
+    // No Mapbox token needed — geocoding uses free Photon + Nominatim
   });
 
   afterEach(() => {

--- a/src/__tests__/edge-cases/postgis-spatial-edge-cases.test.ts
+++ b/src/__tests__/edge-cases/postgis-spatial-edge-cases.test.ts
@@ -55,7 +55,7 @@ describe("PostGIS Spatial Edge Cases - Category C", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env = { ...originalEnv, NEXT_PUBLIC_MAPBOX_TOKEN: "test-token" };
+    process.env = { ...originalEnv };
   });
 
   afterEach(() => {
@@ -265,7 +265,7 @@ describe("PostGIS Spatial Edge Cases - Category C", () => {
       let result = null;
       try {
         await fetch(
-          "https://api.mapbox.com/geocoding/v5/mapbox.places/test.json",
+          "https://nominatim.openstreetmap.org/search?q=test&format=jsonv2&limit=1",
         );
       } catch {
         result = null;
@@ -281,7 +281,7 @@ describe("PostGIS Spatial Edge Cases - Category C", () => {
       });
 
       const response = await fetch(
-        "https://api.mapbox.com/geocoding/v5/mapbox.places/xyz123.json",
+        "https://nominatim.openstreetmap.org/search?q=xyz123&format=jsonv2&limit=1",
       );
       const data = await response.json();
 
@@ -296,7 +296,7 @@ describe("PostGIS Spatial Edge Cases - Category C", () => {
       });
 
       const response = await fetch(
-        "https://api.mapbox.com/geocoding/v5/mapbox.places/test.json",
+        "https://nominatim.openstreetmap.org/search?q=test&format=jsonv2&limit=1",
       );
 
       expect(response.ok).toBe(false);
@@ -328,7 +328,7 @@ describe("PostGIS Spatial Edge Cases - Category C", () => {
       });
 
       const response = await fetch(
-        `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json`,
+        `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=jsonv2`,
       );
       const data = await response.json();
 
@@ -348,7 +348,7 @@ describe("PostGIS Spatial Edge Cases - Category C", () => {
       });
 
       const response = await fetch(
-        `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json`,
+        `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=jsonv2`,
       );
       const data = await response.json();
 

--- a/src/__tests__/lib/circuit-breaker.test.ts
+++ b/src/__tests__/lib/circuit-breaker.test.ts
@@ -414,10 +414,10 @@ describe('circuit-breaker', () => {
       expect(circuitBreakers.email.getState()).toBe('CLOSED');
     });
 
-    describe('mapboxGeocode breaker', () => {
+    describe('nominatimGeocode breaker', () => {
       it('should exist and start closed', () => {
-        expect(circuitBreakers.mapboxGeocode).toBeDefined();
-        expect(circuitBreakers.mapboxGeocode.getState()).toBe('CLOSED');
+        expect(circuitBreakers.nominatimGeocode).toBeDefined();
+        expect(circuitBreakers.nominatimGeocode.getState()).toBe('CLOSED');
       });
     });
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1457,8 +1457,8 @@ export default function MapComponent({
         onMoveEndProp,
     ]);
 
-    // User pin (drop-a-pin) state — token still needed for geocoding
-    const { isDropMode, toggleDropMode, pin: userPin, setPin: setUserPin, handleMapClick: handleUserPinClick } = useUserPin(process.env.NEXT_PUBLIC_MAPBOX_TOKEN || '');
+    // User pin (drop-a-pin) state — uses Nominatim reverse geocoding (no token needed)
+    const { isDropMode, toggleDropMode, pin: userPin, setPin: setUserPin, handleMapClick: handleUserPinClick } = useUserPin();
 
     // Get hovered listing coords for distance display
     const hoveredListingCoords = useMemo(() => {
@@ -1744,7 +1744,6 @@ export default function MapComponent({
                 {/* Boundary polygon for named search areas */}
                 <BoundaryLayer
                     query={searchParams.get('q')}
-                    mapboxToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN || ''}
                     isDarkMode={isDarkMode}
                 />
 
@@ -2045,7 +2044,6 @@ export default function MapComponent({
                     onToggleDropMode={toggleDropMode}
                     pin={userPin}
                     onSetPin={setUserPin}
-                    mapboxToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN || ''}
                     hoveredListingCoords={hoveredListingCoords}
                     isDarkMode={isDarkMode}
                 />

--- a/src/lib/circuit-breaker.ts
+++ b/src/lib/circuit-breaker.ts
@@ -228,8 +228,8 @@ export const circuitBreakers = {
     successThreshold: 3,
   }),
 
-  mapboxGeocode: new CircuitBreaker({
-    name: 'mapbox-geocode',
+  nominatimGeocode: new CircuitBreaker({
+    name: 'nominatim-geocode',
     failureThreshold: 5,
     resetTimeout: 30000, // 30 seconds
     successThreshold: 2,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,8 +23,7 @@ const serverEnvSchema = z.object({
   RESEND_API_KEY: z.string().optional(),
   FROM_EMAIL: z.string().optional(),
 
-  // Geocoding (optional - gracefully degrades)
-  MAPBOX_ACCESS_TOKEN: z.string().optional(),
+  // Geocoding uses Photon + Nominatim (free, no API key needed)
 
   // Redis Rate Limiting (optional - falls back to DB)
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
@@ -205,8 +204,8 @@ export const features = {
     return !!e.RESEND_API_KEY;
   },
   get geocoding() {
-    const e = getServerEnv();
-    return !!e.MAPBOX_ACCESS_TOKEN;
+    // Geocoding is always available (Photon + Nominatim, no API key needed)
+    return true;
   },
   get redis() {
     const e = getServerEnv();
@@ -313,9 +312,6 @@ export function logStartupWarnings(): void {
     warnings.push(
       "Redis not configured - using database-backed rate limiting (slower)",
     );
-  }
-  if (!features.geocoding) {
-    warnings.push("MAPBOX_ACCESS_TOKEN not configured - geocoding disabled");
   }
   if (!features.cronAuth) {
     warnings.push("CRON_SECRET not configured - cron endpoints unprotected");

--- a/src/lib/geocoding.ts
+++ b/src/lib/geocoding.ts
@@ -1,58 +1,28 @@
-import { fetchWithTimeout, FetchTimeoutError } from './fetch-with-timeout';
 import { circuitBreakers, isCircuitOpenError } from './circuit-breaker';
 import { logger } from './logger';
-
-// Timeout for geocoding requests (10 seconds)
-const GEOCODING_TIMEOUT_MS = 10000;
+import { forwardGeocode } from './geocoding/nominatim';
 
 export async function geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {
-    const token = process.env.MAPBOX_ACCESS_TOKEN || process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
-
-    if (!token) {
-        logger.sync.error("Mapbox token is missing");
-        return null;
-    }
-
     try {
-        return await circuitBreakers.mapboxGeocode.execute(async () => {
-            const encodedAddress = encodeURIComponent(address);
-            const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodedAddress}.json?access_token=${token}&limit=1`;
+        return await circuitBreakers.nominatimGeocode.execute(async () => {
+            const result = await forwardGeocode(address);
 
-            const response = await fetchWithTimeout(url, { timeout: GEOCODING_TIMEOUT_MS });
-
-            if (!response.ok) {
-                logger.sync.error("Geocoding API error", {
-                    status: response.status,
-                    statusText: response.statusText,
-                });
+            if (!result) {
+                // No results found
+                logger.sync.warn("No geocoding results found");
                 return null;
             }
 
-            const data = await response.json();
-
-            if (data.features && data.features.length > 0) {
-                const [lng, lat] = data.features[0].center;
-                return { lat, lng };
-            }
-
-            // No results found
-            logger.sync.warn("No geocoding results found");
-            return null;
+            return result;
         });
     } catch (error) {
         if (isCircuitOpenError(error)) {
             logger.sync.warn('[Geocoding] Circuit breaker open, skipping geocode request');
             return null;
         }
-        if (error instanceof FetchTimeoutError) {
-            logger.sync.error('Geocoding request timed out', {
-                timeoutMs: GEOCODING_TIMEOUT_MS,
-            });
-        } else {
-            logger.sync.error("Error geocoding address", {
-                error: error instanceof Error ? error.message : String(error),
-            });
-        }
+        logger.sync.error("Error geocoding address", {
+            error: error instanceof Error ? error.message : String(error),
+        });
         return null;
     }
 }

--- a/src/lib/geocoding/nominatim.ts
+++ b/src/lib/geocoding/nominatim.ts
@@ -1,0 +1,167 @@
+/**
+ * Nominatim geocoding adapter (nominatim.openstreetmap.org)
+ * Official OSM search engine for forward geocoding, reverse geocoding,
+ * and boundary polygon lookups.
+ *
+ * Requirements:
+ * - User-Agent header required on every request
+ * - Max 1 request/second (enforced by built-in rate limiter)
+ * - No autocomplete use (use Photon for that)
+ */
+
+const NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org';
+const USER_AGENT = 'Roomshare/1.0 (contact@roomshare.app)';
+const MIN_REQUEST_INTERVAL_MS = 1100; // Slightly over 1s to be safe
+
+/** Module-level rate limiter for server-side usage */
+let lastRequestTimestamp = 0;
+
+async function rateLimitWait(): Promise<void> {
+  const now = Date.now();
+  const elapsed = now - lastRequestTimestamp;
+  if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, MIN_REQUEST_INTERVAL_MS - elapsed),
+    );
+  }
+  lastRequestTimestamp = Date.now();
+}
+
+/** Common headers for all Nominatim requests */
+const NOMINATIM_HEADERS = {
+  'User-Agent': USER_AGENT,
+  Accept: 'application/json',
+};
+
+interface NominatimSearchResult {
+  place_id: number;
+  osm_type: string;
+  osm_id: number;
+  lat: string; // Nominatim returns strings!
+  lon: string;
+  display_name: string;
+  boundingbox: [string, string, string, string]; // [minLat, maxLat, minLon, maxLon] as strings
+  geojson?: GeoJSON.Geometry;
+  address?: Record<string, string>;
+  type?: string;
+}
+
+interface NominatimReverseResult {
+  place_id: number;
+  osm_type: string;
+  osm_id: number;
+  lat: string;
+  lon: string;
+  display_name: string;
+  address?: Record<string, string>;
+}
+
+/**
+ * Forward geocode an address to coordinates.
+ * Used server-side for listing creation. Includes rate limiting.
+ */
+export async function forwardGeocode(
+  query: string,
+  options?: { signal?: AbortSignal },
+): Promise<{ lat: number; lng: number } | null> {
+  await rateLimitWait();
+
+  const encoded = encodeURIComponent(query);
+  const url = `${NOMINATIM_BASE_URL}/search?q=${encoded}&format=jsonv2&limit=1&addressdetails=1`;
+
+  const response = await fetch(url, {
+    headers: NOMINATIM_HEADERS,
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Nominatim search failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data: NominatimSearchResult[] = await response.json();
+
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  return {
+    lat: parseFloat(data[0].lat),
+    lng: parseFloat(data[0].lon),
+  };
+}
+
+/**
+ * Reverse geocode coordinates to an address string.
+ * Used client-side for user pin placement (low frequency, user-initiated).
+ * No rate limiter needed client-side (one call at a time).
+ */
+export async function reverseGeocode(
+  lat: number,
+  lng: number,
+  options?: { signal?: AbortSignal },
+): Promise<string | null> {
+  const url = `${NOMINATIM_BASE_URL}/reverse?lat=${lat}&lon=${lng}&format=jsonv2&addressdetails=1`;
+
+  const response = await fetch(url, {
+    headers: NOMINATIM_HEADERS,
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data: NominatimReverseResult = await response.json();
+  return data.display_name ?? null;
+}
+
+export interface BoundaryResult {
+  displayName: string;
+  /** Actual GeoJSON polygon geometry (when available) */
+  geometry: GeoJSON.Geometry | null;
+  /** Bounding box as [minLng, minLat, maxLng, maxLat] */
+  bbox: [number, number, number, number] | null;
+}
+
+/**
+ * Search for a place boundary polygon.
+ * Returns actual polygon geometry when available (upgrade from Mapbox bbox rectangles).
+ * Falls back to bounding box when polygon data is unavailable.
+ */
+export async function searchBoundary(
+  query: string,
+  options?: { signal?: AbortSignal },
+): Promise<BoundaryResult | null> {
+  const encoded = encodeURIComponent(query);
+  const url = `${NOMINATIM_BASE_URL}/search?q=${encoded}&format=jsonv2&polygon_geojson=1&limit=1`;
+
+  const response = await fetch(url, {
+    headers: NOMINATIM_HEADERS,
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data: NominatimSearchResult[] = await response.json();
+
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  const result = data[0];
+
+  // Convert Nominatim boundingbox [minLat, maxLat, minLon, maxLon] (strings)
+  // to [minLng, minLat, maxLng, maxLat] (numbers, GeoJSON order)
+  const [minLat, maxLat, minLon, maxLon] = result.boundingbox.map(parseFloat);
+  const bbox: [number, number, number, number] = [minLon, minLat, maxLon, maxLat];
+
+  return {
+    displayName: result.display_name,
+    geometry: result.geojson ?? null,
+    bbox,
+  };
+}

--- a/src/lib/geocoding/photon.ts
+++ b/src/lib/geocoding/photon.ts
@@ -1,0 +1,140 @@
+/**
+ * Photon geocoding adapter (photon.komoot.io)
+ * Free OSM-based geocoder optimized for autocomplete.
+ * No API key needed, fair use policy.
+ *
+ * Transforms Photon GeoJSON responses to match the existing
+ * LocationSuggestion / GeocodingResult interfaces used throughout the app.
+ */
+
+import type { GeocodingResult } from '../geocoding-cache';
+
+const PHOTON_BASE_URL = 'https://photon.komoot.io/api';
+
+/** Max query length (reasonable limit; Photon has no documented cap) */
+export const PHOTON_QUERY_MAX_LENGTH = 500;
+
+interface PhotonProperties {
+  osm_id: number;
+  osm_type: string;
+  name?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  type?: string;
+  extent?: [number, number, number, number]; // [minLng, minLat, maxLng, maxLat]
+  street?: string;
+  housenumber?: string;
+  postcode?: string;
+  district?: string;
+  county?: string;
+}
+
+interface PhotonFeature {
+  type: 'Feature';
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number]; // [lng, lat]
+  };
+  properties: PhotonProperties;
+}
+
+interface PhotonResponse {
+  type: 'FeatureCollection';
+  features: PhotonFeature[];
+}
+
+/** Build a human-readable place name from Photon properties */
+function buildPlaceName(props: PhotonProperties): string {
+  const parts: string[] = [];
+
+  if (props.name) {
+    parts.push(props.name);
+  } else if (props.street) {
+    const street = props.housenumber
+      ? `${props.housenumber} ${props.street}`
+      : props.street;
+    parts.push(street);
+  }
+
+  if (props.city && props.city !== props.name) {
+    parts.push(props.city);
+  } else if (props.district && props.district !== props.name) {
+    parts.push(props.district);
+  }
+
+  if (props.state) {
+    parts.push(props.state);
+  }
+
+  if (props.country) {
+    parts.push(props.country);
+  }
+
+  return parts.join(', ') || 'Unknown location';
+}
+
+/** Map Photon type to Mapbox-compatible place_type array */
+function inferPlaceType(type?: string): string[] {
+  if (!type) return ['place'];
+  switch (type) {
+    case 'city':
+    case 'town':
+    case 'village':
+      return ['place'];
+    case 'district':
+    case 'suburb':
+    case 'neighbourhood':
+      return ['neighborhood'];
+    case 'street':
+      return ['address'];
+    case 'state':
+    case 'county':
+      return ['region'];
+    case 'country':
+      return ['country'];
+    case 'house':
+      return ['address'];
+    case 'locality':
+      return ['locality'];
+    default:
+      return ['place'];
+  }
+}
+
+/** Transform a single Photon feature to GeocodingResult */
+function toGeocodingResult(feature: PhotonFeature): GeocodingResult {
+  const props = feature.properties;
+  return {
+    id: `${props.osm_type || 'N'}:${props.osm_id || 0}`,
+    place_name: buildPlaceName(props),
+    center: feature.geometry.coordinates as [number, number],
+    place_type: inferPlaceType(props.type),
+    bbox: props.extent, // Already [minLng, minLat, maxLng, maxLat]
+  };
+}
+
+/**
+ * Search Photon for autocomplete suggestions.
+ * Returns results in the same shape as the existing GeocodingResult interface.
+ */
+export async function searchPhoton(
+  query: string,
+  options?: { signal?: AbortSignal; limit?: number },
+): Promise<GeocodingResult[]> {
+  const limit = options?.limit ?? 5;
+  const encoded = encodeURIComponent(query);
+  const url = `${PHOTON_BASE_URL}?q=${encoded}&limit=${limit}&lang=en`;
+
+  const response = await fetch(url, { signal: options?.signal });
+
+  if (!response.ok) {
+    if (response.status >= 500) {
+      throw new Error('Location service is temporarily unavailable');
+    }
+    throw new Error('Failed to fetch suggestions');
+  }
+
+  const data: PhotonResponse = await response.json();
+  return (data.features || []).map(toGeocodingResult);
+}


### PR DESCRIPTION
## Summary

- **Replace all Mapbox Geocoding API calls** with free OSM-based alternatives, eliminating the Mapbox token dependency and ongoing billing
- **Photon** (`photon.komoot.io`) powers autocomplete in `LocationSearchInput` — no API key, fair use, optimized for search-as-you-type
- **Nominatim** (`nominatim.openstreetmap.org`) handles forward geocoding (server-side), reverse geocoding (user pin), and boundary polygons — with built-in 1 req/s rate limiting and User-Agent header
- **Boundary layer upgraded**: now renders actual neighborhood/city polygon geometry instead of bbox rectangles

## Changes

### New files (2)
- `src/lib/geocoding/photon.ts` — Photon autocomplete adapter, transforms GeoJSON responses to existing `GeocodingResult` shape
- `src/lib/geocoding/nominatim.ts` — Nominatim adapter with `forwardGeocode`, `reverseGeocode`, `searchBoundary` + server-side rate limiter

### Source migrations (5)
- `LocationSearchInput.tsx` → Photon autocomplete (removed token checks, rate-limit state, Mapbox-specific error handling)
- `BoundaryLayer.tsx` → Nominatim boundary search (actual polygons via `polygon_geojson=1`)
- `UserMarker.tsx` → Nominatim reverse geocoding (removed `mapboxToken` prop)
- `geocoding.ts` → Nominatim forward geocoding (server-side, circuit-breaker wrapped)
- `Map.tsx` → removed Mapbox token props from child components

### Config updates (3)
- `circuit-breaker.ts` — renamed `mapboxGeocode` → `nominatimGeocode`
- `env.ts` — removed `MAPBOX_ACCESS_TOKEN` from schema, geocoding always enabled
- `next.config.ts` — CSP `connect-src` updated for Photon + Nominatim domains
- `.github/workflows/playwright.yml` — removed `NEXT_PUBLIC_MAPBOX_TOKEN` env var

### Test updates (10 files)
- `geocoding.test.ts` — rewritten to mock Nominatim adapter (6 tests)
- `circuit-breaker.test.ts` — renamed breaker reference
- 5 LocationSearchInput test files — Photon mock responses (118 tests)
- `postgis-spatial-edge-cases.test.ts` — Nominatim URLs
- `Map.test.tsx`, `touch-gestures.test.tsx` — removed token env setup
- `map-mock-helpers.ts` (E2E) — Photon + Nominatim route mocks

## Test plan

- [x] `pnpm typecheck` — clean, no errors
- [x] `pnpm test` — 191 suites, 4,678 tests passing
- [x] Zero `api.mapbox.com` references in source/test/CI
- [x] Zero `mapboxGeocode` references remaining
- [ ] E2E tests pass in CI (mocks updated in `map-mock-helpers.ts`)
- [ ] Manual smoke: autocomplete, boundary polygons, drop pin reverse geocode
- [ ] Verify network tab shows zero requests to `api.mapbox.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)