### PR TITLE
fix(security): enforce email verification and block checks in messages API

### DIFF
--- a/src/__tests__/api/messages-pagination.test.ts
+++ b/src/__tests__/api/messages-pagination.test.ts
@@ -36,6 +36,11 @@ jest.mock('@/auth', () => ({
 
 jest.mock('@/app/actions/suspension', () => ({
   checkSuspension: jest.fn().mockResolvedValue({ suspended: false }),
+  checkEmailVerified: jest.fn().mockResolvedValue({ verified: true }),
+}));
+
+jest.mock('@/app/actions/block', () => ({
+  checkBlockBeforeAction: jest.fn().mockResolvedValue({ allowed: true }),
 }));
 
 // Mock next/server to avoid NextRequest issues in Jest


### PR DESCRIPTION
## Summary

- **P1 Security Fix**: The `POST /api/messages` route was missing email verification and participant block checks that were already enforced in the server action layer (`src/app/actions/chat.ts`). This allowed direct API callers to bypass both policies.
- Added `checkEmailVerified()` call after suspension check (returns 403 if unverified)
- Added `checkBlockBeforeAction()` call after participant validation (returns 403 if blocked in either direction)
- Added 3 new test cases covering both checks

## Test plan

- [x] Existing 10 messages API tests still pass
- [x] New test: unverified email returns 403
- [x] New test: sender blocked by recipient returns 403
- [x] New test: sender has blocked recipient returns 403
- [ ] Manual: verify direct `POST /api/messages` rejects unverified users
- [ ] Manual: verify direct `POST /api/messages` rejects blocked participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)