### PR TITLE
fix: harden /api/agent, register METRICS_SECRET, fix CI migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,9 @@ CRON_SECRET=generate-secure-secret-at-least-32-chars
 # Generate with: openssl rand -hex 32
 LOG_HMAC_SECRET=generate-with-openssl-rand-hex-32-chars
 
-# Metrics Ops Endpoint Authentication (optional)
-# When set, GET /api/metrics/ops requires Bearer token matching this value
-# Generate with: openssl rand -base64 32
-# METRICS_SECRET=your-metrics-secret
+# Metrics Ops Endpoint Authentication — REQUIRED in production
+# Generate with: openssl rand -base64 32 (must be at least 32 characters)
+METRICS_SECRET=generate-secure-secret-at-least-32-chars
 
 # ===========================================
 # ORIGIN/HOST SECURITY (Production)

--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ METRICS_SECRET=generate-secure-secret-at-least-32-chars
 # ORIGIN/HOST SECURITY (Production)
 # ===========================================
 # Comma-separated, no trailing slashes
-# Used by /api/chat and /api/metrics for request validation
+# Used by /api/agent, /api/chat, and /api/metrics for request validation
 ALLOWED_ORIGINS=https://roomshare.com,https://www.roomshare.com
 ALLOWED_HOSTS=roomshare.com,www.roomshare.com
 

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -62,8 +62,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma client and push schema
-        run: pnpm exec prisma generate && pnpm exec prisma db push --skip-generate
+      - name: Generate Prisma client and run migrations
+        run: pnpm exec prisma generate && pnpm exec prisma migrate deploy
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -100,22 +100,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma client and push schema
-        run: pnpm exec prisma generate && pnpm exec prisma db push --skip-generate
-
-      - name: Apply search_doc SQL migrations
-        env:
-          PGPASSWORD: password
-        run: |
-          for f in \
-            prisma/migrations/20260110000000_search_doc/migration.sql \
-            prisma/migrations/20260116000000_search_doc_fts/migration.sql \
-            prisma/migrations/20260121000000_search_doc_lower_indexes/migration.sql \
-            prisma/migrations/20260131000000_search_doc_composite_indexes/migration.sql \
-            prisma/migrations/20260208000000_search_doc_gender_columns/migration.sql; do
-            echo "Applying $f ..."
-            psql -h localhost -p 5433 -U postgres -d roomshare -f "$f"
-          done
+      - name: Generate Prisma client and run migrations
+        run: pnpm exec prisma generate && pnpm exec prisma migrate deploy
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -85,7 +85,7 @@ Local Docker default: `postgresql://postgres:password@localhost:5433/roomshare?s
 |----------|----------|-------------|---------------|
 | `CRON_SECRET` | Prod only | Authenticates cron job requests (min 32 chars) | `openssl rand -base64 32` |
 | `LOG_HMAC_SECRET` | Recommended | HMAC key for privacy-safe metric logging | `openssl rand -hex 32` |
-| `METRICS_SECRET` | Recommended | Bearer token for `/api/metrics/ops` endpoint (default-deny if unset) | `openssl rand -base64 32` |
+| `METRICS_SECRET` | Prod only | Bearer token for `/api/metrics/ops` endpoint, min 32 chars (default-deny if unset) | `openssl rand -base64 32` |
 
 ### Origin/Host Security (Production)
 
@@ -94,7 +94,7 @@ Local Docker default: `postgresql://postgres:password@localhost:5433/roomshare?s
 | `ALLOWED_ORIGINS` | Prod only | Comma-separated allowed origins | `https://roomshare.com,https://www.roomshare.com` |
 | `ALLOWED_HOSTS` | Prod only | Comma-separated allowed hosts | `roomshare.com,www.roomshare.com` |
 
-These are enforced by `/api/chat` and `/api/metrics` to reject cross-origin requests.
+These are enforced by `/api/agent`, `/api/chat`, and `/api/metrics` to reject cross-origin requests.
 
 ### Error Tracking (Sentry)
 

--- a/src/__tests__/api/agent.test.ts
+++ b/src/__tests__/api/agent.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for /api/agent route — Security hardening (Issue #11)
+ * Covers: origin/host enforcement, content-type, body size guard, existing behavior.
+ */
+
+jest.mock('@/lib/with-rate-limit', () => ({
+  withRateLimit: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    sync: { error: jest.fn(), warn: jest.fn() },
+  },
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: any, init?: { status?: number }) => ({
+      status: init?.status || 200,
+      json: async () => data,
+      headers: new Map(),
+    }),
+  },
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import { POST } from '@/app/api/agent/route';
+
+function createRequest(
+  body: any,
+  opts: { origin?: string | null; host?: string | null; contentType?: string | null } = {}
+): Request {
+  const headers: Record<string, string> = {};
+  if (opts.contentType !== null) headers['content-type'] = opts.contentType ?? 'application/json';
+  if (opts.origin !== undefined && opts.origin !== null) headers['origin'] = opts.origin;
+  if (opts.host !== undefined && opts.host !== null) headers['host'] = opts.host;
+  return new Request('http://localhost/api/agent', {
+    method: 'POST',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+const validBody = { question: 'Is this area safe?', lat: 37.7749, lng: -122.4194 };
+
+describe('POST /api/agent', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      N8N_WEBHOOK_URL: 'https://n8n.example.com/webhook/agent',
+      NODE_ENV: 'test',
+    } as unknown as NodeJS.ProcessEnv;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ answer: 'Nice neighborhood.' }),
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // ── Origin/Host enforcement (production) ──
+
+  describe('origin/host enforcement (production)', () => {
+    beforeEach(() => {
+      process.env = {
+        ...process.env,
+        NODE_ENV: 'production',
+        ALLOWED_ORIGINS: 'https://roomshare.app',
+        ALLOWED_HOSTS: 'roomshare.app',
+      } as unknown as NodeJS.ProcessEnv;
+    });
+
+    it('returns 403 when origin not in allowlist', async () => {
+      const res = await POST(createRequest(validBody, { origin: 'https://evil.com' }) as any);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when no origin and host not in allowlist', async () => {
+      const res = await POST(createRequest(validBody, { host: 'evil.com' }) as any);
+      expect(res.status).toBe(403);
+    });
+
+    it('allows valid origin', async () => {
+      const res = await POST(createRequest(validBody, { origin: 'https://roomshare.app', host: 'roomshare.app' }) as any);
+      expect(res.status).toBe(200);
+    });
+
+    it('allows valid host with port', async () => {
+      const res = await POST(createRequest(validBody, { host: 'roomshare.app:443' }) as any);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('origin/host enforcement (development)', () => {
+    it('skips enforcement in development', async () => {
+      process.env = { ...process.env, NODE_ENV: 'development' } as unknown as NodeJS.ProcessEnv;
+      const res = await POST(createRequest(validBody, { origin: 'https://evil.com' }) as any);
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  // ── Content-Type enforcement ──
+
+  describe('content-type enforcement', () => {
+    it('returns 415 for non-JSON content type', async () => {
+      const res = await POST(createRequest(validBody, { contentType: 'text/plain' }) as any);
+      expect(res.status).toBe(415);
+    });
+
+    it('returns 415 when content-type missing', async () => {
+      const res = await POST(createRequest(validBody, { contentType: null }) as any);
+      expect(res.status).toBe(415);
+    });
+
+    it('accepts application/json with charset', async () => {
+      const res = await POST(createRequest(validBody, { contentType: 'application/json; charset=utf-8' }) as any);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── Body size guard ──
+
+  describe('body size guard', () => {
+    it('returns 413 for oversized body', async () => {
+      const res = await POST(createRequest({ question: 'x'.repeat(11000), lat: 0, lng: 0 }) as any);
+      expect(res.status).toBe(413);
+    });
+
+    it('returns 413 for multibyte payload exceeding byte limit', async () => {
+      // 5,000 emoji = 5,000 UTF-16 code units but 20,000 UTF-8 bytes
+      const res = await POST(createRequest({ question: '😀'.repeat(5000), lat: 0, lng: 0 }) as any);
+      expect(res.status).toBe(413);
+    });
+  });
+
+  // ── JSON parse ──
+
+  describe('JSON parsing', () => {
+    it('returns 400 for invalid JSON', async () => {
+      const res = await POST(createRequest('not-json{{{') as any);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Existing validation (no regression) ──
+
+  describe('existing validation', () => {
+    it('returns 400 when question missing', async () => {
+      const res = await POST(createRequest({ lat: 37.7, lng: -122.4 }) as any);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid coordinates', async () => {
+      const res = await POST(createRequest({ question: 'Safe?', lat: 999, lng: 0 }) as any);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 503 when N8N_WEBHOOK_URL not configured', async () => {
+      delete process.env.N8N_WEBHOOK_URL;
+      const res = await POST(createRequest(validBody) as any);
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── Happy path ──
+
+  describe('successful request', () => {
+    it('forwards to n8n and returns answer', async () => {
+      const res = await POST(createRequest(validBody) as any);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.answer).toBe('Nice neighborhood.');
+    });
+
+    it('returns fallback on n8n error', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 502 });
+      const res = await POST(createRequest(validBody) as any);
+      const data = await res.json();
+      expect(data.fallback).toBe(true);
+    });
+
+    it('returns fallback on timeout', async () => {
+      mockFetch.mockRejectedValue(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+      const res = await POST(createRequest(validBody) as any);
+      const data = await res.json();
+      expect(data.fallback).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/api/metrics-ops.test.ts
+++ b/src/__tests__/api/metrics-ops.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for /api/metrics/ops route — route-level auth logic (Issue #12)
+ *
+ * Scope: Tests bearer-token matching in the route handler only.
+ * getServerEnv is mocked to bypass Zod lazy-init caching, so these tests
+ * do NOT cover production env-validation behavior (fail-fast throw on
+ * missing METRICS_SECRET). That Zod .refine() path is currently untested;
+ * adding coverage is tracked as a known gap.
+ */
+
+// Mock getServerEnv to read from process.env directly (avoids lazy-init caching)
+jest.mock('@/lib/env', () => ({
+  getServerEnv: () => process.env,
+}));
+
+import { GET } from '@/app/api/metrics/ops/route';
+
+describe('GET /api/metrics/ops', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      METRICS_SECRET: 'test-metrics-secret-32-chars-min!!',
+    } as unknown as NodeJS.ProcessEnv;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 401 when no Authorization header', async () => {
+    const req = new Request('http://localhost/api/metrics/ops');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when bearer token does not match', async () => {
+    const req = new Request('http://localhost/api/metrics/ops', {
+      headers: { authorization: 'Bearer wrong-token' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when METRICS_SECRET is not set', async () => {
+    delete process.env.METRICS_SECRET;
+    const req = new Request('http://localhost/api/metrics/ops', {
+      headers: { authorization: 'Bearer anything' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with Prometheus metrics when token matches', async () => {
+    const req = new Request('http://localhost/api/metrics/ops', {
+      headers: { authorization: 'Bearer test-metrics-secret-32-chars-min!!' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('process_uptime_seconds');
+    expect(text).toContain('nodejs_heap_size_used_bytes');
+  });
+});

--- a/src/__tests__/lib/env-turnstile-production.test.ts
+++ b/src/__tests__/lib/env-turnstile-production.test.ts
@@ -17,6 +17,7 @@ describe("Turnstile production enforcement", () => {
       GOOGLE_CLIENT_ID: "test-client-id",
       GOOGLE_CLIENT_SECRET: "test-client-secret",
       CRON_SECRET: "b".repeat(32),
+      METRICS_SECRET: "m".repeat(32),
     } as unknown as NodeJS.ProcessEnv;
   });
 


### PR DESCRIPTION
## Summary

- **Issue #11:** Harden `/api/agent` with origin/host enforcement, content-type check, body-size guard (now using `Buffer.byteLength` for multibyte safety), and input validation. 17 tests added.
- **Issue #12:** Register `METRICS_SECRET` in Zod env schema with min-32-char production requirement. Add bearer-token auth to `/api/metrics/ops`. 4 tests added.
- **Issue #13:** Replace `prisma db push` with `prisma migrate deploy` in Playwright CI workflows to match production migration strategy.
- **Docs:** Align `DEPLOYMENT.md` and `.env.example` with runtime behavior (METRICS_SECRET requirement level, `/api/agent` in origin/host enforcement list).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm jest src/__tests__/api/agent.test.ts` — 17/17 pass
- [x] `pnpm jest src/__tests__/api/metrics-ops.test.ts` — 4/4 pass
- [x] `pnpm jest src/__tests__/lib/env-turnstile-production.test.ts` — 4/4 pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)