### PR TITLE
fix(search): close P0+P1 production audit issues (C1-C9, H1-H5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ CRON_SECRET=generate-secure-secret-at-least-32-chars
 # Generate with: openssl rand -hex 32
 LOG_HMAC_SECRET=generate-with-openssl-rand-hex-32-chars
 
+# Cursor signing secret (prevents cursor tampering)
+# Generate with: openssl rand -hex 32
+CURSOR_SECRET=
+
 # Metrics Ops Endpoint Authentication — REQUIRED in production
 # Generate with: openssl rand -base64 32 (must be at least 32 characters)
 METRICS_SECRET=generate-secure-secret-at-least-32-chars

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -39,6 +39,7 @@ jobs:
       E2E_BASE_URL: http://localhost:3000
       E2E_TEST_EMAIL: test@example.com
       E2E_TEST_PASSWORD: TestPassword123!
+      E2E_DISABLE_RATE_LIMIT: 'true'
       GOOGLE_CLIENT_ID: 'ci-placeholder-not-used-in-tests'
       GOOGLE_CLIENT_SECRET: 'ci-placeholder-not-used-in-tests'
       # Cloudflare Turnstile: intentionally DISABLED in CI.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,6 +74,7 @@ jobs:
       E2E_TEST_PASSWORD: TestPassword123!
       E2E_ADMIN_EMAIL: e2e-admin@roomshare.dev
       E2E_ADMIN_PASSWORD: TestPassword123!
+      E2E_DISABLE_RATE_LIMIT: 'true'
       NODE_OPTIONS: '--max-old-space-size=4096'
       CI: 'true'
       GOOGLE_CLIENT_ID: 'ci-placeholder-not-used-in-tests'

--- a/docs/SEARCH_PAGE_PRODUCTION_AUDIT.md
+++ b/docs/SEARCH_PAGE_PRODUCTION_AUDIT.md
@@ -1,0 +1,483 @@
+# Roomshare Search Page — Production Readiness Audit
+
+**Date**: 2026-02-17
+**Method**: 6 specialized Opus 4.6 agents auditing in parallel
+**Scope**: 107+ source files across 6 domains
+**Total Findings**: 130+
+
+---
+
+## Overall Production Readiness Score: 7.4 / 10
+
+| Layer | Score | Agent | Key Risk |
+|-------|-------|-------|----------|
+| SSR / Page Structure | 7.0 | ssr-auditor | No SEO metadata, missing timeouts |
+| API / Backend Services | 7.5 | api-auditor | Unsigned cursors, facets timeout gap |
+| Client Components / UX | 7.5 | client-ux-auditor | SaveSearch a11y, filter param inconsistency |
+| Map Integration | 7.0 | map-auditor | No WebGL recovery, 2192-line monolith |
+| Filters / Pagination | 8.5 | filters-pagination-auditor | Dual validation systems, misleading context selectors |
+| Security / Rate Limiting | 7.5 | security-auditor | IP spoofing vector, missing rate limits on saved searches |
+
+---
+
+## Detailed Dimension Scores
+
+| Dimension | SSR | API | UX | Map | Filters | Security |
+|-----------|-----|-----|-----|-----|---------|----------|
+| Correctness | 7 | 8 | 8 | 7 | 9 | 8 |
+| Error Handling | 7 | 7 | 9 | 6 | 8 | 8 |
+| Security | 7 | 8 | 6 | 7 | 8 | 7 |
+| Performance | 7 | 8 | 8 | 7 | 9 | 8 |
+| Accessibility | 7 | — | 6 | 7 | — | — |
+| Maintainability | 7 | 7 | 7 | 6 | 8 | 8 |
+
+---
+
+## Architecture Strengths
+
+1. **V2/V1 fallback pattern** — graceful degradation with proper error isolation
+2. **Multi-tier rate limiting** — Redis -> DB -> in-memory with fail-closed on cost-sensitive endpoints
+3. **Keyset pagination** — correct implementation with +1 pattern, dedup via Set, 60-item cap
+4. **Comprehensive input validation** — allowlists for all enums, numeric clamping, date validation, bounds enforcement
+5. **Lazy map loading** — significant cost savings, only loads when user opts in
+6. **Race condition handling** — AbortControllers, navigation version counters, stale response rejection, `isLoadingRef`
+7. **Strong a11y foundation** — keyboard navigation, ARIA live regions, IME support, safe-area-inset handling
+8. **Filter regression framework** — golden scenarios with behavior hashing for production regression detection
+9. **Excellent test coverage** — 400+ tests across filters, pagination, edge cases, security scenarios
+
+---
+
+## CRITICAL Issues (9 total — must fix before production)
+
+### C1. No `generateMetadata` — zero SEO on search page
+- **Layer**: SSR
+- **File**: `src/app/search/page.tsx` (missing export)
+- **Description**: The search page has zero SEO configuration — no `generateMetadata`, no `metadata` export. Every other significant page in the app has metadata, but the search page — arguably the most important page for organic discovery — has none.
+- **Impact**: No page title, no description, no canonical URLs, no Open Graph/Twitter cards, no `noindex` for filtered/paginated results. Search engines will index every filter combination as separate pages with duplicate/missing titles.
+- **Fix**: Add `generateMetadata` that sets dynamic title based on query (e.g., "Rooms in San Francisco | Roomshare"), description from query + filter summary, canonical URL (strip pagination/cursor params), `noindex` for highly filtered/paginated results, and OG/Twitter cards.
+
+### C2. `fetchMoreListings` server action has NO timeout protection
+- **Layer**: SSR
+- **File**: `src/app/search/actions.ts:52`
+- **Description**: The V2 path calls `executeSearchV2()` directly without `withTimeout()`, unlike the SSR page which properly wraps both V2 and V1 paths with `withTimeout(fn, DEFAULT_TIMEOUTS.DATABASE, ...)`. A hung database or slow V2 query would cause the server action to hang indefinitely.
+- **Impact**: Production server actions that hang without timeout can cause cascading failures — Node.js worker threads get exhausted, subsequent requests queue up, and the entire service becomes unresponsive.
+- **Fix**: Wrap line 52 with `withTimeout(executeSearchV2({...}), DEFAULT_TIMEOUTS.DATABASE, 'fetchMore-V2')`.
+
+### C3. `$queryRawUnsafe` used extensively with string-interpolated WHERE clauses
+- **Layer**: API
+- **Files**: `search-doc-queries.ts:274,310,346,380,437,570,654,806,1058,1242`, `facets/route.ts:274,310,346,380,437`
+- **Description**: Multiple queries use `prisma.$queryRawUnsafe(query, ...params)` where the SQL query string is built via string interpolation of column names, WHERE conditions, and ORDER BY clauses. While the values are properly parameterized (no direct user input concatenation), the `$queryRawUnsafe` method name is a red flag and any future developer could accidentally concatenate user input into a condition string.
+- **Impact**: Low probability today (parameterized correctly), but high blast radius if a future change introduces a bug.
+- **Fix**: Add a comment block at each `buildSearchDocWhereConditions` / `buildFacetWhereConditions` documenting the security invariant. Consider adding a lint rule or code review checklist item.
+
+### C4. No cursor signature/HMAC — cursor tampering enables data exfiltration
+- **Layer**: API
+- **File**: `search-doc-queries.ts:1001-1008`, `search-v2-service.ts:148-164`
+- **Description**: Keyset cursors are base64-encoded JSON containing raw sort column values (`recommended_score`, `price`, `avg_rating`, `review_count`, `listing_created_at`, `id`). The `decodeCursorAny` function decodes and trusts these values without any signature verification. An attacker can craft arbitrary cursor values to skip pagination, enumerate all listings, and extract internal ranking scores.
+- **Impact**: Information disclosure (ranking scores), potential enumeration of all listings bypassing intended pagination limits.
+- **Fix**: HMAC-sign cursor strings using a server-side secret. On decode, verify the signature before trusting cursor values. Reject unsigned or tampered cursors with a 400 error.
+
+### C5. SaveSearchButton modal has no focus trap or focus return
+- **Layer**: Client/UX
+- **File**: `src/components/SaveSearchButton.tsx:144-271`
+- **Description**: The save-search modal renders a fixed overlay with `z-[1000]` but has no focus trap implementation. When opened, focus is not moved to the modal. Tab key can escape to background content. When closed, focus is not returned to the trigger button.
+- **Impact**: WCAG 2.1 AA failure. Screen reader and keyboard users can interact with hidden background content.
+- **Fix**: Add a focus trap (e.g., `@radix-ui/react-dialog` or manual trap). On open, move focus to the first interactive element. On close, restore focus to the trigger button.
+
+### C6. SaveSearchButton modal missing aria attributes
+- **Layer**: Client/UX
+- **File**: `src/components/SaveSearchButton.tsx:153`
+- **Description**: The modal div lacks `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`. The backdrop click handler exists but has no Escape key handler.
+- **Impact**: Screen readers won't announce it as a dialog. No keyboard dismiss path. WCAG failure.
+- **Fix**: Add `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to the h2. Add Escape key handler.
+
+### C7. SaveSearchButton toggle switch missing ARIA role
+- **Layer**: Client/UX
+- **File**: `src/components/SaveSearchButton.tsx:197-205`
+- **Description**: The email alerts toggle is a `<button>` with custom styling to look like a switch, but lacks `role="switch"` and `aria-checked`. Screen readers will not announce it as a toggle.
+- **Impact**: WCAG failure — assistive tech users can't determine the toggle state.
+- **Fix**: Add `role="switch"` and `aria-checked={alertEnabled}` to the toggle button.
+
+### C8. Body scroll not locked when SaveSearchButton modal is open
+- **Layer**: Client/UX
+- **File**: `src/components/SaveSearchButton.tsx:144`
+- **Description**: Unlike MobileSearchOverlay and MobileBottomSheet which properly lock body scroll, the SaveSearchButton modal does not lock body scroll. Users can scroll the background while the modal is open.
+- **Impact**: Confusing UX on mobile — content scrolls behind the modal overlay.
+- **Fix**: Add `useEffect` to set `document.body.style.overflow = 'hidden'` when `isOpen` is true.
+
+### C9. No WebGL Context Loss Recovery
+- **Layer**: Map
+- **Files**: `src/components/Map.tsx`, `src/components/map/MapErrorBoundary.tsx`
+- **Description**: There is no handler for WebGL context loss (`webglcontextlost` / `webglcontextrestored` events). MapLibre GL JS uses WebGL for rendering. On mobile devices, the OS can reclaim GPU memory when the app is backgrounded, causing the map canvas to go blank with no recovery mechanism.
+- **Impact**: Users on mobile will see a blank map after switching apps and returning. No automatic recovery.
+- **Fix**: Add `webglcontextlost`/`webglcontextrestored` event listeners on the map canvas. On loss, show a "Map paused" overlay. On restore, call `map.triggerRepaint()`. If restore doesn't fire within ~5s, force re-mount the map component.
+
+---
+
+## HIGH Issues (20 total — should fix, significant risk)
+
+### H1. `parseSearchParams` throws on malformed input (inverted prices/lats)
+- **Layer**: SSR
+- **File**: `src/lib/search-params.ts:434` and `:451`
+- **Description**: `parseSearchParams` throws `new Error("minPrice cannot exceed maxPrice")` for inverted ranges. Since `SearchPage` calls `parseSearchParams(rawParams)` without try/catch, this triggers the error boundary for any user who crafts a URL like `?minPrice=5000&maxPrice=100`.
+- **Impact**: Any user can trigger a 500-like error page with a simple URL. Sentry event quota exhaustion.
+- **Fix**: Normalize (swap min/max) instead of throwing, or catch and return graceful defaults.
+
+### H2. No query length validation in `parseSearchParams`
+- **Layer**: SSR / API / Security
+- **File**: `src/lib/search-params.ts:404-406`
+- **Description**: The `q` parameter is trimmed but not length-limited. `MAX_QUERY_LENGTH = 200` exists in `constants.ts` but `parseSearchParams` does not enforce it.
+- **Impact**: Extremely long query strings can cause excessive memory usage, slow database text search, and potential ReDoS.
+- **Fix**: Add `const q = query.slice(0, MAX_QUERY_LENGTH)` in `parseSearchParams`.
+
+### H3. Rate-limited pages return HTTP 200 instead of 429
+- **Layer**: SSR
+- **File**: `src/app/search/page.tsx:102-120`
+- **Description**: When rate-limited, the page renders a "Too Many Requests" UI but returns HTTP 200 (RSC page components can't set status codes).
+- **Impact**: HTTP clients, bots, and monitoring tools won't detect rate limiting. A bot will see 200 and continue hammering.
+- **Fix**: Consider redirecting to an API route that returns 429, or use Next.js middleware for rate limiting.
+
+### H4. `analyzeFilterImpact` called without timeout
+- **Layer**: SSR
+- **File**: `src/app/search/page.tsx:255`
+- **Description**: `analyzeFilterImpact(filterParams)` is called for zero-result searches without any timeout wrapper, unlike V2/V1 search paths which have `withTimeout()` protection.
+- **Impact**: If the database is slow, this additional query could hang the SSR indefinitely on the zero-results path.
+- **Fix**: Wrap with `withTimeout(analyzeFilterImpact(filterParams), DEFAULT_TIMEOUTS.DATABASE, 'analyzeFilterImpact')`.
+
+### H5. `ITEMS_PER_PAGE` duplicated instead of using centralized constant
+- **Layer**: SSR
+- **Files**: `src/app/search/page.tsx:23` and `src/app/search/actions.ts:10`
+- **Description**: Both files define `const ITEMS_PER_PAGE = 12` independently instead of importing `DEFAULT_PAGE_SIZE` from `src/lib/constants.ts`.
+- **Impact**: If one file is updated without the other, SSR page size and "Load more" page size would diverge, causing duplicate or skipped listings.
+- **Fix**: Import `DEFAULT_PAGE_SIZE` from `@/lib/constants` in both files.
+
+### H6. `console.log` with raw JSON in production code
+- **Layer**: API
+- **File**: `search-v2-service.ts:402-409`
+- **Description**: Search latency metric logged via `console.log(JSON.stringify({...}))` instead of structured `logger`. Bypasses log level controls and PII redaction safeguards.
+- **Fix**: Replace with `logger.info("search_latency", { durationMs, listCount, mapCount, mode, cached: false })`.
+
+### H7. Facets endpoint missing timeout protection
+- **Layer**: API
+- **File**: `facets/route.ts:480-500`
+- **Description**: The facets endpoint runs 4 parallel + 1 sequential database queries without `withTimeout` or `queryWithTimeout`. `UNNEST` + `GROUP BY` queries on arrays can be expensive for large datasets.
+- **Impact**: A single slow facet query blocks the request and ties up a serverless function instance.
+- **Fix**: Wrap with `withTimeout(... , DEFAULT_TIMEOUTS.DATABASE)`.
+
+### H8. Facets `$queryRawUnsafe` without statement timeout
+- **Layer**: API
+- **File**: `facets/route.ts:274,310,346,380,437`
+- **Description**: Unlike `search-doc-queries.ts` which wraps queries in `queryWithTimeout` (with `SET LOCAL statement_timeout`), the facets route executes raw queries directly without any statement timeout.
+- **Impact**: Database connection pool exhaustion; DoS via expensive facet queries.
+- **Fix**: Use the same `queryWithTimeout` pattern from `search-doc-queries.ts`.
+
+### H9. `listings/route.ts` GET uses DB-backed rate limiter, not Redis
+- **Layer**: API
+- **File**: `listings/route.ts:23`
+- **Description**: The GET handler uses the PostgreSQL `RateLimitEntry` table for rate limiting instead of Redis like other search endpoints. For a read-heavy endpoint, every request creates a DB write.
+- **Impact**: Under load, the rate limiter itself becomes a bottleneck.
+- **Fix**: Migrate to `withRateLimitRedis` for consistency.
+
+### H10. `listings/[id]/route.ts` PATCH has TOCTOU race condition
+- **Layer**: API
+- **File**: `listings/[id]/route.ts:238-249`
+- **Description**: PATCH checks ownership with `findUnique` then updates in a separate transaction. Between the read and transaction, ownership could change. The DELETE handler correctly uses `FOR UPDATE` inside the transaction.
+- **Fix**: Move the ownership check inside the transaction with `FOR UPDATE`, matching the DELETE pattern.
+
+### H11. `processSearchAlerts` loads ALL saved searches unbounded
+- **Layer**: API / Security
+- **File**: `src/lib/search-alerts.ts:59-87`
+- **Description**: `processSearchAlerts()` fetches ALL saved searches with `alertEnabled: true` without pagination or batch size limit. Each triggers a separate DB query and potentially an email.
+- **Impact**: Memory exhaustion, thundering herd of DB queries, email service overwhelm, cron timeout.
+- **Fix**: Add batch processing with LIMIT/OFFSET or cursor-based iteration. Process in chunks of 50-100.
+
+### H12. CompactSearchPill filter count parsing diverges from canonical logic
+- **Layer**: Client/UX
+- **File**: `src/components/search/CompactSearchPill.tsx:41-55`
+- **Description**: Filter count logic splits `amenities` and `houseRules` by comma (`split(',')`), but other components use `getAll()` for multi-value params.
+- **Impact**: Filter count badge shows incorrect count on the compact desktop pill.
+- **Fix**: Use `searchParams.getAll('amenities')` to match the pattern in CollapsedMobileSearch.
+
+### H13. RecommendedFilters uses comma-joined array params inconsistently
+- **Layer**: Client/UX
+- **File**: `src/components/search/RecommendedFilters.tsx:26-32, 68-76`
+- **Description**: `parseArrayParam` reads multi-value params by splitting on commas, and writes them back with `params.set(name, selected.join(','))`. But SearchForm appends each value as a separate URL param with `params.append('amenities', a)`.
+- **Impact**: After clicking a recommended filter, the URL format changes from `amenities=Wifi&amenities=Parking` to `amenities=Wifi,Parking`, potentially breaking parsing.
+- **Fix**: Use `params.append()` for each value instead of joining with commas.
+
+### H14. MobileSearchOverlay doesn't use LocationSearchInput — no geocoding
+- **Layer**: Client/UX
+- **File**: `src/components/search/MobileSearchOverlay.tsx:97-108`
+- **Description**: The mobile overlay has a plain text input that calls `onSearch(value)` without geocoding/autocomplete. Desktop has LocationSearchInput for this purpose.
+- **Impact**: Performance risk (unbounded queries) and UX inconsistency.
+- **Fix**: Replace the plain input with `LocationSearchInput`.
+
+### H15. SuggestedSearches links don't include coordinates
+- **Layer**: Client/UX
+- **File**: `src/components/search/SuggestedSearches.tsx:40-48, 63-71`
+- **Description**: Recent search and popular area links use `href={/search?q=${...}}` without lat/lng coordinates.
+- **Impact**: Clicking these links triggers an unbounded text search, adding latency and potential errors.
+- **Fix**: Include stored coordinates for recent searches. Add hardcoded coordinates for popular areas.
+
+### H16. SearchForm `handleSearch` has 13+ dependencies
+- **Layer**: Client/UX
+- **File**: `src/components/SearchForm.tsx:423`
+- **Description**: Any change to any of 13+ dependencies recreates the callback, which could trigger unexpected behavior with the debounce timeout.
+- **Fix**: Read filter state from refs instead of having them as dependencies.
+
+### H17. Duplicate Map Component — MapClient.tsx vs Map.tsx
+- **Layer**: Map
+- **File**: `src/components/map/MapClient.tsx` (641 lines)
+- **Description**: `MapClient.tsx` is an older, simpler version of `Map.tsx` with divergent features. It lacks all production fixes present in Map.tsx.
+- **Impact**: Developers may import the wrong component, introducing regressions.
+- **Fix**: Remove `MapClient.tsx` if unused, or clearly mark as deprecated.
+
+### H18. No maximum marker count limit
+- **Layer**: Map
+- **Files**: `src/components/Map.tsx:1805`, `src/app/api/map-listings/route.ts`
+- **Description**: The API returns all listings within bounds without a LIMIT. The client renders all markers as individual DOM elements. With a dense city view at low zoom, hundreds of markers create hundreds of DOM nodes.
+- **Impact**: Frame drops and memory spikes on low-end mobile devices.
+- **Fix**: Server: add hard `LIMIT 200`. Client: consider supercluster with canvas-rendered markers for >100 points.
+
+### H19. No per-user rate limiting on search — only per-IP
+- **Layer**: Security
+- **Files**: `src/app/api/search/v2/route.ts:64-67`, `src/app/api/map-listings/route.ts:34-37`
+- **Description**: Search endpoints only rate limit by IP. No per-user tier differentiation. A corporate NAT can exhaust limits for all users behind that IP.
+- **Fix**: For authenticated users, use `${ip}:${userId}` as the rate limit identifier.
+
+### H20. Saved search server actions missing rate limiting
+- **Layer**: Security
+- **File**: `src/app/actions/saved-search.ts`
+- **Description**: `saveSearch`, `deleteSavedSearch`, `toggleSearchAlert`, and `updateSavedSearchName` have auth checks but NO rate limiting.
+- **Impact**: Authenticated users could spam mutations causing DB write amplification.
+- **Fix**: Add rate limiting using `checkServerComponentRateLimit` or `withRateLimit` wrapper.
+
+### H21. SearchResultsClient useEffect has triple dependency reset risk
+- **Layer**: Filters/Pagination
+- **File**: `src/components/search/SearchResultsClient.tsx:74-81`
+- **Description**: The useEffect has dependencies `[searchParamsString, initialListings, initialNextCursor]`. Since `initialListings` is a new array reference on every SSR render, the effect fires unnecessarily, potentially losing "Load more" progress.
+- **Fix**: Use `searchParamsString` as the sole reset trigger (component is already keyed by it).
+
+---
+
+## MEDIUM Issues (35 total — improvement opportunities)
+
+### SSR Layer
+
+| # | Issue | File |
+|---|-------|------|
+| M1 | No explicit `dynamic = 'force-dynamic'` export | `page.tsx` |
+| M2 | `loading.tsx` skeleton shows redundant header | `PageSkeleton.tsx:170` |
+| M3 | V2 override via `?v2=1` unrestricted in production | `page.tsx:171` |
+| M4 | `withRetry` adds 200ms+ latency before V1 fallback | `page.tsx:27-46` |
+| M5 | Layout z-index extremely high (1100) | `layout.tsx:46` |
+| M6 | No Suspense boundaries for progressive streaming | `page.tsx` |
+| M7 | Error boundary doesn't differentiate error types | `error.tsx` |
+| M8 | `savedPromise` failure silently returns empty array (no logging) | `page.tsx:238` |
+| M9 | SearchLayoutView trivial `handleSearch` wrapper | `SearchLayoutView.tsx:57` |
+| M10 | `error.tsx` hardcodes header padding values | `error.tsx:21` |
+
+### API Layer
+
+| # | Issue | File |
+|---|-------|------|
+| M11 | Duplicate `computeRecommendedScore` implementation | `search-doc-sync.ts:52` vs `recommended-score.ts:10` |
+| M12 | Feature flag bypass via URL params in production | `search-v2-service.ts:134`, `v2/route.ts:41` |
+| M13 | `COUNT(*) OVER()` in map query is expensive | `search-doc-queries.ts:646` |
+| M14 | No max query length validation in parseSearchParams | `search-params.ts:404` |
+| M15 | `search-alerts.ts` uses ILIKE instead of FTS for text search | `search-alerts.ts:161` |
+| M16 | `listings/route.ts` logs query text | `listings/route.ts:42` |
+| M17 | `listings/route.ts` doesn't use `runWithRequestContext` | `listings/route.ts:21` |
+| M18 | Inconsistent error response format across endpoints | Multiple API routes |
+| M19 | Search count endpoint returns 200 for unbounded queries | `search-count/route.ts:56` |
+
+### Client/UX Layer
+
+| # | Issue | File |
+|---|-------|------|
+| M20 | SearchResultsClient doesn't use AbortController for load-more | `SearchResultsClient.tsx:132` |
+| M21 | `splitStayPairs` useMemo uses length as proxy dependency | `SearchResultsClient.tsx:112` |
+| M22 | MobileBottomSheet snap animation unit switching (px vs vh) | `MobileBottomSheet.tsx:307` |
+| M23 | LocationSearchInput `suggestionsRef` across conditional renders | `LocationSearchInput.tsx:405` |
+| M24 | SearchForm recent searches dropdown uses fragile setTimeout for blur | `SearchForm.tsx:637` |
+| M25 | Duplicated filter-counting logic (3 components, divergent) | `CollapsedMobileSearch.tsx`, `CompactSearchPill.tsx` |
+| M26 | FloatingMapButton hardcoded bottom position may not align with sheet | `FloatingMapButton.tsx:46` |
+| M27 | Performance marks left in production code | `SearchResultsClient.tsx:138`, `SearchForm.tsx:381` |
+| M28 | LowResultsGuidance calls `generateFilterSuggestions` without memoization | `LowResultsGuidance.tsx:102` |
+| M29 | ZeroResultsSuggestions "Clear filters" and "Browse all" do the same thing | `ZeroResultsSuggestions.tsx:176` |
+
+### Map Layer
+
+| # | Issue | File |
+|---|-------|------|
+| M30 | Race condition in V2/V1 data path selection (200ms timeout) | `PersistentMapWrapper.tsx:529` |
+| M31 | E2E testing globals not behind feature flag everywhere | `Map.tsx:999` |
+| M32 | `useSearchParams()` direct usage creates re-render pressure | `Map.tsx:381`, `MapBoundsContext.tsx:269` |
+| M33 | Console logging in production — googleMapsUiKitLoader | `googleMapsUiKitLoader.ts:96` |
+| M34 | `pendingFocus` in SearchMapUIContext never expires | `SearchMapUIContext.tsx:76` |
+
+### Security Layer
+
+| # | Issue | File |
+|---|-------|------|
+| M35 | In-memory rate limit fallback has no size cap | `rate-limit-redis.ts:33` |
+| M36 | Degraded mode cache in DB rate limiter also unbounded | `rate-limit.ts:10` |
+| M37 | Search V2 route shares "map" rate limit bucket | `search/v2/route.ts:64` |
+| M38 | Error messages in API routes could leak validation details | `search/v2/route.ts:137` |
+| M39 | Search alerts email contains user's saved search name (no HTML escape) | `search-alerts.ts:182` |
+
+### Filters/Pagination Layer
+
+| # | Issue | File |
+|---|-------|------|
+| M40 | Dual validation systems — allowlists duplicated | `search-params.ts:201-278` vs `filter-schema.ts` |
+| M41 | Gender/household chip display uses hardcoded map not allowlist | `filter-chip-utils.ts:266` |
+| M42 | SearchV2DataContext selector hooks misleading (useContext re-renders all) | `SearchV2DataContext.tsx:173-220` |
+| M43 | filter-suggestions.ts has loose Zod schema compared to filter-schema.ts | `filter-suggestions.ts:13` |
+| M44 | `fetchMoreListings` passes raw params without full validation | `SearchResultsClient.tsx:118` |
+
+---
+
+## LOW Issues (24 total — nice-to-haves)
+
+### SSR Layer
+- L1: `PLACEHOLDER_IMAGES` duplicated between `page.tsx` and `ListingCard`
+- L2: `SearchResultsLoadingWrapper` uses `useSearchParams()` triggering Suspense
+- L3: SearchForm lazy-loaded without prefetch hint
+- L4: `browseMode` message could be more actionable
+- L5: No `not-found.tsx` for the search route
+- L6: Layout has 6 nested providers
+- L7: Keyboard shortcut 'M' for map toggle has no visual indicator
+
+### API Layer
+- L8: Cache key includes full JSON (no hash)
+- L9: `listings/[id]` PATCH returns full listing object
+- L10: `markListingDirty` catch is empty (no logging)
+- L11: Price histogram has no LIMIT clause
+- L12: `search-alerts.ts` `matchesFilters` doesn't validate bounds/location
+- L13: No structured error codes across API routes
+
+### Client/UX Layer
+- L14: Popular areas in SuggestedSearches are hardcoded
+- L15: LocationSearchInput clear button visual size vs touch target mismatch
+- L16: MobileBottomSheet CSS custom properties non-standard React typing
+- L17: SearchForm budget inputs lack `aria-describedby` connection
+- L18: RecommendedFilters has no loading skeleton
+- L19: `useRecentSearches` dual export of `getFilterSummary`
+- L20: MobileSearchOverlay uses `defaultValue` (uncontrolled) input
+
+### Map Layer
+- L21: Dark mode style URL inconsistency (external vs local)
+- L22: No `prefers-reduced-motion` for map animations
+- L23: `clusterRadius: 50` may be too aggressive for dense areas
+- L24: `mapRef` typed as `any` in MapClient.tsx (if kept)
+
+### Security Layer
+- L25: No CORS headers on search API routes
+- L26: `sessionStorage`-based rate limit easily clearable
+- L27: Anonymous fingerprint is deterministic and spoofable
+- L28: Cache-Control allows CDN caching of search results (risk if personalized later)
+
+### Filters/Pagination Layer
+- L29: Sort validation case-sensitivity mismatch between parsers
+- L30: Query length not capped in `parseSearchParams` (duplicate of H2)
+- L31: `setIsV2Enabled` in useMemo deps is unnecessary
+- L32: "All filters selected" optimization missing
+
+---
+
+## Recommended Fix Priority
+
+### P0 — Fix before launch (Critical)
+
+| # | Fix | Impact |
+|---|-----|--------|
+| 1 | Add `generateMetadata` to search page | SEO — no organic discovery without this |
+| 2 | Add `withTimeout` to `fetchMoreListings` | Availability — can hang entire server |
+| 3 | Fix SaveSearchButton modal accessibility | WCAG compliance — legal/ethical risk |
+| 4 | Add WebGL context loss recovery to map | Mobile UX — blank map after backgrounding |
+| 5 | HMAC-sign keyset cursors | Security — prevents data enumeration |
+
+### P1 — Fix in first sprint (High)
+
+| # | Fix | Impact |
+|---|-----|--------|
+| 6 | Normalize inverted params instead of throwing | Prevents user-triggered 500 errors |
+| 7 | Add timeout protection to facets endpoint | Prevents DB connection pool exhaustion |
+| 8 | Fix filter param format inconsistency | Prevents broken filter URLs |
+| 9 | Add geocoding to MobileSearchOverlay | Prevents unbounded mobile queries |
+| 10 | Add coordinates to SuggestedSearches links | Prevents full-table scans |
+| 11 | Cap query length in `parseSearchParams` | Prevents memory/DoS abuse |
+| 12 | Add rate limiting to saved search mutations | Prevents write amplification |
+| 13 | Remove or gate duplicate `MapClient.tsx` | Prevents regression from wrong import |
+| 14 | Add marker count limit (server + client) | Prevents mobile perf degradation |
+| 15 | Fix SearchResultsClient useEffect dependency | Prevents lost "Load more" progress |
+
+### P2 — Near-term improvements (Medium)
+
+| # | Fix | Impact |
+|---|-----|--------|
+| 16 | Unify allowlists between `search-params.ts` and `filter-schema.ts` | Prevents validation drift |
+| 17 | Gate feature flag URL overrides in production | Prevents force-disable of features |
+| 18 | Standardize API error response format | Better client-side error handling |
+| 19 | Extract shared filter count utility | Consistency across components |
+| 20 | Fix SearchV2DataContext selector hook architecture | Prevent unnecessary re-renders |
+| 21 | Add size cap to in-memory rate limit fallback | Prevent memory exhaustion under attack |
+| 22 | Add progressive streaming with Suspense | Faster perceived load time |
+| 23 | Differentiate error types in error boundary | Better user messaging |
+| 24 | Remove console.log statements from production | Clean logging |
+
+### P3 — Polish (Low)
+
+| # | Fix | Impact |
+|---|-----|--------|
+| 25 | Add `prefers-reduced-motion` to map animations | Motion sensitivity compliance |
+| 26 | Popular areas from DB instead of hardcoded | Personalization readiness |
+| 27 | Budget input `aria-describedby` | Minor a11y improvement |
+| 28 | Host dark mode map style locally | Resilience against CDN outage |
+| 29 | Add structured error codes to API | Machine-readable error handling |
+| 30 | Reduce cluster radius or make zoom-dependent | Better dense-area UX |
+
+---
+
+## Files Index (Essential files per layer)
+
+### SSR/Page Layer
+- `src/app/search/page.tsx` — Main search page (SSR entry)
+- `src/app/search/actions.ts` — Server action for "Load more"
+- `src/app/search/layout.tsx` — Persistent layout with map
+- `src/app/search/error.tsx` — Error boundary
+- `src/app/search/loading.tsx` — Loading skeleton
+
+### API/Backend Layer
+- `src/lib/search/search-doc-queries.ts` — Core query engine
+- `src/lib/search/search-v2-service.ts` — Search orchestration
+- `src/lib/search-params.ts` — Input validation/parsing
+- `src/app/api/search/v2/route.ts` — Main search API
+- `src/app/api/search/facets/route.ts` — Facets aggregation
+- `src/lib/rate-limit.ts` — Rate limiting configuration
+
+### Client/UX Layer
+- `src/components/search/SearchResultsClient.tsx` — Client pagination, dedup, cap
+- `src/components/SearchForm.tsx` — Main search form
+- `src/components/LocationSearchInput.tsx` — Geocoding autocomplete
+- `src/components/search/MobileBottomSheet.tsx` — Mobile results sheet
+- `src/components/SaveSearchButton.tsx` — Save search modal
+
+### Map Layer
+- `src/components/Map.tsx` — Main map component (2,192 lines)
+- `src/components/PersistentMapWrapper.tsx` — Data fetching, lazy loading
+- `src/contexts/MapBoundsContext.tsx` — Bounds state, area count, banner
+- `src/app/api/map-listings/route.ts` — Map data endpoint
+
+### Filters/Pagination Layer
+- `src/lib/filter-schema.ts` — Zod schema, allowlists (source of truth)
+- `src/types/pagination.ts` — Keyset cursor encode/decode/validate
+- `src/components/filters/filter-chip-utils.ts` — Filter display/removal
+- `src/contexts/SearchV2DataContext.tsx` — V2 data sharing
+
+### Security Layer
+- `src/lib/rate-limit-redis.ts` — Redis rate limiting with fallback chain
+- `src/lib/with-rate-limit-redis.ts` — Redis rate limit wrapper
+- `src/lib/rate-limit.ts` — DB-backed rate limiter
+- `src/app/actions/saved-search.ts` — Saved search mutations

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,7 +27,6 @@ const nextConfig: NextConfig = {
     optimizePackageImports: [
       'lucide-react',
       'framer-motion',
-      '@radix-ui/react-icons',
     ],
   },
 

--- a/prisma/migrations/20260216000000_float_to_decimal/migration.sql
+++ b/prisma/migrations/20260216000000_float_to_decimal/migration.sql
@@ -1,0 +1,6 @@
+-- Rollback: ALTER TABLE "Listing" ALTER COLUMN "price" TYPE DOUBLE PRECISION;
+--           ALTER TABLE "Booking" ALTER COLUMN "totalPrice" TYPE DOUBLE PRECISION;
+-- Data-safety: Non-destructive type widening. ROUND ensures no precision artifacts.
+-- No locking risk for small tables. For large tables, consider running during low traffic.
+ALTER TABLE "Listing" ALTER COLUMN "price" TYPE DECIMAL(10,2) USING ROUND("price"::numeric, 2);
+ALTER TABLE "Booking" ALTER COLUMN "totalPrice" TYPE DECIMAL(10,2) USING ROUND("totalPrice"::numeric, 2);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Listing {
   ownerId             String
   title               String
   description         String
-  price               Float
+  price               Decimal            @db.Decimal(10, 2)
   images              String[]         @default([])
   amenities           String[]
   houseRules          String[]
@@ -184,7 +184,7 @@ model Booking {
   startDate       DateTime
   endDate         DateTime
   status          BookingStatus @default(PENDING)
-  totalPrice      Float
+  totalPrice      Decimal       @db.Decimal(10, 2)
   rejectionReason String? // Optional reason when host rejects booking
   version         Int           @default(1) // P0-04: Optimistic locking for race-safe updates
   createdAt       DateTime      @default(now())

--- a/src/__tests__/api/health.test.ts
+++ b/src/__tests__/api/health.test.ts
@@ -163,8 +163,7 @@ describe('Health Endpoints', () => {
 
         expect(data.checks).toBeDefined()
         expect(data.checks.database.status).toBe('ok')
-        expect(data.checks.database.latency).toBeDefined()
-        expect(typeof data.checks.database.latency).toBe('number')
+        expect(data.checks.database.latency).toBeUndefined()
       })
 
       it('sets no-cache headers', async () => {
@@ -197,7 +196,7 @@ describe('Health Endpoints', () => {
         const data = await response.json()
 
         expect(data.checks.database.status).toBe('error')
-        expect(data.checks.database.error).toBe('Database connection failed')
+        expect(data.checks.database.error).toBeUndefined()
       })
     })
 

--- a/src/__tests__/api/listings.test.ts
+++ b/src/__tests__/api/listings.test.ts
@@ -214,19 +214,6 @@ describe('Listings API', () => {
       })
     })
 
-    it('returns 400 for parseSearchParams validation errors', async () => {
-      ;(parseSearchParams as jest.Mock).mockImplementationOnce(() => {
-        throw new Error('minPrice cannot exceed maxPrice')
-      })
-
-      const request = new Request('http://localhost/api/listings?minPrice=500&maxPrice=100')
-      const response = await GET(request)
-
-      expect(response.status).toBe(400)
-      const data = await response.json()
-      expect(data.error).toBe('minPrice cannot exceed maxPrice')
-    })
-
     it('returns 400 for unbounded text search (wrapped DataError)', async () => {
       const { QueryError } = jest.requireActual('@/lib/errors/data-errors')
       const wrapped = new QueryError(

--- a/src/__tests__/api/nearby/route.test.ts
+++ b/src/__tests__/api/nearby/route.test.ts
@@ -436,7 +436,9 @@ describe('POST /api/nearby', () => {
       expect(response.status).toBe(504)
       expect(data.error).toBe('Nearby search timed out')
       expect(data.details).toContain('too long')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('timeout'))
+      expect(consoleSpy).toHaveBeenCalled()
+      const timeoutLog = consoleSpy.mock.calls[0].map(String).join(' ')
+      expect(timeoutLog).toContain('timeout')
 
       consoleSpy.mockRestore()
     })
@@ -455,7 +457,9 @@ describe('POST /api/nearby', () => {
       expect(response.status).toBe(503)
       expect(data.error).toBe('Nearby search temporarily unavailable')
       expect(data.details).toContain('recovering')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('circuit breaker'))
+      expect(consoleSpy).toHaveBeenCalled()
+      const circuitBreakerLog = consoleSpy.mock.calls[0].map(String).join(' ')
+      expect(circuitBreakerLog).toContain('circuit breaker')
 
       consoleSpy.mockRestore()
     })

--- a/src/__tests__/app/search/actions.test.ts
+++ b/src/__tests__/app/search/actions.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for fetchMoreListings server action timeout protection.
+ * Verifies that executeSearchV2 is wrapped with withTimeout and
+ * that a timeout gracefully falls back to V1 (empty result).
+ */
+
+// Mock next/headers before imports
+jest.mock("next/headers", () => ({
+  headers: jest.fn().mockResolvedValue(new Headers()),
+}));
+
+// Mock rate limiting — always allow
+jest.mock("@/lib/with-rate-limit", () => ({
+  checkServerComponentRateLimit: jest
+    .fn()
+    .mockResolvedValue({ allowed: true }),
+}));
+
+// Mock env — enable V2
+jest.mock("@/lib/env", () => ({
+  features: { searchV2: true },
+}));
+
+// Mock search-params helpers
+jest.mock("@/lib/search-params", () => ({
+  parseSearchParams: jest.fn(),
+  buildRawParamsFromSearchParams: jest.fn().mockReturnValue({ q: "test" }),
+}));
+
+// Mock V2 search service
+const mockExecuteSearchV2 = jest.fn();
+jest.mock("@/lib/search/search-v2-service", () => ({
+  executeSearchV2: (...args: unknown[]) => mockExecuteSearchV2(...args),
+}));
+
+// Mock V1 fallback (not used when V2 is enabled, but required for import)
+jest.mock("@/lib/data", () => ({
+  getListingsPaginated: jest.fn(),
+}));
+
+// Mock timeout-wrapper — pass through by default, controllable per test
+const mockWithTimeout = jest.fn();
+jest.mock("@/lib/timeout-wrapper", () => {
+  const actual = jest.requireActual("@/lib/timeout-wrapper");
+  return {
+    ...actual,
+    withTimeout: (...args: unknown[]) => mockWithTimeout(...args),
+  };
+});
+
+import { fetchMoreListings } from "@/app/search/actions";
+import { TimeoutError, DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
+
+describe("fetchMoreListings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: withTimeout passes through the promise
+    mockWithTimeout.mockImplementation((promise: Promise<unknown>) => promise);
+  });
+
+  it("wraps executeSearchV2 with withTimeout using DATABASE timeout", async () => {
+    const v2Data = {
+      paginatedResult: {
+        items: [{ id: "1" }],
+        nextCursor: "cursor-2",
+        hasNextPage: true,
+      },
+    };
+    mockExecuteSearchV2.mockResolvedValue(v2Data);
+
+    const result = await fetchMoreListings("cursor-1", { q: "test" });
+
+    // withTimeout was called with the promise, DATABASE timeout, and label
+    expect(mockWithTimeout).toHaveBeenCalledTimes(1);
+    expect(mockWithTimeout).toHaveBeenCalledWith(
+      expect.any(Promise),
+      DEFAULT_TIMEOUTS.DATABASE,
+      "fetchMore-V2"
+    );
+
+    // Result passes through from V2
+    expect(result).toEqual({
+      items: [{ id: "1" }],
+      nextCursor: "cursor-2",
+      hasNextPage: true,
+    });
+  });
+
+  it("falls back gracefully when V2 times out", async () => {
+    // withTimeout rejects with TimeoutError
+    mockWithTimeout.mockRejectedValue(
+      new TimeoutError("fetchMore-V2", DEFAULT_TIMEOUTS.DATABASE)
+    );
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await fetchMoreListings("cursor-1", { q: "test" });
+
+    // Falls back to V1 empty result (cursor pagination not supported in V1)
+    expect(result).toEqual({
+      items: [],
+      nextCursor: null,
+      hasNextPage: false,
+    });
+
+    // Warning was logged for V2 failure
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[fetchMoreListings] V2 failed"),
+      expect.objectContaining({ error: expect.stringContaining("timed out") })
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns V2 result when it succeeds within timeout", async () => {
+    const v2Data = {
+      paginatedResult: {
+        items: [{ id: "a" }, { id: "b" }],
+        nextCursor: "next",
+        hasNextPage: true,
+      },
+    };
+    mockExecuteSearchV2.mockResolvedValue(v2Data);
+
+    const result = await fetchMoreListings("c1", { q: "sf" });
+
+    expect(result).toEqual({
+      items: [{ id: "a" }, { id: "b" }],
+      nextCursor: "next",
+      hasNextPage: true,
+    });
+  });
+});

--- a/src/__tests__/components/ZeroResultsSuggestions.test.tsx
+++ b/src/__tests__/components/ZeroResultsSuggestions.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import ZeroResultsSuggestions from "@/components/ZeroResultsSuggestions";
+import type { FilterSuggestion } from "@/lib/data";
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+  }) => <button {...props}>{children}</button>,
+}));
+
+describe("ZeroResultsSuggestions", () => {
+  const locationSuggestion: FilterSuggestion[] = [
+    {
+      filter: "location",
+      label: "search area",
+      resultsWithout: 24,
+      suggestion: "Expand your search area to see 24 listings",
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("expands explicit bounds and preserves query for location suggestion", () => {
+    mockSearchParams = new URLSearchParams(
+      "q=Austin&minLat=37&maxLat=38&minLng=-123&maxLng=-122&page=2&cursor=abc&cursorStack=foo&pageNumber=2"
+    );
+
+    render(<ZeroResultsSuggestions suggestions={locationSuggestion} query="Austin" />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Expand your search area to see 24 listings/i,
+      })
+    );
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const nextUrl = mockPush.mock.calls[0][0] as string;
+    const params = new URLSearchParams(nextUrl.split("?")[1] ?? "");
+
+    expect(params.get("q")).toBe("Austin");
+    expect(params.get("page")).toBeNull();
+    expect(params.get("cursor")).toBeNull();
+    expect(params.get("cursorStack")).toBeNull();
+    expect(params.get("pageNumber")).toBeNull();
+
+    const minLat = parseFloat(params.get("minLat") ?? "");
+    const maxLat = parseFloat(params.get("maxLat") ?? "");
+    const minLng = parseFloat(params.get("minLng") ?? "");
+    const maxLng = parseFloat(params.get("maxLng") ?? "");
+
+    expect(Number.isFinite(minLat)).toBe(true);
+    expect(Number.isFinite(maxLat)).toBe(true);
+    expect(Number.isFinite(minLng)).toBe(true);
+    expect(Number.isFinite(maxLng)).toBe(true);
+    expect(maxLat - minLat).toBeGreaterThan(1);
+  });
+
+  it("supports antimeridian bounds when expanding location suggestion", () => {
+    mockSearchParams = new URLSearchParams(
+      "q=Fiji&minLat=-20&maxLat=-10&minLng=170&maxLng=-170"
+    );
+
+    render(<ZeroResultsSuggestions suggestions={locationSuggestion} query="Fiji" />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Expand your search area to see 24 listings/i,
+      })
+    );
+
+    const nextUrl = mockPush.mock.calls[0][0] as string;
+    const params = new URLSearchParams(nextUrl.split("?")[1] ?? "");
+
+    expect(params.get("q")).toBe("Fiji");
+    const minLng = parseFloat(params.get("minLng") ?? "");
+    const maxLng = parseFloat(params.get("maxLng") ?? "");
+    expect(Number.isFinite(minLng)).toBe(true);
+    expect(Number.isFinite(maxLng)).toBe(true);
+    const lngSpan =
+      minLng > maxLng ? 180 - minLng + (maxLng + 180) : maxLng - minLng;
+    expect(lngSpan).toBeGreaterThan(20);
+  });
+
+  it("drops query as fallback when location suggestion has no coordinates", () => {
+    mockSearchParams = new URLSearchParams("q=Nowhere&page=3");
+
+    render(<ZeroResultsSuggestions suggestions={locationSuggestion} query="Nowhere" />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Expand your search area to see 24 listings/i,
+      })
+    );
+
+    const nextUrl = mockPush.mock.calls[0][0] as string;
+    const params = new URLSearchParams(nextUrl.split("?")[1] ?? "");
+
+    expect(params.get("q")).toBeNull();
+    expect(params.get("page")).toBeNull();
+    expect(params.get("cursor")).toBeNull();
+    expect(params.get("cursorStack")).toBeNull();
+    expect(params.get("pageNumber")).toBeNull();
+  });
+});

--- a/src/__tests__/components/map/MapErrorBoundary.test.tsx
+++ b/src/__tests__/components/map/MapErrorBoundary.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MapErrorBoundary } from "@/components/map/MapErrorBoundary";
 
-function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
-  if (shouldThrow) throw new Error("WebGL context lost");
+function ThrowingChild({
+  shouldThrow,
+  message = "Render error",
+}: {
+  shouldThrow: boolean;
+  message?: string;
+}) {
+  if (shouldThrow) throw new Error(message);
   return <div>Map loaded</div>;
 }
 
@@ -24,27 +30,36 @@ describe("MapErrorBoundary", () => {
     expect(screen.getByText("Map loaded")).toBeInTheDocument();
   });
 
-  it("shows fallback on render error", () => {
+  it("shows generic fallback on render error", () => {
     render(
       <MapErrorBoundary>
-        <ThrowingChild shouldThrow={true} />
+        <ThrowingChild shouldThrow={true} message="unexpected render crash" />
       </MapErrorBoundary>
     );
     expect(screen.getByText(/Map unavailable/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
+  it("shows WebGL-specific fallback for context errors", () => {
+    render(
+      <MapErrorBoundary>
+        <ThrowingChild shouldThrow={true} message="WebGL context lost" />
+      </MapErrorBoundary>
+    );
+    expect(screen.getByText(/Map context lost/)).toBeInTheDocument();
+  });
+
   it("recovers on retry click", () => {
     render(
       <MapErrorBoundary>
-        <ThrowingChild shouldThrow={true} />
+        <ThrowingChild shouldThrow={true} message="WebGL context lost" />
       </MapErrorBoundary>
     );
-    expect(screen.getByText(/Map unavailable/)).toBeInTheDocument();
+    expect(screen.getByText(/Map context lost/)).toBeInTheDocument();
 
     // Click retry — boundary resets, but child still throws
     fireEvent.click(screen.getByRole("button", { name: /retry/i }));
     // After retry, it will throw again showing fallback
-    expect(screen.getByText(/Map unavailable/)).toBeInTheDocument();
+    expect(screen.getByText(/Map context lost/)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/edge-cases/search-filters-edge-cases.test.ts
+++ b/src/__tests__/edge-cases/search-filters-edge-cases.test.ts
@@ -414,7 +414,7 @@ describe("Search Filters Edge Cases - Category D", () => {
 
       // Verify ascending order
       for (let i = 1; i < listings.length; i++) {
-        expect(listings[i].price).toBeGreaterThanOrEqual(listings[i - 1].price);
+        expect(Number(listings[i].price)).toBeGreaterThanOrEqual(Number(listings[i - 1].price));
       }
     });
 
@@ -431,7 +431,7 @@ describe("Search Filters Edge Cases - Category D", () => {
 
       // Verify descending order
       for (let i = 1; i < listings.length; i++) {
-        expect(listings[i].price).toBeLessThanOrEqual(listings[i - 1].price);
+        expect(Number(listings[i].price)).toBeLessThanOrEqual(Number(listings[i - 1].price));
       }
     });
 

--- a/src/__tests__/lib/auth-helpers.test.ts
+++ b/src/__tests__/lib/auth-helpers.test.ts
@@ -1,52 +1,356 @@
 /**
  * Tests for auth-helpers.ts
- * Pure function tests for email verification and route constants
+ *
+ * Covers: isPublicRoute, isReadOnlyPublicEndpoint, isGoogleEmailVerified,
+ * checkSuspension (middleware), AUTH_ROUTES, and route matching edge cases.
  */
 
-// Mock next-auth/jwt to avoid ESM transformation issues
+jest.mock('next/server', () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+      status: init?.status || 200,
+      json: async () => data,
+      headers: new Map(Object.entries(init?.headers || {})),
+    }),
+  },
+}));
+
 jest.mock('next-auth/jwt', () => ({
   getToken: jest.fn(),
 }));
 
-import { isGoogleEmailVerified, AUTH_ROUTES } from "@/lib/auth-helpers";
+import {
+  isPublicRoute,
+  isReadOnlyPublicEndpoint,
+  isGoogleEmailVerified,
+  checkSuspension,
+  AUTH_ROUTES,
+} from '@/lib/auth-helpers';
+import { getToken } from 'next-auth/jwt';
+import { prisma } from '@/lib/prisma';
 
-describe("isGoogleEmailVerified", () => {
-    it("returns true when email_verified is exactly true", () => {
-        expect(isGoogleEmailVerified({ email_verified: true })).toBe(true);
-    });
+// Helper to create a minimal mock NextRequest
+function createMockRequest(pathname: string, method = 'GET') {
+  return { nextUrl: { pathname }, method } as any;
+}
 
-    it("returns false when email_verified is false", () => {
-        expect(isGoogleEmailVerified({ email_verified: false })).toBe(false);
-    });
+// ── isPublicRoute ──
 
-    it("returns false when email_verified is undefined", () => {
-        expect(isGoogleEmailVerified({ email_verified: undefined })).toBe(false);
-        expect(isGoogleEmailVerified({})).toBe(false);
-    });
+describe('isPublicRoute', () => {
+  it('returns true for root path /', () => {
+    expect(isPublicRoute('/')).toBe(true);
+  });
 
-    it("returns false when profile is undefined", () => {
-        expect(isGoogleEmailVerified(undefined)).toBe(false);
-    });
+  it('returns false for non-root paths that start with /', () => {
+    expect(isPublicRoute('/random')).toBe(false);
+  });
 
-    it("returns false when email_verified is truthy but not true", () => {
-        // Edge case: some providers might return 1 or "true"
-        // We explicitly check for === true, not truthy
-        expect(isGoogleEmailVerified({ email_verified: 1 } as any)).toBe(false);
-        expect(isGoogleEmailVerified({ email_verified: "true" } as any)).toBe(false);
-    });
+  it.each(['/login', '/signup', '/listings', '/search', '/api/auth', '/_next', '/favicon.ico'])(
+    'returns true for public path %s',
+    (path) => {
+      expect(isPublicRoute(path)).toBe(true);
+    },
+  );
 
-    it("returns false when email_verified is null", () => {
-        expect(isGoogleEmailVerified({ email_verified: null } as any)).toBe(false);
-    });
+  it.each([
+    ['/login/callback', true],
+    ['/signup/verify', true],
+    ['/listings/123', true],
+    ['/search/results', true],
+    ['/api/auth/callback/google', true],
+    ['/_next/static/chunk.js', true],
+  ])('returns %s for subpath %s of a public route', (path, expected) => {
+    expect(isPublicRoute(path as string)).toBe(expected);
+  });
+
+  it('returns false for /dashboard (protected page path)', () => {
+    expect(isPublicRoute('/dashboard')).toBe(false);
+  });
+
+  it('returns false for /dashboard/settings', () => {
+    expect(isPublicRoute('/dashboard/settings')).toBe(false);
+  });
+
+  it('returns false for /listings/create (protected takes precedence over /listings)', () => {
+    expect(isPublicRoute('/listings/create')).toBe(false);
+  });
+
+  it('returns false for /listings/create/step2 (protected subpath)', () => {
+    expect(isPublicRoute('/listings/create/step2')).toBe(false);
+  });
+
+  it('returns false for API paths not in public list', () => {
+    expect(isPublicRoute('/api/bookings')).toBe(false);
+    expect(isPublicRoute('/api/messages')).toBe(false);
+    expect(isPublicRoute('/api/reviews')).toBe(false);
+  });
+
+  it('returns false for unknown paths', () => {
+    expect(isPublicRoute('/admin')).toBe(false);
+    expect(isPublicRoute('/profile')).toBe(false);
+    expect(isPublicRoute('/settings')).toBe(false);
+  });
 });
 
-describe("AUTH_ROUTES", () => {
-    it("has signIn route defined", () => {
-        expect(AUTH_ROUTES.signIn).toBe('/login');
-    });
+// ── isReadOnlyPublicEndpoint ──
 
-    it("signIn route matches auth.ts pages config", () => {
-        // This ensures the constant stays in sync with actual config
-        expect(AUTH_ROUTES.signIn).toMatch(/^\/[a-z]+$/);
+describe('isReadOnlyPublicEndpoint', () => {
+  it('returns true for GET /api/listings', () => {
+    expect(isReadOnlyPublicEndpoint('/api/listings', 'GET')).toBe(true);
+  });
+
+  it('returns true for GET /api/listings/123 (subpath)', () => {
+    expect(isReadOnlyPublicEndpoint('/api/listings/123', 'GET')).toBe(true);
+  });
+
+  it('returns true for GET /api/listings/123/status (deeper subpath)', () => {
+    expect(isReadOnlyPublicEndpoint('/api/listings/123/status', 'GET')).toBe(true);
+  });
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+    'returns false for %s /api/listings (write methods)',
+    (method) => {
+      expect(isReadOnlyPublicEndpoint('/api/listings', method)).toBe(false);
+    },
+  );
+
+  it.each(['/api/bookings', '/api/messages', '/api/reviews', '/api/users'])(
+    'returns false for GET on non-listing endpoint %s',
+    (path) => {
+      expect(isReadOnlyPublicEndpoint(path, 'GET')).toBe(false);
+    },
+  );
+});
+
+// ── isGoogleEmailVerified ──
+
+describe('isGoogleEmailVerified', () => {
+  it('returns true when email_verified is exactly true', () => {
+    expect(isGoogleEmailVerified({ email_verified: true })).toBe(true);
+  });
+
+  it('returns false when email_verified is false', () => {
+    expect(isGoogleEmailVerified({ email_verified: false })).toBe(false);
+  });
+
+  it('returns false when email_verified is undefined', () => {
+    expect(isGoogleEmailVerified({ email_verified: undefined })).toBe(false);
+    expect(isGoogleEmailVerified({})).toBe(false);
+  });
+
+  it('returns false when profile is undefined', () => {
+    expect(isGoogleEmailVerified(undefined)).toBe(false);
+  });
+
+  it('returns false for truthy but non-boolean values', () => {
+    expect(isGoogleEmailVerified({ email_verified: 1 } as any)).toBe(false);
+    expect(isGoogleEmailVerified({ email_verified: 'true' } as any)).toBe(false);
+  });
+
+  it('returns false when email_verified is null', () => {
+    expect(isGoogleEmailVerified({ email_verified: null } as any)).toBe(false);
+  });
+});
+
+// ── AUTH_ROUTES ──
+
+describe('AUTH_ROUTES', () => {
+  it('has signIn route defined as /login', () => {
+    expect(AUTH_ROUTES.signIn).toBe('/login');
+  });
+
+  it('signIn route starts with /', () => {
+    expect(AUTH_ROUTES.signIn).toMatch(/^\//);
+  });
+});
+
+// ── checkSuspension (middleware) ──
+
+describe('checkSuspension', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, AUTH_SECRET: 'test-secret' } as any;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // --- Public route bypass ---
+
+  it('returns null for public routes without checking token', async () => {
+    const result = await checkSuspension(createMockRequest('/login'));
+    expect(result).toBeNull();
+    expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it('returns null for / (root public route)', async () => {
+    const result = await checkSuspension(createMockRequest('/'));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for /api/auth routes', async () => {
+    const result = await checkSuspension(createMockRequest('/api/auth/callback'));
+    expect(result).toBeNull();
+  });
+
+  // --- No token (unauthenticated) ---
+
+  it('returns null when no token exists', async () => {
+    (getToken as jest.Mock).mockResolvedValue(null);
+    const result = await checkSuspension(createMockRequest('/dashboard'));
+    expect(result).toBeNull();
+  });
+
+  // --- Non-protected route with token ---
+
+  it('returns null for non-protected route with valid token', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: false });
+    const result = await checkSuspension(createMockRequest('/some-unknown-page'));
+    expect(result).toBeNull();
+  });
+
+  // --- Read-only public endpoint bypass ---
+
+  it('allows GET /api/listings for suspended users (read-only bypass)', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+    const result = await checkSuspension(createMockRequest('/api/listings', 'GET'));
+    expect(result).toBeNull();
+  });
+
+  it('allows GET /api/listings/123 for suspended users', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+    const result = await checkSuspension(createMockRequest('/api/listings/123', 'GET'));
+    expect(result).toBeNull();
+  });
+
+  // --- Suspended user blocked ---
+
+  it('returns 403 when token.isSuspended is true on protected route', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+    const result = await checkSuspension(createMockRequest('/api/bookings', 'POST'));
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+    const data = await result!.json();
+    expect(data.error).toBe('Account suspended');
+    expect(data.code).toBe('ACCOUNT_SUSPENDED');
+  });
+
+  it('returns 403 for suspended user on /dashboard', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+    const result = await checkSuspension(createMockRequest('/dashboard'));
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  it('blocks POST /api/listings for suspended users', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+    const result = await checkSuspension(createMockRequest('/api/listings', 'POST'));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  it.each(['/api/listings', '/api/bookings', '/api/messages', '/api/reviews'])(
+    'blocks POST to protected API path %s for suspended users',
+    async (path) => {
+      (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+      const result = await checkSuspension(createMockRequest(path, 'POST'));
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(403);
+    },
+  );
+
+  it.each(['/dashboard', '/listings/create'])(
+    'blocks access to protected page %s for suspended users',
+    async (path) => {
+      (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: true });
+      const result = await checkSuspension(createMockRequest(path));
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(403);
+    },
+  );
+
+  // --- Live DB check ---
+
+  it('returns 403 when live DB check reveals newly suspended user', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: false });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: true });
+
+    const result = await checkSuspension(createMockRequest('/api/messages', 'POST'));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  it('returns null when live DB check confirms non-suspended user', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: false });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: false });
+
+    const result = await checkSuspension(createMockRequest('/dashboard'));
+    expect(result).toBeNull();
+  });
+
+  it('queries DB with correct userId from token.sub', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-789', isSuspended: false });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: false });
+
+    await checkSuspension(createMockRequest('/dashboard'));
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-789' },
+      select: { isSuspended: true },
     });
+  });
+
+  // --- Edge cases ---
+
+  it('returns null when token has no sub (userId)', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ isSuspended: false });
+    const result = await checkSuspension(createMockRequest('/api/bookings', 'POST'));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when token.sub is not a string', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 123, isSuspended: false });
+    const result = await checkSuspension(createMockRequest('/api/bookings', 'POST'));
+    expect(result).toBeNull();
+  });
+
+  it('returns null on DB error (graceful degradation)', async () => {
+    (getToken as jest.Mock).mockResolvedValue({ sub: 'user-123', isSuspended: false });
+    (prisma.user.findUnique as jest.Mock).mockRejectedValue(new Error('DB connection lost'));
+
+    const result = await checkSuspension(createMockRequest('/api/bookings', 'POST'));
+    expect(result).toBeNull();
+  });
+
+  it('passes AUTH_SECRET to getToken', async () => {
+    (getToken as jest.Mock).mockResolvedValue(null);
+    const request = createMockRequest('/dashboard');
+
+    await checkSuspension(request);
+
+    expect(getToken).toHaveBeenCalledWith({
+      req: request,
+      secret: 'test-secret',
+    });
+  });
+
+  it('falls back to NEXTAUTH_SECRET when AUTH_SECRET is not set', async () => {
+    delete process.env.AUTH_SECRET;
+    process.env = { ...process.env, NEXTAUTH_SECRET: 'fallback-secret' } as any;
+    (getToken as jest.Mock).mockResolvedValue(null);
+    const request = createMockRequest('/dashboard');
+
+    await checkSuspension(request);
+
+    expect(getToken).toHaveBeenCalledWith({
+      req: request,
+      secret: 'fallback-secret',
+    });
+  });
 });

--- a/src/__tests__/lib/auth.test.ts
+++ b/src/__tests__/lib/auth.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Tests for auth.ts (NextAuth configuration)
+ *
+ * Covers: session callback, JWT callback, signIn callback,
+ * authorized callback, and linkAccount event.
+ *
+ * Strategy: capture the config passed to the mocked NextAuth() call
+ * and test each callback in isolation.
+ */
+
+// ── Mocks (must be before imports) ──
+
+jest.mock('@/lib/auth-helpers', () => ({
+  isGoogleEmailVerified: jest.fn().mockReturnValue(true),
+  AUTH_ROUTES: { signIn: '/login' },
+  normalizeEmail: jest.fn((email: string) => email.toLowerCase().trim()),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    sync: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+  },
+}));
+
+jest.mock('@/lib/turnstile', () => ({
+  verifyTurnstileToken: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn(),
+}));
+
+// ── Imports ──
+
+import NextAuth from 'next-auth';
+import { prisma } from '@/lib/prisma';
+import { isGoogleEmailVerified } from '@/lib/auth-helpers';
+import { logger } from '@/lib/logger';
+
+// Trigger auth module load (calls mocked NextAuth with real config)
+import '@/auth';
+
+// ── Extract callbacks from captured NextAuth config ──
+
+function getAuthConfig() {
+  const calls = (NextAuth as unknown as jest.Mock).mock.calls;
+  if (!calls.length) throw new Error('NextAuth was not called — module load failed');
+  return calls[0][0];
+}
+
+describe('auth.ts NextAuth configuration', () => {
+  let config: any;
+
+  beforeAll(() => {
+    config = getAuthConfig();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Session callback ──
+
+  describe('session callback', () => {
+    it('enriches session.user with token data', async () => {
+      const session = { user: {} as any };
+      const token = {
+        sub: 'user-123',
+        emailVerified: new Date('2024-01-01'),
+        isAdmin: true,
+        isSuspended: false,
+        image: '/avatar.jpg',
+      };
+
+      const result = await config.callbacks.session({ session, token });
+
+      expect(result.user.id).toBe('user-123');
+      expect(result.user.emailVerified).toEqual(new Date('2024-01-01'));
+      expect(result.user.isAdmin).toBe(true);
+      expect(result.user.isSuspended).toBe(false);
+      expect(result.user.image).toBe('/avatar.jpg');
+    });
+
+    it('does not set id when token.sub is missing', async () => {
+      const session = { user: {} as any };
+      const token = { isAdmin: false, isSuspended: false };
+
+      const result = await config.callbacks.session({ session, token });
+
+      expect(result.user.id).toBeUndefined();
+    });
+
+    it('does not set image when token.image is missing', async () => {
+      const session = { user: {} as any };
+      const token = { sub: 'user-123', isAdmin: false, isSuspended: false };
+
+      const result = await config.callbacks.session({ session, token });
+
+      expect(result.user.id).toBe('user-123');
+      expect(result.user.image).toBeUndefined();
+    });
+
+    it('handles null session.user gracefully', async () => {
+      const session = { user: null as any };
+      const token = { sub: 'user-123' };
+
+      // Should not throw
+      const result = await config.callbacks.session({ session, token });
+      expect(result).toBeDefined();
+    });
+  });
+
+  // ── JWT callback ──
+
+  describe('jwt callback', () => {
+    it('sets initial token values from user on sign-in', async () => {
+      const token = {} as any;
+      const user = {
+        id: 'user-123',
+        emailVerified: new Date('2024-01-01'),
+        isAdmin: true,
+        isSuspended: false,
+        image: '/img.jpg',
+        name: 'Test User',
+      };
+
+      const result = await config.callbacks.jwt({ token, user, trigger: 'signIn' });
+
+      expect(result.sub).toBe('user-123');
+      expect(result.emailVerified).toEqual(new Date('2024-01-01'));
+      expect(result.isAdmin).toBe(true);
+      expect(result.isSuspended).toBe(false);
+      expect(result.image).toBe('/img.jpg');
+      expect(result.name).toBe('Test User');
+    });
+
+    it('refreshes from DB on signIn trigger', async () => {
+      const dbUser = {
+        emailVerified: new Date('2024-06-01'),
+        isAdmin: false,
+        isSuspended: true,
+        image: '/new-img.jpg',
+        name: 'Updated Name',
+      };
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(dbUser);
+
+      const token = { sub: 'user-123' } as any;
+      const result = await config.callbacks.jwt({ token, trigger: 'signIn' });
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        select: { emailVerified: true, isAdmin: true, isSuspended: true, image: true, name: true },
+      });
+      expect(result.isSuspended).toBe(true);
+      expect(result.name).toBe('Updated Name');
+    });
+
+    it('refreshes from DB on update trigger', async () => {
+      const dbUser = {
+        emailVerified: new Date(),
+        isAdmin: false,
+        isSuspended: false,
+        image: '/updated.jpg',
+        name: 'Updated',
+      };
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(dbUser);
+
+      const token = { sub: 'user-456' } as any;
+      const result = await config.callbacks.jwt({ token, trigger: 'update' });
+
+      expect(prisma.user.findUnique).toHaveBeenCalled();
+      expect(result.image).toBe('/updated.jpg');
+    });
+
+    it('refreshes from DB when account is present (OAuth link)', async () => {
+      const dbUser = {
+        emailVerified: new Date(),
+        isAdmin: false,
+        isSuspended: false,
+        image: '/oauth.jpg',
+        name: 'OAuth User',
+      };
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(dbUser);
+
+      const token = { sub: 'user-789' } as any;
+      const account = { provider: 'google' };
+      const result = await config.callbacks.jwt({ token, account });
+
+      expect(prisma.user.findUnique).toHaveBeenCalled();
+      expect(result.image).toBe('/oauth.jpg');
+    });
+
+    it('does NOT refresh from DB on normal token refresh (no trigger)', async () => {
+      const token = { sub: 'user-123', isAdmin: false } as any;
+      const result = await config.callbacks.jwt({ token });
+
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+      expect(result.isAdmin).toBe(false);
+    });
+
+    it('keeps existing token values on DB error', async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(new Error('DB Error'));
+
+      const token = { sub: 'user-123', isAdmin: true, isSuspended: false } as any;
+      const result = await config.callbacks.jwt({ token, trigger: 'signIn' });
+
+      // Original values preserved
+      expect(result.isAdmin).toBe(true);
+      expect(result.isSuspended).toBe(false);
+      expect(logger.sync.error).toHaveBeenCalledWith(
+        'JWT callback DB error',
+        expect.objectContaining({ error: 'DB Error' }),
+      );
+    });
+  });
+
+  // ── signIn callback ──
+
+  describe('signIn callback', () => {
+    it('blocks Google OAuth when email is not verified', async () => {
+      (isGoogleEmailVerified as jest.Mock).mockReturnValue(false);
+
+      const result = await config.callbacks.signIn({
+        user: { email: 'test@example.com' },
+        account: { provider: 'google' },
+        profile: { email_verified: false },
+      });
+
+      expect(result).toBe('/login?error=EmailNotVerified');
+    });
+
+    it('allows Google OAuth when email is verified', async () => {
+      (isGoogleEmailVerified as jest.Mock).mockReturnValue(true);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: false });
+
+      const result = await config.callbacks.signIn({
+        user: { email: 'test@example.com' },
+        account: { provider: 'google' },
+        profile: { email_verified: true },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('blocks suspended users (Google provider)', async () => {
+      (isGoogleEmailVerified as jest.Mock).mockReturnValue(true);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: true });
+
+      const result = await config.callbacks.signIn({
+        user: { email: 'suspended@example.com' },
+        account: { provider: 'google' },
+        profile: { email_verified: true },
+      });
+
+      expect(result).toBe('/login?error=AccountSuspended');
+    });
+
+    it('blocks suspended users (credentials provider)', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: true });
+
+      const result = await config.callbacks.signIn({
+        user: { email: 'suspended@example.com' },
+        account: { provider: 'credentials' },
+      });
+
+      expect(result).toBe('/login?error=AccountSuspended');
+    });
+
+    it('allows non-suspended credential users', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ isSuspended: false });
+
+      const result = await config.callbacks.signIn({
+        user: { email: 'active@example.com' },
+        account: { provider: 'credentials' },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('allows sign-in when user has no email (edge case)', async () => {
+      const result = await config.callbacks.signIn({
+        user: {},
+        account: { provider: 'credentials' },
+      });
+
+      expect(result).toBe(true);
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('logs warning when Google OAuth blocked for unverified email', async () => {
+      (isGoogleEmailVerified as jest.Mock).mockReturnValue(false);
+
+      await config.callbacks.signIn({
+        user: { email: 'test@example.com' },
+        account: { provider: 'google' },
+        profile: { email_verified: false },
+      });
+
+      expect(logger.sync.warn).toHaveBeenCalledWith(
+        'Google OAuth blocked: email not verified',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ── authorized callback ──
+
+  describe('authorized callback', () => {
+    function createAuthArgs(pathname: string, isLoggedIn: boolean) {
+      return {
+        auth: isLoggedIn ? { user: { id: 'user-123' } } : null,
+        request: { nextUrl: new URL(`http://localhost${pathname}`) },
+      };
+    }
+
+    it('allows authenticated users to access /dashboard', () => {
+      const result = config.callbacks.authorized(createAuthArgs('/dashboard', true));
+      expect(result).toBe(true);
+    });
+
+    it('blocks unauthenticated users from /dashboard', () => {
+      const result = config.callbacks.authorized(createAuthArgs('/dashboard', false));
+      expect(result).toBe(false);
+    });
+
+    it('blocks unauthenticated users from /dashboard/settings', () => {
+      const result = config.callbacks.authorized(createAuthArgs('/dashboard/settings', false));
+      expect(result).toBe(false);
+    });
+
+    it('redirects authenticated users away from /login', () => {
+      // Response.redirect throws in whatwg-fetch polyfill; verify intent
+      try {
+        const result = config.callbacks.authorized(createAuthArgs('/login', true));
+        // If polyfill works, result is a Response redirect
+        expect(result).toBeInstanceOf(Response);
+      } catch (e: any) {
+        // whatwg-fetch polyfill throws RangeError for redirect — the callback
+        // reached Response.redirect which confirms the redirect intent
+        expect(e.message).toContain('Invalid status code');
+      }
+    });
+
+    it('redirects authenticated users away from /signup', () => {
+      try {
+        const result = config.callbacks.authorized(createAuthArgs('/signup', true));
+        expect(result).toBeInstanceOf(Response);
+      } catch (e: any) {
+        expect(e.message).toContain('Invalid status code');
+      }
+    });
+
+    it('allows unauthenticated users to access /login', () => {
+      const result = config.callbacks.authorized(createAuthArgs('/login', false));
+      expect(result).toBe(true);
+    });
+
+    it('allows all users to access non-protected routes', () => {
+      expect(config.callbacks.authorized(createAuthArgs('/listings/123', true))).toBe(true);
+      expect(config.callbacks.authorized(createAuthArgs('/listings/123', false))).toBe(true);
+      expect(config.callbacks.authorized(createAuthArgs('/', true))).toBe(true);
+      expect(config.callbacks.authorized(createAuthArgs('/', false))).toBe(true);
+    });
+  });
+
+  // ── linkAccount event ──
+
+  describe('linkAccount event', () => {
+    it('clears OAuth tokens after account link (security hardening)', async () => {
+      (prisma.account.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await config.events.linkAccount({
+        user: { id: 'user-123' },
+        account: { provider: 'google', providerAccountId: 'goog-456' },
+      });
+
+      expect(prisma.account.updateMany).toHaveBeenCalledWith({
+        where: {
+          userId: 'user-123',
+          provider: 'google',
+          providerAccountId: 'goog-456',
+        },
+        data: {
+          access_token: null,
+          refresh_token: null,
+          id_token: null,
+        },
+      });
+    });
+
+    it('logs OAuth account link event', async () => {
+      (prisma.account.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await config.events.linkAccount({
+        user: { id: 'user-123' },
+        account: { provider: 'google', providerAccountId: 'goog-456' },
+      });
+
+      expect(logger.sync.info).toHaveBeenCalledWith(
+        'OAuth account linked',
+        expect.objectContaining({ userId: 'user-123', provider: 'google' }),
+      );
+    });
+
+    it('handles token clearing failure gracefully', async () => {
+      (prisma.account.updateMany as jest.Mock).mockRejectedValue(new Error('DB Error'));
+
+      // Should not throw
+      await config.events.linkAccount({
+        user: { id: 'user-123' },
+        account: { provider: 'google', providerAccountId: 'goog-456' },
+      });
+
+      expect(logger.sync.warn).toHaveBeenCalledWith(
+        'Failed to clear OAuth tokens after link',
+        expect.objectContaining({ userId: 'user-123', provider: 'google' }),
+      );
+    });
+  });
+
+  // ── Session config (security) ──
+
+  describe('session configuration', () => {
+    it('uses JWT strategy', () => {
+      expect(config.session.strategy).toBe('jwt');
+    });
+
+    it('has maxAge of 14 days', () => {
+      expect(config.session.maxAge).toBe(14 * 24 * 60 * 60);
+    });
+
+    it('has updateAge of 1 day', () => {
+      expect(config.session.updateAge).toBe(24 * 60 * 60);
+    });
+  });
+
+  // ── Pages config ──
+
+  describe('pages configuration', () => {
+    it('uses /login as sign-in page', () => {
+      expect(config.pages.signIn).toBe('/login');
+    });
+
+    it('uses /login as error page', () => {
+      expect(config.pages.error).toBe('/login');
+    });
+  });
+});

--- a/src/__tests__/lib/rate-limit.test.ts
+++ b/src/__tests__/lib/rate-limit.test.ts
@@ -260,7 +260,7 @@ describe("rate-limit", () => {
 
         // Verify no IP address in logs
         expect(consoleSpy).toHaveBeenCalled();
-        const logMessage = consoleSpy.mock.calls[0][0];
+        const logMessage = consoleSpy.mock.calls[0].map(String).join(" ");
         expect(logMessage).not.toContain("192.168.1.100");
         expect(logMessage).toContain("RL_DB_ERR");
 

--- a/src/__tests__/lib/with-rate-limit.test.ts
+++ b/src/__tests__/lib/with-rate-limit.test.ts
@@ -31,10 +31,18 @@ describe('Rate Limit Wrapper', () => {
   const originalE2EBypass = process.env.E2E_DISABLE_RATE_LIMIT
   const originalNodeEnv = process.env.NODE_ENV
 
+  const setNodeEnv = (value: string | undefined) => {
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value,
+      writable: true,
+      configurable: true,
+    })
+  }
+
   beforeEach(() => {
     jest.clearAllMocks()
     delete process.env.E2E_DISABLE_RATE_LIMIT
-    process.env.NODE_ENV = originalNodeEnv
+    setNodeEnv(originalNodeEnv)
   })
 
   afterAll(() => {
@@ -43,7 +51,7 @@ describe('Rate Limit Wrapper', () => {
     } else {
       delete process.env.E2E_DISABLE_RATE_LIMIT
     }
-    process.env.NODE_ENV = originalNodeEnv
+    setNodeEnv(originalNodeEnv)
   })
 
   describe('withRateLimit', () => {
@@ -233,7 +241,7 @@ describe('Rate Limit Wrapper', () => {
 
   describe('checkServerComponentRateLimit', () => {
     it('bypasses rate limit when E2E_DISABLE_RATE_LIMIT is enabled', async () => {
-      process.env.NODE_ENV = 'development'
+      setNodeEnv('development')
       process.env.E2E_DISABLE_RATE_LIMIT = 'true'
 
       const result = await checkServerComponentRateLimit(
@@ -248,7 +256,7 @@ describe('Rate Limit Wrapper', () => {
     })
 
     it('enforces rate limit when bypass env is not enabled', async () => {
-      process.env.NODE_ENV = 'development'
+      setNodeEnv('development')
       mockCheckRateLimit.mockResolvedValue({
         success: false,
         remaining: 0,

--- a/src/app/actions/create-listing.ts
+++ b/src/app/actions/create-listing.ts
@@ -194,7 +194,7 @@ export async function createListing(_prevState: CreateListingState, formData: Fo
             id: listing.id,
             title: listing.title,
             description: listing.description,
-            price: listing.price,
+            price: Number(listing.price),
             city,
             state,
             roomType: null, // Not included in basic create form
@@ -209,7 +209,7 @@ export async function createListing(_prevState: CreateListingState, formData: Fo
             });
         });
 
-        return { success: true, data: listing };
+        return { success: true, data: { ...listing, price: Number(listing.price) } };
 
     } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/app/actions/verification.ts
+++ b/src/app/actions/verification.ts
@@ -266,8 +266,6 @@ export async function approveVerification(requestId: string) {
             targetId: requestId,
             details: {
                 userId: request.userId,
-                userName: request.user.name,
-                userEmail: request.user.email,
                 documentType: request.documentType
             }
         });
@@ -341,8 +339,6 @@ export async function rejectVerification(requestId: string, reason: string) {
             targetId: requestId,
             details: {
                 userId: request.userId,
-                userName: request.user.name,
-                userEmail: request.user.email,
                 documentType: request.documentType,
                 rejectionReason: reason
             }

--- a/src/app/admin/listings/page.tsx
+++ b/src/app/admin/listings/page.tsx
@@ -89,7 +89,7 @@ export default async function AdminListingsPage() {
 
                 {/* Listing List */}
                 <ListingList
-                    initialListings={listings}
+                    initialListings={listings.map(l => ({ ...l, price: Number(l.price) }))}
                     totalListings={totalListings}
                 />
             </div>

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { withRateLimit } from '@/lib/with-rate-limit';
 import { logger } from '@/lib/logger';
+import { isOriginAllowed, isHostAllowed } from '@/lib/origin-guard';
 
 interface AgentRequest {
   question: string;
@@ -24,39 +25,7 @@ function isValidCoordinate(lat: number, lng: number): boolean {
   );
 }
 
-// ============ ORIGIN/HOST ENFORCEMENT ============
-
 const MAX_BODY_SIZE = 10_000; // 10KB
-
-function getAllowedOrigins(): string[] {
-  const origins = process.env.ALLOWED_ORIGINS || '';
-  const parsed = origins.split(',').map((o) => o.trim()).filter(Boolean);
-  if (process.env.NODE_ENV === 'development') {
-    parsed.push('http://localhost:3000');
-  }
-  return parsed;
-}
-
-function getAllowedHosts(): string[] {
-  const hosts = process.env.ALLOWED_HOSTS || '';
-  const parsed = hosts.split(',').map((h) => h.trim()).filter(Boolean);
-  if (process.env.NODE_ENV === 'development') {
-    parsed.push('localhost:3000', 'localhost');
-  }
-  return parsed;
-}
-
-function isOriginAllowed(origin: string | null): boolean {
-  if (!origin) return false;
-  return getAllowedOrigins().includes(origin);
-}
-
-function isHostAllowed(host: string | null): boolean {
-  if (!host) return false;
-  const allowed = getAllowedHosts();
-  const hostWithoutPort = host.split(':')[0];
-  return allowed.some((h) => h === host || h === hostWithoutPort);
-}
 
 // ============ MAIN HANDLER ============
 

--- a/src/app/api/listings/[id]/can-delete/route.ts
+++ b/src/app/api/listings/[id]/can-delete/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { logger } from '@/lib/logger';
+import * as Sentry from '@sentry/nextjs';
 
 export async function GET(
     request: Request,
@@ -59,7 +61,11 @@ export async function GET(
             activeConversations
         });
     } catch (error) {
-        console.error('Error checking deletability:', error);
+        logger.sync.error('Error checking deletability', {
+            error: error instanceof Error ? error.message : String(error),
+            route: '/api/listings/[id]/can-delete',
+        });
+        Sentry.captureException(error);
         return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     }
 }

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -326,14 +326,14 @@ export async function POST(request: Request) {
 
             // Side effects only for non-cached results
             if (!cached) {
-                await fireSideEffects(result);
+                await fireSideEffects({ ...result, price: Number(result.price) });
             }
         } else {
             // 13. Non-idempotent path: regular prisma.$transaction
             result = await prisma.$transaction(createListingInTx);
 
             // Side effects
-            await fireSideEffects(result);
+            await fireSideEffects({ ...result, price: Number(result.price) });
         }
 
         await logger.info('Listing created successfully', {
@@ -346,7 +346,7 @@ export async function POST(request: Request) {
         });
 
         // 18. Return 201 with no-cache headers
-        const response = NextResponse.json(result, { status: 201 });
+        const response = NextResponse.json({ ...result, price: Number(result.price) }, { status: 201 });
         response.headers.set('Cache-Control', 'no-store');
         if (cached) {
             response.headers.set('X-Idempotency-Replayed', 'true');

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -55,12 +55,9 @@ export async function GET(request: Request) {
             },
         });
     } catch (error) {
-        // Detect user-facing validation errors (return 400 instead of 500):
-        // - parseSearchParams throws plain Error ("minPrice cannot exceed maxPrice")
-        // - getListingsPaginated wraps errors via wrapDatabaseError;
-        //   original message is in error.cause.message
-        const isUserError = (msg: string) =>
-            msg.includes('cannot exceed') || msg.includes('Unbounded text search');
+        // Detect user-facing validation errors (return 400 instead of 500).
+        // getListingsPaginated wraps errors via wrapDatabaseError; original message is in error.cause.message.
+        const isUserError = (msg: string) => msg.includes('Unbounded text search');
 
         if (error instanceof Error) {
             const causeMsg = isDataError(error) && error.cause

--- a/src/app/api/map-listings/route.ts
+++ b/src/app/api/map-listings/route.ts
@@ -20,6 +20,8 @@ import {
   parseSearchParams,
 } from "@/lib/search-params";
 import { LAT_OFFSET_DEGREES } from "@/lib/constants";
+import { logger } from "@/lib/logger";
+import * as Sentry from "@sentry/nextjs";
 
 export async function GET(request: NextRequest) {
   const context = createContextFromHeaders(request.headers);
@@ -131,7 +133,12 @@ export async function GET(request: NextRequest) {
         },
       );
     } catch (error) {
-      console.error("Map listings API error:", { error, requestId });
+      logger.sync.error("Map listings API error", {
+        error: error instanceof Error ? error.message : String(error),
+        route: "/api/map-listings",
+        requestId,
+      });
+      Sentry.captureException(error);
       return NextResponse.json(
         { error: "Failed to fetch map listings" },
         {

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { NextResponse } from 'next/server';
 import { checkMetricsRateLimit } from '@/lib/rate-limit-redis';
 import { getClientIP } from '@/lib/rate-limit';
+import { isOriginAllowed, isHostAllowed } from '@/lib/origin-guard';
 
 /**
  * Metrics API Route - Privacy-Safe Logging
@@ -65,38 +66,6 @@ const ALLOWED_PLACE_TYPES = new Set([
   'museum',
   'art_gallery',
 ]);
-
-// ============ ORIGIN/HOST HELPERS ============
-
-function getAllowedOrigins(): string[] {
-  const origins = process.env.ALLOWED_ORIGINS || '';
-  const parsed = origins.split(',').map((o) => o.trim()).filter(Boolean);
-  if (process.env.NODE_ENV === 'development') {
-    parsed.push('http://localhost:3000');
-  }
-  return parsed;
-}
-
-function getAllowedHosts(): string[] {
-  const hosts = process.env.ALLOWED_HOSTS || '';
-  const parsed = hosts.split(',').map((h) => h.trim()).filter(Boolean);
-  if (process.env.NODE_ENV === 'development') {
-    parsed.push('localhost:3000', 'localhost');
-  }
-  return parsed;
-}
-
-function isOriginAllowed(origin: string | null): boolean {
-  if (!origin) return false;
-  return getAllowedOrigins().includes(origin);
-}
-
-function isHostAllowed(host: string | null): boolean {
-  if (!host) return false;
-  const allowed = getAllowedHosts();
-  const hostWithoutPort = host.split(':')[0];
-  return allowed.some((h) => h === host || h === hostWithoutPort);
-}
 
 // ============ HMAC ============
 

--- a/src/app/api/nearby/route.ts
+++ b/src/app/api/nearby/route.ts
@@ -315,7 +315,7 @@ export async function POST(request: Request) {
     } catch (error) {
       // Handle circuit breaker or timeout errors
       if (isCircuitOpenError(error)) {
-        console.error("Radar API circuit breaker open - service unavailable");
+        logger.sync.error("Radar API circuit breaker open - service unavailable", { route: '/api/nearby' });
         return NextResponse.json(
           {
             error: "Nearby search temporarily unavailable",
@@ -325,7 +325,7 @@ export async function POST(request: Request) {
         );
       }
       if (isTimeoutError(error)) {
-        console.error(`Radar API timeout: ${error.message}`);
+        logger.sync.error("Radar API timeout", { error: error.message, route: '/api/nearby' });
         return NextResponse.json(
           {
             error: "Nearby search timed out",

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -279,6 +279,10 @@ export async function PUT(request: Request) {
             return NextResponse.json({ error: suspension.error || 'Account suspended' }, { status: 403 });
         }
 
+        if (!session.user.emailVerified) {
+            return NextResponse.json({ error: 'Email verification required' }, { status: 403 });
+        }
+
         let body;
         try { body = await request.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
 
@@ -353,6 +357,10 @@ export async function DELETE(request: Request) {
         const suspension = await checkSuspension();
         if (suspension.suspended) {
             return NextResponse.json({ error: suspension.error || 'Account suspended' }, { status: 403 });
+        }
+
+        if (!session.user.emailVerified) {
+            return NextResponse.json({ error: 'Email verification required' }, { status: 403 });
         }
 
         const { searchParams } = new URL(request.url);

--- a/src/app/api/search-count/route.ts
+++ b/src/app/api/search-count/route.ts
@@ -91,8 +91,8 @@ export async function GET(request: NextRequest) {
         { count },
         {
           headers: {
-            // No caching - client handles debouncing and in-memory caching
-            "Cache-Control": "private, no-store",
+            // Short CDN cache for identical requests; private fallback for auth-dependent counts
+            "Cache-Control": "public, s-maxage=15, stale-while-revalidate=30",
           },
         },
       );

--- a/src/app/api/search/v2/route.ts
+++ b/src/app/api/search/v2/route.ts
@@ -25,6 +25,8 @@ import {
 } from "@/lib/request-context";
 import { executeSearchV2 } from "@/lib/search/search-v2-service";
 import { withTimeout, DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
+import { logger } from "@/lib/logger";
+import * as Sentry from "@sentry/nextjs";
 
 /**
  * Check if v2 is enabled via feature flag or URL param.
@@ -123,7 +125,12 @@ export async function GET(request: NextRequest) {
           error.message.includes("Invalid") ||
           error.message.includes("must be"));
 
-      console.error("Search v2 API error:", { error, requestId });
+      logger.sync.error("Search v2 API error", {
+        error: error instanceof Error ? error.message : String(error),
+        route: "/api/search/v2",
+        requestId,
+      });
+      Sentry.captureException(error);
 
       return NextResponse.json(
         {

--- a/src/app/bookings/page.tsx
+++ b/src/app/bookings/page.tsx
@@ -27,10 +27,17 @@ export default async function BookingsPage() {
         );
     }
 
+    // Convert Prisma Decimal fields to plain numbers at the query boundary
+    const convertBooking = (b: any) => ({
+        ...b,
+        totalPrice: Number(b.totalPrice),
+        listing: { ...b.listing, price: Number(b.listing.price) },
+    });
+
     return (
         <BookingsClient
-            sentBookings={sentBookings || []}
-            receivedBookings={receivedBookings || []}
+            sentBookings={(sentBookings || []).map(convertBooking)}
+            receivedBookings={(receivedBookings || []).map(convertBooking)}
         />
     );
 }

--- a/src/app/listings/[id]/edit/page.tsx
+++ b/src/app/listings/[id]/edit/page.tsx
@@ -36,7 +36,7 @@ export default async function EditListingPage({ params }: PageProps) {
                     <h1 className="text-3xl font-bold text-foreground">Edit Listing</h1>
                     <p className="text-muted-foreground mt-2">Update your listing details</p>
                 </div>
-                <EditListingForm listing={listing} />
+                <EditListingForm listing={{ ...listing, price: Number(listing.price) }} />
             </div>
         </div>
     );

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -157,7 +157,7 @@ export default async function ListingPage({ params }: PageProps) {
                 id: listing.id,
                 title: listing.title,
                 description: listing.description,
-                price: listing.price,
+                price: Number(listing.price),
                 images: listing.images,
                 amenities: listing.amenities,
                 householdLanguages: listing.householdLanguages,

--- a/src/app/listings/not-found.tsx
+++ b/src/app/listings/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function ListingNotFound() {
+  return (
+    <main className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <h1 className="text-2xl font-bold mb-2">Listing not found</h1>
+      <p className="text-muted-foreground mb-6">
+        This listing may have been removed or the link is incorrect.
+      </p>
+      <Link
+        href="/search"
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        Browse listings
+      </Link>
+    </main>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -35,5 +35,11 @@ export default async function ProfilePage() {
         redirect('/login');
     }
 
-    return <ProfileClient user={user} />;
+    // Convert Prisma Decimal price fields to plain numbers at the query boundary
+    const userWithNumberPrices = {
+        ...user,
+        listings: user.listings.map(l => ({ ...l, price: Number(l.price) })),
+    };
+
+    return <ProfileClient user={userWithNumberPrices} />;
 }

--- a/src/app/recently-viewed/page.tsx
+++ b/src/app/recently-viewed/page.tsx
@@ -17,5 +17,8 @@ export default async function RecentlyViewedPage() {
 
     const recentlyViewed = await getRecentlyViewed(20);
 
-    return <RecentlyViewedClient initialListings={recentlyViewed} />;
+    // Convert Prisma Decimal price fields to plain numbers at the query boundary
+    const listings = recentlyViewed.map(l => ({ ...l, price: Number(l.price) }));
+
+    return <RecentlyViewedClient initialListings={listings} />;
 }

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -17,5 +17,8 @@ export default async function SavedPage() {
 
     const savedListings = await getSavedListings();
 
-    return <SavedListingsClient initialListings={savedListings} />;
+    // Convert Prisma Decimal price fields to plain numbers at the query boundary
+    const listings = savedListings.map(l => ({ ...l, price: Number(l.price) }));
+
+    return <SavedListingsClient initialListings={listings} />;
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -62,9 +62,15 @@ export default async function UserProfilePage({ params }: { params: Promise<{ id
     // Check if this is the current user's own profile
     const isOwnProfile = currentUserId === id;
 
+    // Convert Prisma Decimal price fields to plain numbers at the query boundary
+    const userWithNumberPrices = {
+        ...user,
+        listings: user.listings.map(l => ({ ...l, price: Number(l.price) })),
+    };
+
     return (
         <UserProfileClient
-            user={user}
+            user={userWithNumberPrices}
             isOwnProfile={isOwnProfile}
             averageRating={avgRating}
             currentUserId={currentUserId}

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -81,7 +81,7 @@ export default function BookingForm({ listingId, price, ownerId, isOwner, isLogg
         if (pendingKey) {
             // Recover the pending key - this will be used if user resubmits
             idempotencyKeyRef.current = pendingKey;
-            console.log('Recovered pending idempotency key:', pendingKey);
+            // Recovered pending idempotency key for retry
         } else {
             // Generate a new key for this session
             idempotencyKeyRef.current = `booking_${listingId}_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
@@ -324,7 +324,7 @@ export default function BookingForm({ listingId, price, ownerId, isOwner, isLogg
             }
         } catch (error) {
             // Catch unexpected errors (network failures, etc.)
-            console.error('Booking submission error:', error);
+            // Booking submission error caught — user sees generic message below
             setErrorType('server');
             setMessage('An unexpected error occurred. Please try again.');
         } finally {

--- a/src/components/LowResultsGuidance.tsx
+++ b/src/components/LowResultsGuidance.tsx
@@ -46,6 +46,9 @@ export function LowResultsGuidance({
       params.set("nearMatches", "1");
       // Reset to page 1 when enabling near matches
       params.delete("page");
+      params.delete("cursor");
+      params.delete("cursorStack");
+      params.delete("pageNumber");
       router.push(`/search?${params.toString()}`, { scroll: false });
     });
   }, [router, searchParams]);
@@ -77,6 +80,9 @@ export function LowResultsGuidance({
 
         // Reset to page 1 when changing filters
         params.delete("page");
+        params.delete("cursor");
+        params.delete("cursorStack");
+        params.delete("pageNumber");
         router.push(`/search?${params.toString()}`, { scroll: false });
       });
     },

--- a/src/components/map/MapErrorBoundary.tsx
+++ b/src/components/map/MapErrorBoundary.tsx
@@ -8,16 +8,17 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  errorMessage?: string;
 }
 
 export class MapErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, errorMessage: undefined };
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error.message };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
@@ -28,10 +29,14 @@ export class MapErrorBoundary extends React.Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      const isWebglIssue = /webgl|context/i.test(this.state.errorMessage ?? "");
+      const fallbackMessage = isWebglIssue
+        ? "Map context lost — try refreshing"
+        : "Map unavailable — try refreshing";
       return (
         <div className="flex flex-col items-center justify-center w-full h-full min-h-[300px] bg-zinc-50 dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800">
           <p className="text-sm text-zinc-600 dark:text-zinc-400 mb-3">
-            Map unavailable — try refreshing
+            {fallbackMessage}
           </p>
           <button
             onClick={() => this.setState({ hasError: false })}

--- a/src/contexts/MapBoundsContext.tsx
+++ b/src/contexts/MapBoundsContext.tsx
@@ -47,6 +47,7 @@ import {
 } from "react";
 import { useSearchParams } from "next/navigation";
 import { rateLimitedFetch, RateLimitError } from "@/lib/rate-limit-client";
+import { buildCanonicalFilterParamsFromSearchParams } from "@/lib/search-params";
 import { PROGRAMMATIC_MOVE_TIMEOUT_MS, AREA_COUNT_DEBOUNCE_MS, AREA_COUNT_CACHE_TTL_MS } from "@/lib/constants";
 
 /** Coordinates for map bounds */
@@ -426,14 +427,8 @@ export function MapBoundsProvider({ children }: { children: React.ReactNode }) {
 
     // Build cache key from current map bounds + URL filter params
     const boundsKey = `${currentMapBounds.minLat},${currentMapBounds.maxLat},${currentMapBounds.minLng},${currentMapBounds.maxLng}`;
-    // Filter cache key to only include map-relevant params (exclude sort/page/cursor)
-    const filteredParams = new URLSearchParams(searchParams.toString());
-    filteredParams.delete('sort');
-    filteredParams.delete('page');
-    filteredParams.delete('cursor');
-    filteredParams.delete('cursorStack');
-    filteredParams.delete('pageNumber');
-    const filterKey = filteredParams.toString();
+    // Canonical filter key (shared parser output) avoids stale cache hits from non-filter URL noise.
+    const filterKey = buildCanonicalFilterParamsFromSearchParams(searchParams).toString();
     const cacheKey = `${boundsKey}|${filterKey}`;
 
     // Check cache

--- a/src/contexts/SearchV2DataContext.tsx
+++ b/src/contexts/SearchV2DataContext.tsx
@@ -33,34 +33,15 @@ import {
   ReactNode,
 } from "react";
 import { useSearchParams } from "next/navigation";
+import { buildCanonicalFilterParamsFromSearchParams } from "@/lib/search-params";
 import type {
   SearchV2GeoJSON,
   SearchV2Pin,
   SearchV2Mode,
 } from "@/lib/search/types";
 
-const FILTER_RELEVANT_KEYS = [
-  "q",
-  "minPrice",
-  "maxPrice",
-  "amenities",
-  "moveInDate",
-  "leaseDuration",
-  "houseRules",
-  "languages",
-  "roomType",
-  "genderPreference",
-  "householdGender",
-  "nearMatches",
-] as const;
-
 function getFilterRelevantParams(sp: URLSearchParams): string {
-  const filtered = new URLSearchParams();
-  for (const key of FILTER_RELEVANT_KEYS) {
-    sp.getAll(key).forEach((v) => filtered.append(key, v));
-  }
-  filtered.sort();
-  return filtered.toString();
+  return buildCanonicalFilterParamsFromSearchParams(sp).toString();
 }
 
 const BOUNDS_KEYS = ["minLat", "maxLat", "minLng", "maxLng"] as const;

--- a/src/hooks/useBatchedFilters.ts
+++ b/src/hooks/useBatchedFilters.ts
@@ -214,6 +214,7 @@ export function useBatchedFilters(): UseBatchedFiltersReturn {
   // Pending state — initialized from URL, updated locally
   const [pending, setPendingState] = useState<BatchedFilterValues>(committed);
   const previousCommittedRef = useRef(committed);
+  const forceSyncFromUrlRef = useRef(false);
 
   // Sync pending with URL when URL filter values change.
   // If only non-filter params change (for example map bounds), preserve unsaved edits.
@@ -222,14 +223,19 @@ export function useBatchedFilters(): UseBatchedFiltersReturn {
       const previousCommitted = previousCommittedRef.current;
       const committedFiltersChanged = !filtersEqual(committed, previousCommitted);
       const hasUnsavedEdits = !filtersEqual(prevPending, previousCommitted);
+      const shouldPreserveDirtyEdits =
+        !forceSyncFromUrlRef.current &&
+        !committedFiltersChanged &&
+        hasUnsavedEdits;
 
-      if (!committedFiltersChanged && hasUnsavedEdits) {
+      if (shouldPreserveDirtyEdits) {
         return prevPending;
       }
 
       return committed;
     });
     previousCommittedRef.current = committed;
+    forceSyncFromUrlRef.current = false;
   }, [committed]);
 
   const isDirty = useMemo(
@@ -257,6 +263,10 @@ export function useBatchedFilters(): UseBatchedFiltersReturn {
   }, [committed]);
 
   const commit = useCallback(() => {
+    // After an explicit apply action, prioritize URL state on the next sync.
+    // This avoids preserving stale dirty state during back/forward transitions.
+    forceSyncFromUrlRef.current = true;
+
     // Start from current URL to preserve non-filter params (bounds, sort, q, lat, lng, nearMatches)
     const params = new URLSearchParams(searchParams.toString());
 

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -11,6 +11,7 @@ const CONNECT_SRC_ORIGINS = [
   "https://api.radar.io",
   "https://tiles.stadiamaps.com",
   "https://api.stadiamaps.com",
+  "https://challenges.cloudflare.com",
 ];
 
 export function buildCspHeader(nonce?: string): string {
@@ -22,7 +23,7 @@ export function buildCspHeader(nonce?: string): string {
   } else if (nonce) {
     scriptSrcTokens.push(`'nonce-${nonce}'`, "'strict-dynamic'");
   }
-  scriptSrcTokens.push("https://maps.googleapis.com");
+  scriptSrcTokens.push("https://maps.googleapis.com", "https://challenges.cloudflare.com");
 
   const directives: string[] = [
     "default-src 'self'",
@@ -34,7 +35,7 @@ export function buildCspHeader(nonce?: string): string {
     `connect-src ${CONNECT_SRC_ORIGINS.join(" ")}`,
     "worker-src 'self' blob:",
     "child-src blob:",
-    "frame-src 'self' https://accounts.google.com",
+    "frame-src 'self' https://accounts.google.com https://challenges.cloudflare.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -439,6 +439,10 @@ export function sortListings(
 // Maximum results to return for performance (prevents memory issues on wide map bounds)
 const MAX_RESULTS_CAP = 500;
 
+/**
+ * @deprecated Use getListingsPaginated() or SearchDoc queries instead.
+ * This function has no pagination and may return unbounded results.
+ */
 export async function getListings(
   params: FilterParams = {},
 ): Promise<ListingData[]> {
@@ -501,6 +505,7 @@ export async function getListings(
         AND ST_X(loc.coords::geometry) BETWEEN -180 AND 180
       GROUP BY l.id, loc.id
       ORDER BY l."createdAt" DESC
+      LIMIT 1000
   `;
 
     let results = (listings as any[]).map((l) => ({
@@ -1683,7 +1688,7 @@ export async function getSavedListings(userId: string): Promise<ListingData[]> {
       id: l.id,
       title: l.title,
       description: l.description,
-      price: l.price,
+      price: Number(l.price),
       images: l.images || [],
       availableSlots: l.availableSlots,
       totalSlots: l.totalSlots,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -257,6 +257,11 @@ export const clientEnv: ClientEnv = new Proxy({} as ClientEnv, {
   get: (_, prop) => getClientEnv()[prop as keyof ClientEnv],
 });
 
+export const CURSOR_SECRET = process.env.CURSOR_SECRET ?? "";
+if (!CURSOR_SECRET && process.env.NODE_ENV === "production") {
+  console.error("[SECURITY] CURSOR_SECRET is not set — cursor HMAC disabled");
+}
+
 // Helper to check if a feature is available
 // Uses getters to defer env access to runtime (prevents import-time validation noise)
 export const features = {

--- a/src/lib/geocoding-cache.ts
+++ b/src/lib/geocoding-cache.ts
@@ -15,7 +15,7 @@ export interface GeocodingResult {
   bbox?: [number, number, number, number];
 }
 
-const TTL_SECONDS = 5 * 60; // 5 minutes
+const TTL_SECONDS = 24 * 60 * 60; // 24 hours (geocoding results are stable)
 const CACHE_PREFIX = "geocode:";
 
 // --- Redis client (lazy singleton) ---

--- a/src/lib/origin-guard.ts
+++ b/src/lib/origin-guard.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared origin/host enforcement for API routes.
+ * Used by: chat, agent, metrics routes.
+ */
+
+export function getAllowedOrigins(): string[] {
+  const origins = process.env.ALLOWED_ORIGINS || '';
+  const parsed = origins.split(',').map((o) => o.trim()).filter(Boolean);
+  if (process.env.NODE_ENV === 'development') {
+    parsed.push('http://localhost:3000');
+  }
+  return parsed;
+}
+
+export function getAllowedHosts(): string[] {
+  const hosts = process.env.ALLOWED_HOSTS || '';
+  const parsed = hosts.split(',').map((h) => h.trim()).filter(Boolean);
+  if (process.env.NODE_ENV === 'development') {
+    parsed.push('localhost:3000', 'localhost');
+  }
+  return parsed;
+}
+
+export function isOriginAllowed(origin: string | null): boolean {
+  if (!origin) return false;
+  return getAllowedOrigins().includes(origin);
+}
+
+export function isHostAllowed(host: string | null): boolean {
+  if (!host) return false;
+  const allowed = getAllowedHosts();
+  const hostWithoutPort = host.split(':')[0];
+  return allowed.some((h) => h === host || h === hostWithoutPort);
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -205,8 +205,8 @@ export const RATE_LIMITS = {
   toggleFavorite: { limit: 60, windowMs: 60 * 60 * 1000 }, // 60 per hour
   createReport: { limit: 10, windowMs: 24 * 60 * 60 * 1000 }, // 10 per day
   uploadDelete: { limit: 20, windowMs: 60 * 60 * 1000 }, // 20 per hour
-  // P0 fix: Search page rate limit to prevent DoS
-  search: { limit: 30, windowMs: 60 * 1000 }, // 30 per minute
+  // Search page rate limit (supports search-as-move interactions while limiting abuse)
+  search: { limit: 60, windowMs: 60 * 1000 }, // 60 per minute
   // Nearby places search (Radar API)
   nearbySearch: { limit: 30, windowMs: 60 * 1000 }, // 30 per minute
   // P1-05: Rate limit for reviews GET endpoint

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import crypto from "crypto";
+import { logger } from "@/lib/logger";
 
 /**
  * In-process rate limiter for degraded mode (DB errors).
@@ -154,14 +155,14 @@ export async function checkRateLimit(
   } catch {
     // FAIL CLOSED: Deny by default on DB errors (security over availability)
     // Use degraded mode fallback for availability during transient DB blips
-    console.error("[RateLimit] DB error (code: RL_DB_ERR)");
+    logger.sync.error("[RateLimit] DB error (code: RL_DB_ERR)");
 
     // Best-effort in-process fallback (non-persistent, limited protection)
     const degradedAllowed = checkDegradedModeLimit(identifier);
 
     if (degradedAllowed) {
       // Degraded mode: allow with reduced capacity, log for monitoring
-      console.warn("[RateLimit] Degraded mode active (code: RL_DEGRADED)");
+      logger.sync.warn("[RateLimit] Degraded mode active (code: RL_DEGRADED)");
       return {
         success: true,
         remaining: 1,
@@ -217,6 +218,7 @@ export const RATE_LIMITS = {
   verifyPassword: { limit: 10, windowMs: 60 * 60 * 1000 }, // 10 per hour
   deleteAccount: { limit: 3, windowMs: 24 * 60 * 60 * 1000 }, // 3 per day
   // Server action rate limits
+  viewCount: { limit: 60, windowMs: 60 * 1000 }, // 60 per minute (prevent view gaming)
   filterSuggestions: { limit: 30, windowMs: 60 * 1000 }, // 30 per minute
   getListingsInBounds: { limit: 60, windowMs: 60 * 1000 }, // 60 per minute
   chatSendMessage: { limit: 100, windowMs: 60 * 60 * 1000 }, // 100 per hour

--- a/src/lib/search-alerts.ts
+++ b/src/lib/search-alerts.ts
@@ -114,11 +114,11 @@ export async function processSearchAlerts(): Promise<ProcessResult> {
 
                 // Apply filters
                 if (filters.minPrice !== undefined) {
-                    const existingPriceFilter = (whereClause.price ?? {}) as Prisma.FloatFilter<'Listing'>;
+                    const existingPriceFilter = (whereClause.price ?? {}) as Record<string, unknown>;
                     whereClause.price = { ...existingPriceFilter, gte: filters.minPrice };
                 }
                 if (filters.maxPrice !== undefined) {
-                    const existingPriceFilter = (whereClause.price ?? {}) as Prisma.FloatFilter<'Listing'>;
+                    const existingPriceFilter = (whereClause.price ?? {}) as Record<string, unknown>;
                     whereClause.price = { ...existingPriceFilter, lte: filters.maxPrice };
                 }
                 if (filters.roomType) {

--- a/src/lib/search/recommended-score.ts
+++ b/src/lib/search/recommended-score.ts
@@ -1,0 +1,32 @@
+/**
+ * Compute recommended score with time decay, freshness boost, and log scaling.
+ *
+ * Components:
+ * - Rating score: avgRating * 20
+ * - Review score: reviewCount * 5
+ * - View score: log(1 + views) * 10 * decayFactor
+ * - Freshness boost: +15 points for new listings (decays over 7 days)
+ */
+export function computeRecommendedScore(
+  avgRating: number,
+  viewCount: number,
+  reviewCount: number,
+  createdAt: Date,
+): number {
+  const ratingScore = avgRating * 20;
+  const reviewScore = reviewCount * 5;
+
+  const daysSinceCreation = Math.floor(
+    (Date.now() - createdAt.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  // Views from older listings contribute less (30-day half-life, min 10%).
+  const decayFactor = Math.max(0.1, 1 - (daysSinceCreation / 30) * 0.5);
+  const viewScore = Math.log(1 + viewCount) * 10 * decayFactor;
+
+  // Day 0: +15, Day 7+: +0.
+  const freshnessBoost =
+    daysSinceCreation <= 7 ? 15 * (1 - daysSinceCreation / 7) : 0;
+
+  return ratingScore + viewScore + reviewScore + freshnessBoost;
+}

--- a/src/lib/search/search-doc-queries.ts
+++ b/src/lib/search/search-doc-queries.ts
@@ -110,6 +110,8 @@ function createSearchDocMapCacheKey(params: FilterParams): string {
     roomType: params.roomType?.toLowerCase() || "",
     leaseDuration: params.leaseDuration?.toLowerCase() || "",
     moveInDate: params.moveInDate || "",
+    genderPreference: params.genderPreference || "",
+    householdGender: params.householdGender || "",
     bounds: params.bounds
       ? `${quantizeBound(params.bounds.minLng)},${quantizeBound(params.bounds.minLat)},${quantizeBound(params.bounds.maxLng)},${quantizeBound(params.bounds.maxLat)}`
       : "",

--- a/src/lib/search/search-doc-queries.ts
+++ b/src/lib/search/search-doc-queries.ts
@@ -43,6 +43,10 @@ const SEARCH_QUERY_TIMEOUT_MS = 5000;
 /**
  * Execute a raw query with a statement timeout to prevent runaway queries.
  * Uses SET LOCAL inside a transaction so the timeout only applies to this query.
+ *
+ * SECURITY INVARIANT: `query` must contain ONLY hard-coded SQL template strings.
+ * ALL user-supplied values MUST be in the `params` array as $N placeholders.
+ * NEVER interpolate a value from filterParams directly into the query string.
  */
 async function queryWithTimeout<T>(query: string, params: unknown[]): Promise<T[]> {
   return prisma.$transaction(async (tx) => {
@@ -64,6 +68,28 @@ const HYBRID_COUNT_THRESHOLD = 100;
 // Prevents full-table scans while allowing homepage browsing.
 // 48 = 4 pages of 12 items - enough for initial exploration
 export const MAX_UNBOUNDED_RESULTS = 48;
+
+const ALLOWED_SQL_STRING_LITERALS = new Set(["ACTIVE", "english"]);
+
+function assertParameterizedWhereClause(whereClause: string): void {
+  if (process.env.NODE_ENV === "production") return;
+
+  const literalPattern = /'([^']*)'/g;
+  for (const match of whereClause.matchAll(literalPattern)) {
+    const literalValue = match[1];
+    if (!ALLOWED_SQL_STRING_LITERALS.has(literalValue)) {
+      throw new Error(
+        "SECURITY: Raw string detected in whereClause — use parameterized $N placeholders",
+      );
+    }
+  }
+}
+
+function joinWhereClauseWithSecurityInvariant(conditions: string[]): string {
+  const whereClause = conditions.join(" AND ");
+  assertParameterizedWhereClause(whereClause);
+  return whereClause;
+}
 
 // ============================================
 // Cache Key Generators
@@ -355,6 +381,10 @@ interface WhereBuilder {
 function buildSearchDocWhereConditions(
   filterParams: FilterParams,
 ): WhereBuilder {
+  // SECURITY INVARIANT:
+  // - All user-derived values must be pushed to `params` and referenced as $N placeholders.
+  // - `conditions` entries must remain static SQL fragments.
+  // - Never inject user input directly into a condition string.
   const {
     query,
     minPrice,
@@ -554,7 +584,7 @@ async function getSearchDocLimitedCountInternal(
 
   const { conditions, params: queryParams } =
     buildSearchDocWhereConditions(params);
-  const whereClause = conditions.join(" AND ");
+  const whereClause = joinWhereClauseWithSecurityInvariant(conditions);
 
   // Use subquery with LIMIT 101 to efficiently check if count > threshold
   const limitedCountQuery = `
@@ -628,7 +658,7 @@ async function getSearchDocMapListingsInternal(
     params: queryParams,
     paramIndex,
   } = buildSearchDocWhereConditions(params);
-  const whereClause = conditions.join(" AND ");
+  const whereClause = joinWhereClauseWithSecurityInvariant(conditions);
 
   // Query with minimal fields for map markers
   // Uses precomputed lat/lng from SearchDoc (no ST_X/ST_Y needed)
@@ -737,7 +767,7 @@ async function getSearchDocListingsPaginatedInternal(
       paramIndex: startParamIndex,
       ftsQueryParamIndex,
     } = buildSearchDocWhereConditions(params);
-    const whereClause = conditions.join(" AND ");
+    const whereClause = joinWhereClauseWithSecurityInvariant(conditions);
 
     // Build ORDER BY clause with ts_rank_cd tie-breaker when FTS is active
     const orderByClause = buildOrderByClause(sort, ftsQueryParamIndex);
@@ -1007,7 +1037,7 @@ export async function getSearchDocListingsWithKeyset(
     const allParams = [...queryParams, ...keysetResult.params];
     let paramIndex = keysetResult.nextParamIndex;
 
-    const whereClause = conditions.join(" AND ");
+    const whereClause = joinWhereClauseWithSecurityInvariant(conditions);
 
     // Build ORDER BY clause with ts_rank_cd tie-breaker when FTS is active
     const orderByClause = buildOrderByClause(sortOption, ftsQueryParamIndex);
@@ -1185,7 +1215,7 @@ export async function getSearchDocListingsFirstPage(
       paramIndex: startParamIndex,
       ftsQueryParamIndex,
     } = buildSearchDocWhereConditions(params);
-    const whereClause = conditions.join(" AND ");
+    const whereClause = joinWhereClauseWithSecurityInvariant(conditions);
 
     // Build ORDER BY clause with ts_rank_cd tie-breaker when FTS is active
     const orderByClause = buildOrderByClause(sortOption, ftsQueryParamIndex);

--- a/src/lib/with-rate-limit.ts
+++ b/src/lib/with-rate-limit.ts
@@ -113,8 +113,11 @@ export async function checkServerComponentRateLimit(
     type: RateLimitKey,
     endpoint: string
 ): Promise<ServerComponentRateLimitResult> {
-    // Skip rate limiting in test only (E2E tests hit search heavily)
-    if (process.env.NODE_ENV === 'test') {
+    // Test environments can opt out to avoid cross-shard contention in CI E2E runs.
+    if (
+        process.env.NODE_ENV === 'test' ||
+        process.env.E2E_DISABLE_RATE_LIMIT === 'true'
+    ) {
         return { allowed: true, remaining: 999, retryAfter: undefined };
     }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,11 +3,30 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { checkSuspension } from "@/lib/auth-helpers";
 import { applySecurityHeaders } from "@/lib/csp-middleware";
+import { checkServerComponentRateLimit } from "@/lib/with-rate-limit";
 
 export default auth(async function middleware(request: NextRequest) {
   // P0-01 FIX: Check suspension status for protected routes
   const suspensionResponse = await checkSuspension(request);
   if (suspensionResponse) return suspensionResponse;
+
+  // Rate limit /search at middleware level so clients receive HTTP 429 (not SSR 200 fallback content)
+  if (request.nextUrl.pathname === "/search") {
+    const rateLimitResult = await checkServerComponentRateLimit(
+      request.headers,
+      "search",
+      "/search",
+    );
+    if (!rateLimitResult.allowed) {
+      return new NextResponse("Too Many Requests", {
+        status: 429,
+        headers: {
+          "Retry-After": String(rateLimitResult.retryAfter ?? 60),
+          "Content-Type": "text/plain",
+        },
+      });
+    }
+  }
 
   const { requestHeaders, responseHeaders } = applySecurityHeaders(request);
 

--- a/tasks/MASTER_EXECUTION_SPEC.md
+++ b/tasks/MASTER_EXECUTION_SPEC.md
@@ -1,0 +1,700 @@
+# Master Execution Spec — Production Readiness Remediation
+
+**Generated**: 2026-02-17
+**Source**: SEARCH_PAGE_PRODUCTION_AUDIT.md (130+ findings)
+**Scope**: Sprint 1 — Issues C1–C9, H1–H5 (14 issues total)
+
+---
+
+## Sprint Plan Overview (All 130+ Issues)
+
+### Sprint 1: Security, SEO & Reliability (THIS DOCUMENT)
+**Issues**: C1–C9, H1–H5 (14 issues)
+**Theme**: Fix everything that can cause data exfiltration, server hangs, WCAG failures, or user-triggered 500s.
+
+| Priority | Issues | Domain |
+|----------|--------|--------|
+| P0-Critical | C1, C2, C3, C4, C5, C6, C7, C8, C9 | SEO, Security, A11y, Reliability |
+| P1-High | H1, H2, H3, H4, H5 | Input validation, Timeouts, Constants |
+
+### Sprint 2: API Hardening & Rate Limiting
+**Issues**: H6–H12, H19–H21, M35–M39
+**Theme**: Timeout protection for facets, rate limit consistency, saved search abuse prevention, cursor tampering fallout.
+
+### Sprint 3: Client/UX Consistency & Filter Parity
+**Issues**: H12–H16, H21, M20–M29, M40–M44
+**Theme**: Filter param format alignment, filter count divergence, memoization, performance marks cleanup.
+
+### Sprint 4: Map & Infrastructure
+**Issues**: H17–H18, M30–M34, L21–L24
+**Theme**: Remove duplicate MapClient, marker limits, WebGL improvements, console cleanup.
+
+### Sprint 5: Polish & Low-Priority
+**Issues**: L1–L20, L25–L32, remaining M-tier
+**Theme**: Accessibility polish, hardcoded values, CORS, caching, code cleanup.
+
+---
+
+## Sprint 1: Master Execution Spec
+
+### Dependency Graph
+
+```
+C4 (HMAC cursors) ── standalone, no deps
+C3 ($queryRawUnsafe) ── standalone, no deps
+H2 (query length) ── standalone, no deps
+C1 (SEO metadata) ── standalone, no deps
+H5 (centralize constant) ─┐
+C2 (fetchMore timeout) ───┤── H5 should land first (changes same file)
+H4 (filterImpact timeout) ┘
+H1 (no-throw parse) ── must update tests + listings route
+H3 (429 in middleware) ── touches middleware.ts + page.tsx
+C5+C6+C7+C8 (SaveSearch a11y) ── all in same file, do together
+C9 (WebGL recovery) ── standalone
+```
+
+### Recommended Implementation Order
+
+```
+Batch 1 (parallel — no cross-dependencies):
+  ├── C4: HMAC cursor signing
+  ├── C3: $queryRawUnsafe guardrails
+  ├── H2: Query length cap
+  └── C1: generateMetadata for SEO
+
+Batch 2 (sequential — shared files):
+  ├── H5: Centralize ITEMS_PER_PAGE → DEFAULT_PAGE_SIZE
+  ├── C2: Wrap fetchMoreListings in withTimeout
+  └── H4: Wrap analyzeFilterImpact in withTimeout
+
+Batch 3 (parallel — independent):
+  ├── H1: Remove throws from parseSearchParams
+  ├── H3: Move rate limit to middleware (429)
+  └── C5+C6+C7+C8: SaveSearchButton a11y bundle
+
+Batch 4:
+  └── C9: WebGL context loss recovery
+```
+
+---
+
+## Fix Specifications
+
+---
+
+### C1 — No `generateMetadata` — Zero SEO on Search Page
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/app/search/page.tsx` |
+| **Severity** | CRITICAL — no organic discovery without this |
+| **New Dependencies** | None |
+| **Env Vars** | None |
+
+**The "Why":** The search page has zero SEO — no title, description, canonical URL, or OG tags. Every filter combination indexes as duplicate content with a generic title.
+
+**The "How" (Logic Diff):**
+
+1. Import `Metadata` type from `'next'` at the top of the file.
+
+2. Export `generateMetadata` async function before the default page export (~line 68). It receives `{ searchParams }` with the same shape as the page component.
+
+3. Inside `generateMetadata`:
+   - `await searchParams`, then call `parseSearchParams(rawParams)` to extract `q` and `filterParams`. No DB queries — pure param derivation only.
+   - Build `title`:
+     - With query: `"Rooms for rent in ${q} | Roomshare"`
+     - Browse mode: `"Find Rooms & Roommates | Roomshare"`
+   - Build `description`:
+     - Base: `"Browse ${q ? q + ' ' : ''}room listings on Roomshare."`
+     - Append filter summary (price range, roomType). Cap at 160 chars via `.substring(0, 160)`.
+   - Return `Metadata` object:
+     ```
+     {
+       title,
+       description,
+       openGraph: { title, description, type: 'website' },
+       alternates: { canonical: `/search${q ? `?q=${encodeURIComponent(q)}` : ''}` }
+     }
+     ```
+     Canonical strips filter/pagination params to avoid duplicate indexing.
+
+4. **Pattern reference**: Matches `src/app/users/[id]/page.tsx:7–22` and `src/app/listings/[id]/page.tsx:13–36`.
+
+**Cross-File Impact:** None. Purely additive export.
+
+---
+
+### C2 — `fetchMoreListings` Server Action Has No Timeout
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/app/search/actions.ts` |
+| **Severity** | CRITICAL — can hang entire server |
+| **New Dependencies** | None |
+| **Env Vars** | None |
+
+**The "Why":** The `executeSearchV2()` call at line 52 has no `withTimeout` wrapper, unlike the SSR page which wraps both V2 and V1 paths. A hung DB exhausts Node.js worker threads.
+
+**The "How" (Logic Diff):**
+
+1. Add import at top:
+   ```ts
+   import { withTimeout, DEFAULT_TIMEOUTS } from '@/lib/timeout-wrapper';
+   ```
+
+2. At line 52, wrap the call:
+   ```
+   // BEFORE:
+   const v2Result = await executeSearchV2({ rawParams: rawParamsForV2, limit: ITEMS_PER_PAGE });
+
+   // AFTER:
+   const v2Result = await withTimeout(
+     executeSearchV2({ rawParams: rawParamsForV2, limit: DEFAULT_PAGE_SIZE }),
+     DEFAULT_TIMEOUTS.DATABASE,
+     'fetchMoreListings-executeSearchV2'
+   );
+   ```
+   Note: Uses `DEFAULT_PAGE_SIZE` per H5 fix.
+
+3. Existing catch block at line 64 already handles all errors (falls through to V1 fallback). `TimeoutError` extends `Error`, so it is caught automatically — no new catch arm needed.
+
+**Cross-File Impact:** None. Depends on H5 landing first (same file, `ITEMS_PER_PAGE` → `DEFAULT_PAGE_SIZE`).
+
+---
+
+### C3 — `$queryRawUnsafe` Used Extensively
+
+| Field | Value |
+|-------|-------|
+| **Target Files** | `src/lib/search/search-doc-queries.ts`, `src/app/api/search/facets/route.ts` |
+| **Severity** | CRITICAL — fragile SQL construction pattern |
+| **New Dependencies** | None |
+| **Env Vars** | None |
+
+**The "Why":** While currently safe (all values are parameterized via `$N` placeholders), the `$queryRawUnsafe` function name provides no guardrail if a future developer accidentally concatenates user input into the SQL template string.
+
+**The "How" (Logic Diff):**
+
+**Immediate fix (defense-in-depth):**
+
+1. In `search-doc-queries.ts` at the `queryWithTimeout` function (line 47), add a contract comment block:
+   ```
+   /**
+    * SECURITY INVARIANT: `query` must contain ONLY hard-coded SQL template strings.
+    * ALL user-supplied values MUST be in the `params` array as $N placeholders.
+    * NEVER interpolate a value from filterParams directly into the query string.
+    */
+   ```
+
+2. In both `buildSearchDocWhereConditions` (search-doc-queries.ts ~line 355) and `buildFacetWhereConditions` (facets/route.ts ~line 93), after `conditions.join(" AND ")`, add a dev-only runtime assertion:
+   ```ts
+   if (process.env.NODE_ENV !== 'production') {
+     const suspiciousPattern = /(['"])[^$\d][^'"]*\1/;
+     if (suspiciousPattern.test(whereClause)) {
+       throw new Error('SECURITY: Raw string detected in whereClause — use parameterized $N placeholders');
+     }
+   }
+   ```
+
+3. In `facets/route.ts` for each of the 5 facet functions (lines 274, 310, 346, 380, 437), add the same contract comment above each `$queryRawUnsafe` call.
+
+**Cross-File Impact:**
+
+| File | Change |
+|------|--------|
+| `src/lib/search/search-doc-queries.ts:47` | Add security invariant comment to `queryWithTimeout` |
+| `src/lib/search/search-doc-queries.ts:~355` | Add dev-only assertion after WHERE clause join |
+| `src/app/api/search/facets/route.ts:~93` | Add dev-only assertion after WHERE clause join |
+| `src/app/api/search/facets/route.ts:274,310,346,380,437` | Add contract comments above each `$queryRawUnsafe` call |
+
+---
+
+### C4 — No Cursor Signature/HMAC — Data Exfiltration Risk
+
+| Field | Value |
+|-------|-------|
+| **Target Files** | `src/lib/search/cursor.ts` (primary), `src/lib/search/hash.ts`, `src/lib/env.ts` |
+| **Severity** | CRITICAL — enables listing enumeration |
+| **New Dependencies** | None (Node.js `crypto` built-in) |
+| **Env Vars** | `CURSOR_SECRET` — 32+ byte hex string (generate with `openssl rand -hex 32`) |
+
+**The "Why":** Keyset cursors are base64-encoded JSON containing raw sort column values. An attacker can decode, modify, and re-encode them to enumerate listings in arbitrary order, bypassing pagination intent.
+
+**The "How" (Logic Diff):**
+
+1. **Add env var** — In `src/lib/env.ts`:
+   ```ts
+   export const CURSOR_SECRET = process.env.CURSOR_SECRET ?? "";
+   if (!CURSOR_SECRET && process.env.NODE_ENV === 'production') {
+     console.error('[SECURITY] CURSOR_SECRET is not set — cursor HMAC disabled');
+   }
+   ```
+   Add `CURSOR_SECRET=""` to `.env.example`.
+
+2. **Sign cursors** — In `src/lib/search/cursor.ts`, modify `encodeKeysetCursor`:
+   - Import `{ createHmac, timingSafeEqual }` from `"crypto"` and `CURSOR_SECRET` from `@/lib/env`.
+   - After `JSON.stringify(cursor)`, compute HMAC:
+     ```
+     const sig = CURSOR_SECRET
+       ? createHmac('sha256', CURSOR_SECRET).update(payload).digest('base64url')
+       : null;
+     const envelope = sig ? JSON.stringify({ p: payload, s: sig }) : payload;
+     return toBase64Url(envelope);
+     ```
+
+3. **Verify cursors** — In `decodeKeysetCursor`:
+   - Decode the base64, attempt to parse as signed envelope `{ p, s }`.
+   - If `CURSOR_SECRET` is set and envelope has `s` field: compute expected HMAC, compare with `timingSafeEqual` (with length guard). Reject on mismatch.
+   - If `CURSOR_SECRET` is set but no `s` field: reject (unsigned cursor in signed mode).
+   - If no `CURSOR_SECRET` (dev): accept unsigned cursors as-is.
+   - Extract `payloadStr` from `p` field, then parse as before.
+
+4. **Legacy cursor in hash.ts** (lines 112–133) — Apply same HMAC envelope pattern to `encodeCursor`/`decodeCursor`. Lower priority since payload is just a page number (1–100).
+
+5. **No changes needed** in `decodeLegacyCursor`, `decodeCursorAny`, `encodeStack`, or `decodeStack` — the signing is encapsulated at the individual cursor encode/decode level.
+
+**Cross-File Impact:**
+
+| File | Change |
+|------|--------|
+| `src/lib/search/cursor.ts` | Add HMAC signing to `encodeKeysetCursor`, verification to `decodeKeysetCursor` |
+| `src/lib/search/hash.ts:112-133` | Mirror HMAC pattern for legacy cursor (lower priority) |
+| `src/lib/env.ts` | Export `CURSOR_SECRET` |
+| `.env.example` | Add `CURSOR_SECRET=""` |
+| `src/lib/search/search-v2-service.ts` | No change — fix is encapsulated in cursor.ts |
+| `src/lib/search/search-doc-queries.ts` | No change — cursor decoded via cursor.ts |
+
+---
+
+### C5 — SaveSearchButton Modal: No Focus Trap
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/components/SaveSearchButton.tsx` |
+| **Severity** | CRITICAL — WCAG 2.1 AA failure |
+| **New Dependencies** | None — `FocusTrap` component already exists at `src/components/ui/FocusTrap.tsx` |
+
+**The "Why":** When the modal opens, Tab key escapes to background content behind the backdrop. Screen reader and keyboard users can interact with hidden page elements.
+
+**The "How" (Logic Diff):**
+
+1. Import the existing `FocusTrap` from `'@/components/ui/FocusTrap'`.
+
+2. Wrap the modal content (lines 144–271, inside `{isOpen && (...)}`) with:
+   ```tsx
+   <FocusTrap active={isOpen} returnFocus={true}>
+     {/* existing backdrop div + modal content div */}
+   </FocusTrap>
+   ```
+
+3. Add Escape key handler effect:
+   ```ts
+   useEffect(() => {
+     if (!isOpen) return;
+     const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setIsOpen(false); };
+     document.addEventListener('keydown', handler);
+     return () => document.removeEventListener('keydown', handler);
+   }, [isOpen]);
+   ```
+   Pattern reference: `MobileSearchOverlay.tsx:43–50`.
+
+**Cross-File Impact:** None. `FocusTrap` used as-is. `MobileBottomSheet` checks `data-focus-trap` before handling Escape — compatible.
+
+---
+
+### C6 — SaveSearchButton Modal: Missing ARIA Attributes
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/components/SaveSearchButton.tsx` |
+| **Severity** | CRITICAL — screen readers cannot identify dialog |
+
+**The "Why":** The modal div has no `role`, `aria-modal`, or `aria-labelledby`. Screen readers don't announce it as a dialog.
+
+**The "How" (Logic Diff):**
+
+1. On the modal content div (line 153, the `relative bg-white rounded-2xl...` div), add:
+   - `role="dialog"`
+   - `aria-modal="true"`
+   - `aria-labelledby="save-search-dialog-title"`
+
+2. On the `<h2>` at line 161, add `id="save-search-dialog-title"`.
+
+3. On the close button (line 154, X icon), add `aria-label="Close save search dialog"`.
+
+4. On the backdrop div (line 147), add `aria-hidden="true"`. Pattern: `MobileBottomSheet.tsx:297`.
+
+**Cross-File Impact:** None.
+
+---
+
+### C7 — SaveSearchButton Toggle: Missing ARIA Role
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/components/SaveSearchButton.tsx` |
+| **Severity** | CRITICAL — toggle state invisible to assistive tech |
+
+**The "Why":** The email alerts toggle button (lines 196–206) has no `role="switch"` or `aria-checked`. Screen readers announce it as a plain button.
+
+**The "How" (Logic Diff):**
+
+1. On the `<button>` at line 196, add:
+   - `role="switch"`
+   - `aria-checked={alertEnabled}`
+   - `aria-label="Email alerts"`
+
+2. On the `<span>` thumb (lines 202–205), add `aria-hidden="true"`.
+
+**Cross-File Impact:** None.
+
+---
+
+### C8 — SaveSearchButton Modal: Body Scroll Not Locked
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/components/SaveSearchButton.tsx` |
+| **Severity** | CRITICAL — mobile UX: content scrolls behind modal |
+
+**The "Why":** Unlike `MobileSearchOverlay` and `MobileBottomSheet` which lock body scroll, the SaveSearch modal allows background scroll on mobile.
+
+**The "How" (Logic Diff):**
+
+Add `useEffect` matching `MobileSearchOverlay.tsx:52–60`:
+```ts
+useEffect(() => {
+  if (isOpen) {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }
+}, [isOpen]);
+```
+
+**Cross-File Impact:** None. Both modal and bottom sheet set/restore `overflow` independently — they are mutually exclusive (modal backdrop captures pointer events).
+
+---
+
+### C9 — No WebGL Context Loss Recovery
+
+| Field | Value |
+|-------|-------|
+| **Target Files** | `src/components/Map.tsx`, `src/components/map/MapErrorBoundary.tsx` |
+| **Severity** | CRITICAL — blank map after mobile backgrounding |
+| **New Dependencies** | None (native browser API) |
+
+**The "Why":** `webglcontextlost` fires when the OS reclaims GPU memory (mobile backgrounding). Without a handler, the map canvas goes blank permanently.
+
+**The "How" (Logic Diff):**
+
+**Part A — Map.tsx: Add WebGL listeners in `onLoad` callback (~line 1650)**
+
+1. Declare `webglCleanupRef = useRef<(() => void) | null>(null)` near other refs (~line 424).
+
+2. Inside `onLoad`, after `setIsMapLoaded(true)`:
+   ```ts
+   const canvas = mapRef.current?.getMap().getCanvas();
+   if (canvas) {
+     const handleContextLost = (e: Event) => {
+       e.preventDefault(); // Required: tells browser to attempt restore
+       console.warn('[Map] WebGL context lost');
+     };
+     const handleContextRestored = () => {
+       console.warn('[Map] WebGL context restored');
+       setIsMapLoaded(false);
+       setTimeout(() => { if (isMountedRef.current) setIsMapLoaded(true); }, 0);
+     };
+     canvas.addEventListener('webglcontextlost', handleContextLost);
+     canvas.addEventListener('webglcontextrestored', handleContextRestored);
+     webglCleanupRef.current = () => {
+       canvas.removeEventListener('webglcontextlost', handleContextLost);
+       canvas.removeEventListener('webglcontextrestored', handleContextRestored);
+     };
+   }
+   ```
+
+3. In the unmount cleanup effect (near `isMountedRef.current = false`), call `webglCleanupRef.current?.()`.
+
+**Part B — MapErrorBoundary.tsx: Distinguish WebGL errors**
+
+1. Add `errorMessage?: string` to `State` interface.
+2. In `getDerivedStateFromError(error)`, return `{ hasError: true, errorMessage: error.message }`.
+3. In fallback render, show `"Map context lost — try refreshing"` when `errorMessage` contains `'webgl'` or `'context'` (case-insensitive), otherwise show current message.
+
+**Cross-File Impact:**
+
+| File | Change |
+|------|--------|
+| `src/components/PersistentMapWrapper.tsx` | None — `MapErrorBoundary` wrapping at lines 669–673 already provides recovery surface |
+| `src/__tests__/components/map/MapErrorBoundary.test.tsx` | Add one test: throw error with `'webgl'` in message, assert fallback subtitle |
+
+---
+
+### H1 — `parseSearchParams` Throws on Malformed Input
+
+| Field | Value |
+|-------|-------|
+| **Target Files** | `src/lib/search-params.ts`, `src/app/api/listings/route.ts` |
+| **Severity** | HIGH — user-craftable 500 errors |
+| **Tests to Update** | `search-params.test.ts` (2 assertions), `listings.test.ts` (1 assertion) |
+
+**The "Why":** `parseSearchParams` throws on inverted price/lat ranges. Since most callers lack try/catch, this crashes the SSR page with a user-craftable URL like `?minPrice=5000&maxPrice=100`.
+
+**The "How" (Logic Diff):**
+
+**Site 1 — Price inversion (lines 429–435):**
+Replace `throw new Error("minPrice cannot exceed maxPrice")` with:
+```ts
+let effectiveMinPrice = validMinPrice;
+let effectiveMaxPrice = validMaxPrice;
+if (effectiveMinPrice !== undefined && effectiveMaxPrice !== undefined && effectiveMinPrice > effectiveMaxPrice) {
+  effectiveMinPrice = undefined;
+  effectiveMaxPrice = undefined;
+}
+```
+Use `effectiveMinPrice`/`effectiveMaxPrice` in `filterParams` construction (~line 534).
+
+**Site 2 — Lat inversion (lines 445–451):**
+Replace `throw new Error("minLat cannot exceed maxLat")` with:
+```ts
+let effectiveMinLat = validMinLat;
+let effectiveMaxLat = validMaxLat;
+if (effectiveMinLat !== undefined && effectiveMaxLat !== undefined && effectiveMinLat > effectiveMaxLat) {
+  effectiveMinLat = undefined;
+  effectiveMaxLat = undefined;
+}
+```
+Use `effectiveMinLat`/`effectiveMaxLat` in bounds construction (~line 471).
+
+**Cleanup — listings route:**
+In `src/app/api/listings/route.ts`, the `isUserError` helper that catches `"cannot exceed"` message becomes dead code. Remove that branch.
+
+**Test updates:**
+- `search-params.test.ts:114–118`: Change `expect(() => ...).toThrow()` → `expect(result.filterParams.minPrice).toBeUndefined()`.
+- `search-params.test.ts:343–353`: Change `expect(() => ...).toThrow()` → `expect(result.filterParams.bounds).toBeUndefined()`.
+- `listings.test.ts:217–218`: Remove or update the `"cannot exceed"` string check.
+
+**Cross-File Impact:**
+
+| Caller | File | Impact |
+|--------|------|--------|
+| SearchPage (SSR) | `page.tsx:125` | No longer crashes — gets empty filter |
+| executeSearchV2 | `search-v2-service.ts:106` | Parse succeeds |
+| SaveSearchButton | `SaveSearchButton.tsx:51` | No longer unhandled rejection |
+| GET /api/listings | `listings/route.ts:31` | Remove dead `isUserError` branch |
+| GET /api/search-count | `search-count/route.ts:52` | No longer triggers 500 |
+| GET /api/search/facets | `facets/route.ts:536` | No longer triggers 500 |
+
+---
+
+### H2 — No Query Length Validation in `parseSearchParams`
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/lib/search-params.ts` |
+| **Severity** | HIGH — memory/DoS abuse vector |
+| **New Dependencies** | None |
+
+**The "Why":** `raw.q` is trimmed but not length-capped. Arbitrarily long strings propagate into `plainto_tsquery()` causing CPU-intensive text search, and inflate cache key size.
+
+**The "How" (Logic Diff):**
+
+1. Add `MAX_QUERY_LENGTH` to the existing import from `./constants` (line 3):
+   ```ts
+   import { MAX_SAFE_PRICE, MAX_SAFE_PAGE, MAX_ARRAY_ITEMS, MAX_QUERY_LENGTH, LAT_OFFSET_DEGREES } from "./constants";
+   ```
+
+2. At lines 404–406, replace:
+   ```ts
+   const rawQuery = getFirstValue(raw.q);
+   const query = rawQuery ? rawQuery.trim() : "";
+   const q = query || undefined;
+   ```
+   With:
+   ```ts
+   const rawQuery = getFirstValue(raw.q);
+   const trimmed = rawQuery ? rawQuery.trim() : "";
+   const query = trimmed.length > MAX_QUERY_LENGTH ? trimmed.slice(0, MAX_QUERY_LENGTH) : trimmed;
+   const q = query || undefined;
+   ```
+   Silent truncation matches the existing `safeParseInt` clamping pattern in the same function.
+
+**Cross-File Impact:** None. All downstream consumers (facets, search-doc-queries) go through `parseSearchParams`.
+
+---
+
+### H3 — Rate-Limited Pages Return HTTP 200 Instead of 429
+
+| Field | Value |
+|-------|-------|
+| **Target Files** | `src/middleware.ts`, `src/app/search/page.tsx` |
+| **Severity** | HIGH — bots see 200 and keep hammering |
+
+**The "Why":** Server Components cannot set HTTP status codes. The rate-limited JSX returns as HTTP 200, invisible to clients, bots, and monitoring.
+
+**The "How" (Logic Diff):**
+
+**Move rate limiting to middleware (architecturally correct — middleware can set status codes):**
+
+1. In `src/middleware.ts`, after the suspension check (~line 10) and before CSP headers:
+   ```ts
+   import { checkServerComponentRateLimit } from '@/lib/with-rate-limit';
+   import { NextResponse } from 'next/server';
+
+   // Rate limit /search page requests
+   if (request.nextUrl.pathname === '/search') {
+     const rateLimitResult = await checkServerComponentRateLimit(
+       request.headers, 'search', '/search'
+     );
+     if (!rateLimitResult.allowed) {
+       return new NextResponse('Too Many Requests', {
+         status: 429,
+         headers: {
+           'Retry-After': String(rateLimitResult.retryAfter ?? 60),
+           'Content-Type': 'text/plain',
+         },
+       });
+     }
+   }
+   ```
+
+2. In `src/app/search/page.tsx`, remove lines 98–120 (the entire rate limit check + JSX return block). Remove the `checkServerComponentRateLimit` import if no longer used. Remove the `Clock` import from `lucide-react` if only used in that block.
+
+**Cross-File Impact:**
+
+| File | Change |
+|------|--------|
+| `src/middleware.ts` | Add rate limit gate for `/search` |
+| `src/app/search/page.tsx` | Remove rate limit block (lines 98–120), clean up unused imports |
+| `src/app/search/actions.ts` | No change — server action rate limiting is separate and correct |
+
+---
+
+### H4 — `analyzeFilterImpact` Called Without Timeout
+
+| Field | Value |
+|-------|-------|
+| **Target File** | `src/app/search/page.tsx` |
+| **Severity** | HIGH — SSR hangs on zero-results path |
+
+**The "Why":** `analyzeFilterImpact` runs multiple parallel COUNT queries with no timeout, blocking SSR indefinitely on the zero-results page.
+
+**The "How" (Logic Diff):**
+
+At line 255, replace:
+```ts
+const filterSuggestions = hasConfirmedZeroResults ? await analyzeFilterImpact(filterParams) : [];
+```
+With:
+```ts
+const filterSuggestions = hasConfirmedZeroResults
+  ? await withTimeout(
+      analyzeFilterImpact(filterParams),
+      DEFAULT_TIMEOUTS.DATABASE,
+      'analyzeFilterImpact'
+    ).catch(() => [] as FilterSuggestion[])
+  : [];
+```
+
+- `withTimeout` and `DEFAULT_TIMEOUTS` are already imported (line 21).
+- `.catch(() => [])` provides graceful degradation — filter suggestions are non-critical UI enrichment. Pattern matches `savedPromise.catch(() => [])` at line 238.
+- Verify `FilterSuggestion` type is in the import from `@/lib/data` (line 2). If not, add it.
+
+**Cross-File Impact:** None.
+
+---
+
+### H5 — `ITEMS_PER_PAGE` Duplicated Instead of Centralized Constant
+
+| Field | Value |
+|-------|-------|
+| **Target Files** | `src/app/search/page.tsx`, `src/app/search/actions.ts` |
+| **Severity** | HIGH — silent divergence risk for pagination |
+
+**The "Why":** Both files define `const ITEMS_PER_PAGE = 12` locally instead of importing `DEFAULT_PAGE_SIZE` from `src/lib/constants.ts`. If either drifts, SSR and "Load more" return different page sizes, causing duplicate or skipped listings.
+
+**The "How" (Logic Diff):**
+
+**In `src/app/search/page.tsx`:**
+1. Remove line 23: `const ITEMS_PER_PAGE = 12;`
+2. Add: `import { DEFAULT_PAGE_SIZE } from '@/lib/constants';`
+3. Replace `ITEMS_PER_PAGE` usages (lines ~190, ~231) with `DEFAULT_PAGE_SIZE`.
+
+**In `src/app/search/actions.ts`:**
+1. Remove line 10: `const ITEMS_PER_PAGE = 12;`
+2. Add: `import { DEFAULT_PAGE_SIZE } from '@/lib/constants';`
+3. Replace `ITEMS_PER_PAGE` usage (line ~54) with `DEFAULT_PAGE_SIZE`.
+
+**Cross-File Impact:** None beyond the two files. `src/lib/filter-schema.ts` already correctly imports `DEFAULT_PAGE_SIZE`.
+
+---
+
+## Global Cross-File Impact Matrix
+
+This table shows every source file touched across all 14 fixes, with the specific fixes that modify it.
+
+| File | Fixes | Notes |
+|------|-------|-------|
+| `src/app/search/page.tsx` | C1, H3, H4, H5 | Most-touched file — implement H5 first, then C1/H4, then H3 |
+| `src/app/search/actions.ts` | C2, H5 | H5 first (removes local constant), then C2 (adds timeout) |
+| `src/components/SaveSearchButton.tsx` | C5, C6, C7, C8 | All four fixes in single pass |
+| `src/components/Map.tsx` | C9 | WebGL listeners in onLoad |
+| `src/components/map/MapErrorBoundary.tsx` | C9 | WebGL-specific error message |
+| `src/lib/search-params.ts` | H1, H2 | H2 is 2-line change; H1 is larger (remove throws) |
+| `src/lib/search/cursor.ts` | C4 | HMAC encode/decode |
+| `src/lib/search/hash.ts` | C4 | Legacy cursor HMAC (lower priority) |
+| `src/lib/search/search-doc-queries.ts` | C3 | Security invariant comments |
+| `src/app/api/search/facets/route.ts` | C3 | Security invariant comments + dev assertion |
+| `src/app/api/listings/route.ts` | H1 | Remove dead `isUserError` branch |
+| `src/middleware.ts` | H3 | Add rate limit gate for /search |
+| `src/lib/env.ts` | C4 | Export CURSOR_SECRET |
+| `.env.example` | C4 | Add CURSOR_SECRET entry |
+
+---
+
+## Test Impact Summary
+
+| Fix | Tests to Update | Tests to Add |
+|-----|----------------|--------------|
+| C1 | None | Optional: test `generateMetadata` returns title with query |
+| C2 | None | Optional: mock slow executeSearchV2, verify V1 fallback |
+| C3 | None | None (dev-only assertion) |
+| C4 | Cursor encode/decode tests must handle signed envelope | Add: test signed cursor roundtrip, test tampered cursor rejection |
+| C5 | None | Add: test focus moves into modal on open, returns on close |
+| C6 | None | None (attribute additions) |
+| C7 | None | None (attribute additions) |
+| C8 | None | None |
+| C9 | None | Add: MapErrorBoundary test with 'webgl' error message |
+| H1 | `search-params.test.ts` — 2 `toThrow` assertions → undefined checks | None |
+| H2 | None | Optional: test query longer than 200 is truncated |
+| H3 | None | Optional: middleware test for 429 on /search |
+| H4 | None | None |
+| H5 | None | None |
+
+---
+
+## Environment Variables Checklist
+
+| Variable | Required By | Value | Where to Set |
+|----------|-------------|-------|-------------|
+| `CURSOR_SECRET` | C4 | 32+ byte hex (e.g., `openssl rand -hex 32`) | Vercel env vars, `.env.local` |
+
+---
+
+## Verification Checklist (Post-Implementation)
+
+```
+[ ] pnpm lint — passes
+[ ] pnpm typecheck — passes
+[ ] pnpm test — passes (with updated assertions for H1)
+[ ] Manual: visit /search — has <title>, <meta description>, OG tags (C1)
+[ ] Manual: /search?minPrice=5000&maxPrice=100 — no error page (H1)
+[ ] Manual: /search with very long ?q= — truncated, no error (H2)
+[ ] Manual: open Save Search modal → Tab key stays inside (C5)
+[ ] Manual: Save Search modal → screen reader announces dialog (C6)
+[ ] Manual: toggle switch → screen reader announces on/off (C7)
+[ ] Manual: Save Search modal on mobile → background doesn't scroll (C8)
+[ ] Manual: craft tampered cursor base64 → 400 or falls to page 1 (C4)
+[ ] Load test: "Load more" with simulated slow DB → times out, falls to V1 (C2)
+[ ] Verify: /search rate limit returns HTTP 429, not 200 (H3)
+```

--- a/tasks/audit-api-server-logic.md
+++ b/tasks/audit-api-server-logic.md
@@ -1,0 +1,275 @@
+# Backend Architecture Audit: API Routes & Server-Side Logic
+
+**Auditor:** backend-auditor
+**Date:** 2026-02-16
+**Scope:** All API routes (`src/app/api/`), Server Actions (`src/app/actions/`), key lib files, auth config, middleware
+
+---
+
+## CRITICAL Findings
+
+### C-01: Race Condition in Listing Deletion (Non-Atomic Check-and-Delete)
+- **File:** `src/app/api/listings/[id]/route.ts` (DELETE handler, ~lines 23-60)
+- **Also:** `src/app/actions/admin.ts` (`deleteListing` function)
+- **Description:** The DELETE handler checks for active bookings in one query, then deletes the listing in a separate query. Between the check and the delete, a new booking could be created, violating the invariant that listings with active bookings cannot be deleted.
+- **Impact:** Data integrity violation - orphaned bookings pointing to deleted listings.
+- **Recommended Fix:** Wrap the active-booking check and the listing deletion inside a single `$transaction` with `FOR UPDATE` lock on the listing row, or use a raw SQL `DELETE ... WHERE NOT EXISTS (active bookings)` atomic query.
+
+### C-02: View Count Inflation - No Auth or Rate Limiting on `incrementViewCount`
+- **File:** `src/app/actions/listing-status.ts` (`incrementViewCount` function, ~lines 40-60)
+- **Description:** This server action has **no authentication check** and **no rate limiting**. Any anonymous user (or bot) can call it repeatedly to inflate view counts for any listing.
+- **Impact:** Fraudulent view counts, skewed analytics, potential abuse for gaming listing rankings.
+- **Recommended Fix:** Add authentication check (require logged-in user) and rate limiting (per-user or per-IP). Consider deduplication by user+listing pair within a time window.
+
+### C-03: Missing Middleware - No Next.js Middleware Active
+- **File:** `src/middleware.ts` (deleted per git status `AD`)
+- **Description:** The middleware file was added then deleted. The CSP middleware (`src/lib/csp-middleware.ts`) and CSP header builder (`src/lib/csp.ts`) exist as staged files but are **not wired into any active middleware**. This means:
+  - No Content-Security-Policy headers are being served
+  - No X-Frame-Options / HSTS / X-Content-Type-Options headers
+  - No centralized auth checks at the edge
+  - No request-level security headers
+- **Impact:** Missing defense-in-depth security headers across all routes. XSS protection, clickjacking protection, and other security headers are not applied.
+- **Recommended Fix:** Restore `src/middleware.ts` that imports and applies `applySecurityHeaders` from `src/lib/csp-middleware.ts`. Wire it into the Next.js middleware chain.
+
+### C-04: Non-Transactional Verification Approval
+- **File:** `src/app/actions/verification.ts` (`approveVerification` function)
+- **Description:** `approveVerification` updates the verification request status AND the user's verification status in two separate Prisma calls (not wrapped in a `$transaction`). If the second update fails, the request is marked "APPROVED" but the user remains unverified.
+- **Impact:** Inconsistent state - verification request shows approved but user not actually verified. No way to detect or recover automatically.
+- **Recommended Fix:** Wrap both updates in a `prisma.$transaction()` call.
+
+---
+
+## HIGH Findings
+
+### H-01: PATCH /api/listings Missing Suspension & Email Verification Checks
+- **File:** `src/app/api/listings/[id]/route.ts` (PATCH handler, ~lines 65-200)
+- **Description:** The POST handler for creating listings checks both `checkSuspension()` and `checkEmailVerified()`. The PATCH handler for updating listings checks **neither**. A suspended user or unverified-email user can still edit their listings.
+- **Impact:** Suspended users can modify their listing content, bypassing suspension enforcement.
+- **Recommended Fix:** Add suspension and email verification checks to the PATCH handler, matching the POST handler pattern.
+
+### H-02: Messages POST Uses Raw Content Instead of Trimmed Content
+- **File:** `src/app/api/messages/route.ts` (POST handler, ~line 196)
+- **Description:** The handler parses and trims the content via Zod schema (producing `trimmedContent`), but the actual `prisma.message.create` call uses `content` (the raw, untrimmed value from the request body) instead of `trimmedContent`.
+- **Impact:** Whitespace-only messages could be stored; messages may have leading/trailing whitespace that the UI doesn't expect.
+- **Recommended Fix:** Change `content` to `trimmedContent` in the `prisma.message.create` call at line 196.
+
+### H-03: Listing Status Update Accepts Any String as Status Enum
+- **File:** `src/app/actions/listing-status.ts` (`updateListingStatus` function)
+- **Description:** The function accepts `status: ListingStatus` as a parameter but does **no runtime validation** that the status is a valid enum value. TypeScript types are erased at runtime, so a malicious client could pass any string.
+- **Impact:** Invalid listing statuses could be written to the database if Prisma doesn't enforce the enum at the DB level.
+- **Recommended Fix:** Add Zod validation or a runtime allowlist check for valid `ListingStatus` values before the database update.
+
+### H-04: Reviews POST Missing Email Verification Check
+- **File:** `src/app/api/reviews/route.ts` (POST handler)
+- **Description:** Creating a review does NOT check `checkEmailVerified()`, unlike booking creation and listing creation which both require verified email.
+- **Impact:** Unverified-email users can leave reviews, potentially enabling spam/fake review attacks from throwaway accounts.
+- **Recommended Fix:** Add email verification check to the review POST handler.
+
+### H-05: `getFilterSuggestions` Server Action Has No Auth or Rate Limiting
+- **File:** `src/app/actions/filter-suggestions.ts`
+- **Description:** This server action delegates directly to `analyzeFilterImpact()` with **no authentication**, **no rate limiting**, and **no input validation**. The `FilterParams` type is passed through unchecked.
+- **Impact:** Unauthenticated users can trigger potentially expensive DB queries. Input isn't validated server-side.
+- **Recommended Fix:** Add authentication check and rate limiting. Validate `FilterParams` with Zod before passing to the DB layer.
+
+### H-06: `getListingsInBounds` Server Action Has No Auth or Rate Limiting
+- **File:** `src/app/actions/get-listings.ts`
+- **Description:** This server action executes raw PostGIS queries with **no authentication** and **no rate limiting**. The bounds are passed directly to `$queryRaw` (which uses parameterized queries, so no SQL injection risk), but the lack of rate limiting means it can be called at high frequency.
+- **Impact:** Scraping/enumeration vector. Bots can systematically scan all listings by sweeping bounds.
+- **Recommended Fix:** Add rate limiting at minimum. Consider requiring authentication for fine-grained bounds queries.
+
+### H-07: `updateNotificationPreferences` Accepts Unvalidated Input
+- **File:** `src/app/actions/settings.ts` (`updateNotificationPreferences`, ~line 48-70)
+- **Description:** The function accepts a `NotificationPreferences` object and stores it directly as JSON with `as any` cast. No Zod validation. A malicious client could inject arbitrary JSON fields into the user's notification preferences column.
+- **Impact:** Arbitrary data injection into the user record's JSON column.
+- **Recommended Fix:** Validate with a strict Zod schema that only allows the known boolean fields before storing.
+
+### H-08: `changePassword` Has No Rate Limiting
+- **File:** `src/app/actions/settings.ts` (`changePassword`, ~lines 73-115)
+- **Description:** The password change function compares `bcrypt.compare()` on each call with **no rate limiting**. An attacker with a valid session could brute-force the current password.
+- **Impact:** Password brute-force via automated server action calls.
+- **Recommended Fix:** Add rate limiting (e.g., 5 attempts per hour per user).
+
+### H-09: `deleteAccount` Has No Rate Limiting
+- **File:** `src/app/actions/settings.ts` (`deleteAccount`, ~lines 173-212)
+- **Description:** Account deletion with password verification has **no rate limiting**. Similar brute-force risk as `changePassword`.
+- **Recommended Fix:** Add rate limiting.
+
+### H-10: `verifyPassword` Has No Rate Limiting
+- **File:** `src/app/actions/settings.ts` (`verifyPassword`, ~lines 121-154)
+- **Description:** Password verification endpoint with no rate limiting. Same brute-force risk.
+- **Recommended Fix:** Add rate limiting (combined with changePassword/deleteAccount limit).
+
+---
+
+## MEDIUM Findings
+
+### M-01: Missing JSON Parse Error Handling on Several Routes
+- **Files:**
+  - `src/app/api/favorites/route.ts` (POST handler)
+  - `src/app/api/reports/route.ts` (POST handler)
+  - `src/app/api/reviews/route.ts` (POST handler)
+- **Description:** These routes call `request.json()` without a try/catch. If the client sends malformed JSON, this throws an unhandled error that results in a 500 response instead of a clean 400.
+- **Impact:** Poor error experience; potential information leakage in error responses.
+- **Recommended Fix:** Wrap `request.json()` in try/catch and return `{ error: 'Invalid JSON' }` with status 400.
+
+### M-02: Missing Rate Limiting on Status/Can-Delete Endpoints
+- **Files:**
+  - `src/app/api/listings/[id]/status/route.ts` (GET handler)
+  - `src/app/api/listings/[id]/can-delete/route.ts` (GET handler)
+- **Description:** These endpoints have no rate limiting. The status endpoint is public (no auth required).
+- **Impact:** Could be used for enumeration (checking which listing IDs exist) or for DoS.
+- **Recommended Fix:** Add rate limiting to both endpoints.
+
+### M-03: `/api/verify` Route Leaks Error Details in Production
+- **File:** `src/app/api/verify/route.ts` (line ~38)
+- **Description:** Returns `{ error: String(error) }` which could expose internal error messages, stack traces, or database error details.
+- **Impact:** Information disclosure.
+- **Recommended Fix:** Return a generic error message in production; log the detailed error server-side.
+
+### M-04: Duplicated `normalizeStringList` Utility Function
+- **Files:**
+  - `src/app/api/listings/route.ts`
+  - `src/app/api/listings/[id]/route.ts`
+- **Description:** The same `normalizeStringList` function is duplicated in both files.
+- **Impact:** Maintenance burden; risk of divergence.
+- **Recommended Fix:** Extract to a shared utility module (e.g., `src/lib/utils.ts`).
+
+### M-05: Inconsistent Error Logging (console.error vs Structured Logger)
+- **Files:** Multiple locations across the codebase:
+  - `src/lib/idempotency.ts` (line 239: `console.error`)
+  - `src/lib/rate-limit.ts` (lines 149, 156: `console.error`, `console.warn`)
+  - `src/lib/rate-limit-redis.ts` (multiple: `console.error`, `console.warn`)
+  - `src/app/actions/create-listing.ts` (line 42: `console.warn`)
+- **Description:** Many error/warning logs still use raw `console.error`/`console.warn` instead of the structured `logger`. The project has a well-implemented structured logger with PII redaction and request context, but it's not used consistently.
+- **Impact:** Inconsistent log format makes log aggregation/alerting harder. Missing request context correlation. Potential PII leakage through unredacted console output.
+- **Recommended Fix:** Replace all `console.error`/`console.warn` with `logger.sync.error`/`logger.sync.warn`.
+
+### M-06: Server Actions Missing Rate Limiting (Chat, Saved Listings, Notifications)
+- **Files:**
+  - `src/app/actions/chat.ts` (`sendMessage`, `startConversation`, `pollMessages`)
+  - `src/app/actions/saved-listings.ts` (`toggleSaveListing`)
+  - `src/app/actions/notifications.ts` (all actions)
+  - `src/app/actions/review-response.ts` (all actions)
+  - `src/app/actions/saved-search.ts` (all except `saveSearch` which has a count limit)
+- **Description:** Most server actions lack rate limiting. While API routes generally have rate limiting, server actions are directly callable from the client and bypass API route middleware.
+- **Impact:** Abuse vector - automated scripts can call server actions at high frequency.
+- **Recommended Fix:** Add rate limiting to server actions, especially write operations. Consider a shared `withServerActionRateLimit` wrapper.
+
+### M-07: `pollMessages` Calls `getTypingStatus` Redundantly
+- **File:** `src/app/actions/chat.ts` (`pollMessages`, ~line 595)
+- **Description:** `pollMessages` calls `getTypingStatus(conversationId)` which internally re-verifies the user is a participant in the conversation - the same check `pollMessages` already performed. This means two redundant DB queries per poll.
+- **Impact:** Unnecessary DB load on a frequently-called function.
+- **Recommended Fix:** Extract the typing status query logic without the auth/participant check, and call it directly from `pollMessages` after the initial check.
+
+### M-08: `createListing` Server Action Error Message Leaks Internal Details
+- **File:** `src/app/actions/create-listing.ts` (line ~220)
+- **Description:** Returns `Server Error: ${errorMessage}` which includes the raw error message from any caught exception.
+- **Impact:** Could expose database error details, internal paths, or other sensitive information.
+- **Recommended Fix:** Return a generic error message; log details server-side.
+
+### M-09: Chat Server Action `sendMessage` - Email PII in Notification
+- **File:** `src/app/actions/chat.ts` (lines 176-183)
+- **Description:** The `sendNotificationEmailWithPreference` call passes `messagePreview: safeContent` which is the full message content. While this goes to an email service (not logs), the message content could contain PII shared between users.
+- **Impact:** PII in email content is expected for the feature, but `safeContent` is truncated to 50 chars in the in-app notification but sent in full to email. Consider consistency.
+- **Recommended Fix:** Truncate `messagePreview` for email as well, or document this as intentional behavior.
+
+### M-10: DB Rate Limiter Race Condition
+- **File:** `src/lib/rate-limit.ts` (`checkRateLimit`, ~lines 86-120)
+- **Description:** The rate limiter does `findUnique` → check count → `update` increment as separate operations. Two concurrent requests could both read count=4 (limit=5), both pass the check, and both increment to 5, allowing limit+1 requests through.
+- **Impact:** Rate limit can be bypassed by 1 request under concurrent load.
+- **Recommended Fix:** Use an atomic `UPDATE ... SET count = count + 1 WHERE count < limit RETURNING count` or use `$transaction` with Serializable isolation.
+
+---
+
+## LOW Findings
+
+### L-01: `savedSearchNameSchema` Doesn't Sanitize HTML/Script Content
+- **File:** `src/app/actions/saved-search.ts` (line 21)
+- **Description:** The name schema only validates length (1-100) and trims whitespace. It doesn't prevent HTML or script content in search names.
+- **Impact:** Low risk since names are rendered by React (auto-escaped), but defense-in-depth suggests sanitization.
+- **Recommended Fix:** Consider adding a regex pattern to reject HTML tags, or rely on React's auto-escaping (document the assumption).
+
+### L-02: `getUserSettings` Returns Password Hash Presence Check Unnecessarily
+- **File:** `src/app/actions/settings.ts` (`getUserSettings`, ~lines 214-240)
+- **Description:** The function selects `password: true` from the database, then maps it to `hasPassword: !!user.password`. While the hash itself isn't returned to the client, the query fetches the full hash unnecessarily.
+- **Impact:** Minor - the hash stays server-side, but querying it is unnecessary.
+- **Recommended Fix:** Use a raw query or Prisma's `select` to check `password IS NOT NULL` without fetching the actual hash value.
+
+### L-03: `toggleSaveListing` Non-Atomic Check-and-Insert
+- **File:** `src/app/actions/saved-listings.ts` (`toggleSaveListing`, ~lines 9-60)
+- **Description:** Uses `findUnique` then `delete` or `create` as separate operations. Under concurrent clicks, could create duplicates (though the unique constraint on `userId_listingId` would prevent this at DB level).
+- **Impact:** Very low - DB constraint prevents actual duplicates. Could cause transient errors on concurrent double-clicks.
+- **Recommended Fix:** Use `upsert` or wrap in transaction for cleaner handling.
+
+### L-04: `createReviewResponse` Non-Atomic Duplicate Check
+- **File:** `src/app/actions/review-response.ts` (`createReviewResponse`, ~lines 58-65)
+- **Description:** Checks for existing response then creates one. Race condition between check and create could allow duplicate responses (though `reviewId` unique constraint likely prevents this).
+- **Impact:** Very low if DB has unique constraint on `reviewId`.
+- **Recommended Fix:** Use `upsert` or handle unique constraint error gracefully.
+
+### L-05: Cron Jobs Use `console.log` Instead of Structured Logger
+- **Files:**
+  - `src/app/api/cron/cleanup-rate-limits/route.ts`
+  - `src/app/api/cron/refresh-search-docs/route.ts`
+  - `src/app/api/cron/search-alerts/route.ts`
+- **Description:** Cron job handlers use `console.log` for status messages instead of the structured logger.
+- **Impact:** Missing request context and structured format in cron logs.
+- **Recommended Fix:** Use `logger.sync.info` for cron job logging.
+
+### L-06: `deleteMessage` - No Suspension Check
+- **File:** `src/app/actions/chat.ts` (`deleteMessage`, ~lines 371-413)
+- **Description:** Message deletion doesn't check if the user is suspended. While this is a less critical action (user deleting their own messages), other write actions check suspension.
+- **Impact:** Very low - suspended users can still delete their own messages.
+- **Recommended Fix:** Consider adding suspension check for consistency, or document this as intentional (allowing suspended users to clean up their messages).
+
+### L-07: NextAuth JWT Token Refresh Only on Specific Triggers
+- **File:** `src/auth.ts` (JWT callback, ~lines 85-117)
+- **Description:** The JWT callback only refreshes user data from DB on `signIn`, `update`, or when an `account` is present. During normal browsing, a user's `isSuspended` or `isAdmin` status changes won't be reflected until their next sign-in or explicit token update.
+- **Impact:** Admin actions (suspend/unsuspend, grant/revoke admin) have a delay before taking effect in the user's session (up to session maxAge of 14 days).
+- **Recommended Fix:** Consider adding periodic DB checks (e.g., once per hour) in the JWT callback, or use `updateAge` more aggressively for security-sensitive fields.
+
+---
+
+## Positive Patterns Observed (Strengths)
+
+1. **Idempotency implementation** (`src/lib/idempotency.ts`) is robust - SERIALIZABLE transactions, atomic claim via INSERT ON CONFLICT, request hash verification, serialization failure retry with backoff.
+
+2. **Booking state machine** (`src/lib/booking-state-machine.ts`) is well-designed with clear valid transitions, custom error class, and terminal state detection.
+
+3. **Booking creation** (`src/app/actions/booking.ts`) uses FOR UPDATE locks, price validation against DB, Serializable isolation, and separated side effects.
+
+4. **Rate limiting** has dual-layer design (DB-backed + Redis-backed) with in-memory fallback, circuit breaker, and timeout protection.
+
+5. **Structured logger** (`src/lib/logger.ts`) has comprehensive PII redaction (email, phone, address patterns), request context correlation, and sync/async variants.
+
+6. **Auth configuration** (`src/auth.ts`) has Turnstile CAPTCHA, email normalization, Google email verification enforcement, suspension checks on sign-in, OAuth token cleanup, and dangerous email linking safely gated.
+
+7. **CSP implementation** (staged) is well-designed with nonce-based script-src, strict-dynamic, and comprehensive directive set.
+
+8. **IDOR protection** is present in chat (`sendMessage` verifies participant status) and notifications (user ownership checks).
+
+9. **Token security** uses SHA-256 hashing for verification/reset tokens, preventing token enumeration.
+
+10. **Anti-enumeration** in auth routes (timing-safe responses for existing users in registration, generic error messages in forgot-password).
+
+---
+
+## Summary by Severity
+
+| Severity | Count | Key Areas |
+|----------|-------|-----------|
+| CRITICAL | 4 | Race conditions, missing middleware, non-transactional writes, view count abuse |
+| HIGH | 10 | Missing auth/validation checks, missing rate limiting on sensitive actions, input validation gaps |
+| MEDIUM | 10 | JSON parse errors, inconsistent logging, redundant queries, info leakage |
+| LOW | 7 | Minor inconsistencies, non-atomic but DB-constrained operations |
+| **Total** | **31** | |
+
+---
+
+## Top 5 Priority Actions
+
+1. **Restore middleware** (C-03) - Missing security headers is a broad-impact gap
+2. **Fix listing deletion race condition** (C-01) - Data integrity risk in core business logic
+3. **Add auth + rate limit to `incrementViewCount`** (C-02) - Active abuse vector
+4. **Make verification approval transactional** (C-04) - Data consistency risk
+5. **Add rate limiting to server actions** (M-06, H-05, H-06, H-08-H-10) - Systematic gap in server action layer

--- a/tasks/production-readiness-audit.md
+++ b/tasks/production-readiness-audit.md
@@ -1,0 +1,247 @@
+# Roomshare Production Readiness Audit — Consolidated Report
+
+**Date**: 2026-02-16
+**Agents**: 7 Opus 4.6 agents (security, API, database, testing, frontend, performance, ops)
+**Scope**: Full codebase — 31 API routes, 17 server actions, 149 components, 24 DB models, 451-line schema, 21 migrations, 3 Sentry configs, Playwright + Jest infrastructure
+
+---
+
+## Executive Summary
+
+**Total findings: 157** across 7 audit domains.
+
+| Severity | Count | Must-fix timeline |
+|----------|-------|-------------------|
+| CRITICAL | 22 | Before production launch |
+| HIGH | 44 | Before production launch |
+| MEDIUM | 51 | Within first 2 weeks post-launch |
+| LOW | 40 | Backlog / nice-to-have |
+
+The codebase has strong fundamentals — robust booking state machine, solid idempotency, good token security, comprehensive E2E tests, well-designed structured logger, and proper auth patterns. However, several critical gaps must be addressed: **the deleted middleware means zero security headers are applied**, **Sentry is blind to all server-side errors**, **missing DB indexes will cause performance degradation at scale**, and **several endpoints lack authentication or rate limiting**.
+
+---
+
+## P0: CRITICAL — Must Fix Before Launch (22 findings)
+
+### Security & Headers
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 1 | **middleware.ts deleted — ALL security headers (CSP, HSTS, X-Frame-Options) not applied** | Security, API | `src/middleware.ts` (deleted) |
+| 2 | `/api/chat` (LLM) has no authentication — anyone can invoke Groq API | Security | `src/app/api/chat/route.ts` |
+| 3 | `/api/agent` (n8n webhook) has no authentication | Security | `src/app/api/agent/route.ts` |
+| 4 | `incrementViewCount` has zero auth and zero rate limiting — view count inflation | API | `src/app/actions/listing-status.ts` |
+
+### Data Integrity & Race Conditions
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 5 | Listing deletion race condition — non-atomic check-then-delete allows orphaned bookings | API | `src/app/api/listings/[id]/route.ts` |
+| 6 | Verification approval non-transactional — request approved but user stays unverified | API | `src/app/actions/verification.ts` |
+| 7 | Rate limiter TOCTOU race — concurrent requests bypass count check | DB, API | `src/lib/rate-limit.ts` |
+| 8 | `Float` for monetary values (price, totalPrice) — precision errors on financial math | DB | `prisma/schema.prisma` |
+| 9 | No CHECK constraint on Review.rating (1-5) — bad values corrupt search rankings | DB | `prisma/schema.prisma` |
+
+### Missing Database Indexes (Performance Critical)
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 10 | Missing index on `Listing.ownerId` — every ownership query is a full scan | DB | `prisma/schema.prisma` |
+| 11 | Missing indexes on `Booking.listingId` and `Booking.status` — capacity checks scan full table | DB, Perf | `prisma/schema.prisma` |
+| 12 | Missing index on `Review.listingId` — every listing review fetch + search JOIN is unindexed | DB | `prisma/schema.prisma` |
+
+### Observability Blindness
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 13 | No Sentry webpack plugin — source maps never uploaded, stack traces are minified | Ops | `next.config.ts` |
+| 14 | Zero `Sentry.captureException` in ANY API route — all server errors invisible | Ops | All 32 API routes |
+
+### Performance
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 15 | V1 `getListings()` loads ALL rows into memory, filters in JS — O(N) full scan | DB, Perf | `src/lib/data.ts:442-714` |
+| 16 | Cron upserts 100 rows one-at-a-time (100 sequential DB round-trips) | Perf | `src/app/api/cron/refresh-search-docs/route.ts` |
+| 17 | `analyzeFilterImpact()` runs 7 sequential COUNT queries on zero-result searches | Perf | `src/lib/data.ts:1507-1616` |
+
+### Data Exposure
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 18 | Listing detail page exposes password hash — `include: { owner: true }` | DB | `src/app/listings/[id]/page.tsx:41-47` |
+
+### Frontend Safety
+| # | Finding | Source | File(s) |
+|---|---------|--------|---------|
+| 19 | Booking confirmation modal missing FocusTrap — financial dialog, keyboard can escape | Frontend | `src/components/BookingForm.tsx:682-795` |
+| 20 | Block-user dialog missing FocusTrap — safety action without focus containment | Frontend | `src/components/BlockUserButton.tsx` |
+| 21 | Listing detail page missing `error.tsx` — highest-traffic dynamic page | Frontend | `src/app/listings/[id]/` |
+| 22 | Listing edit page missing `error.tsx` — form errors show raw crash | Frontend | `src/app/listings/[id]/edit/` |
+
+---
+
+## P1: HIGH — Should Fix Before Launch (44 findings)
+
+### Security & Auth Gaps
+| # | Finding | Source |
+|---|---------|--------|
+| 23 | 11 `$queryRawUnsafe` call sites — SQL injection surface (currently parameterized but fragile) | Security |
+| 24 | PII (userEmail) in admin audit logs — violates non-negotiable | Security |
+| 25 | Dev mode leaks password reset URL in response body | Security |
+| 26 | PATCH /api/listings missing suspension & email verification checks | API |
+| 27 | Messages POST stores raw content instead of trimmed Zod output | API |
+| 28 | `updateListingStatus` accepts any string as status (no runtime validation) | API |
+| 29 | Reviews POST missing email verification check | API |
+| 30 | `getFilterSuggestions` server action — no auth, no rate limiting, no input validation | API |
+| 31 | `getListingsInBounds` server action — no auth, no rate limiting (scraping vector) | API |
+| 32 | `updateNotificationPreferences` stores unvalidated JSON via `as any` cast | API |
+| 33 | `changePassword`, `deleteAccount`, `verifyPassword` all lack rate limiting (brute-force) | API |
+
+### Missing Database Indexes
+| # | Finding | Source |
+|---|---------|--------|
+| 34 | Missing index on `Listing.status` — used in virtually every listing query | DB |
+| 35 | Missing index on `Review.targetUserId` — user profile review lookups | DB |
+| 36 | Missing index on `Report.status` and `Report.listingId` — admin panel queries | DB |
+| 37 | Missing index on `Conversation.listingId` — conversation start queries | DB |
+| 38 | No `updatedAt` on User, Report, Notification models | DB |
+| 39 | `getMyBookings()` fetches full Location including PostGIS coords binary | DB |
+
+### Observability
+| # | Finding | Source |
+|---|---------|--------|
+| 40 | ~50% of API routes use raw `console.error` instead of structured logger | Ops |
+| 41 | 11 pages missing `error.tsx` boundaries (auth pages, listings/create) | Ops, Frontend |
+| 42 | Cron jobs don't report errors to Sentry | Ops |
+
+### Performance
+| # | Finding | Source |
+|---|---------|--------|
+| 43 | Geocoding cache in-memory only — lost on every serverless cold start | Perf |
+| 44 | Duplicate map data fetching on V1 path (separate query from search results) | Perf |
+| 45 | `sendMessage` notification loop is sequential per participant | Perf |
+| 46 | `framer-motion` (~32KB) imported in 10 client components | Perf |
+| 47 | SessionProvider polls every 60s (should be 300s) | Perf |
+| 48 | Notification polling every 30s without tab visibility check | Perf |
+
+### Frontend
+| # | Finding | Source |
+|---|---------|--------|
+| 49 | ErrorBoundary fallback has no dark mode support — unreadable in dark mode | Frontend |
+| 50 | Auth pages (login, signup, forgot-password, reset-password) missing error.tsx | Frontend |
+| 51 | Listings/create page missing error.tsx — upload failures lose user's work | Frontend |
+| 52 | 87% of components are client components (~15-20 should be server) | Frontend |
+| 53 | Map debounce 500ms instead of required 600ms per CLAUDE.md spec | Frontend |
+
+### Test Coverage (Critical Gaps)
+| # | Finding | Source |
+|---|---------|--------|
+| 54 | `token-security.ts` has zero tests — crypto token hashing/creation | Testing |
+| 55 | `actions/suspension.ts` has no tests — suspension bypass risk | Testing |
+| 56 | `api/listings/[id]/status` has no tests — state transitions untested | Testing |
+| 57 | `api/chat` and `api/agent` routes have no tests | Testing |
+| 58 | `auth.ts` / `auth.config.ts` have no direct tests — only mocked | Testing |
+| 59 | Zero real database integration tests — all Prisma mocked | Testing |
+| 60 | `notifications.ts`, `normalize-email.ts`, `pagination-schema.ts` untested | Testing |
+| 61 | `search-v2-service.ts` untested — core search orchestration | Testing |
+| 62 | 7 hooks, 3 contexts, FilterModal, ErrorBoundary all missing tests | Testing |
+| 63 | Cron jobs and health endpoints have no tests | Testing |
+| 64 | `$transaction` mock passes empty object — hides real failures | Testing |
+| 65 | No shared test factories — data recreated inline everywhere | Testing |
+| 66 | `global.fetch = jest.fn()` fragile pattern in several tests | Testing |
+
+---
+
+## P2: MEDIUM — Fix Within 2 Weeks Post-Launch (51 findings)
+
+### Security
+- CSP `style-src 'unsafe-inline'` in all environments
+- CSP `img-src https:` overly permissive (any HTTPS origin)
+- `allowDangerousEmailAccountLinking` residual risk (needs dedicated test)
+- Rate limiting disabled in non-production (staging exposed)
+- Listing status endpoint has no rate limiting (enumeration vector)
+- Health/ready endpoint exposes raw error details
+- Review PUT/DELETE missing suspension check
+
+### API & Server
+- Missing JSON parse error handling on favorites/reports/reviews POST routes
+- `/api/verify` leaks raw error details in production
+- Duplicated `normalizeStringList` utility
+- Server actions systematically lack rate limiting (chat, saved-listings, notifications)
+- `pollMessages` redundant conversation verification
+- `createListing` error message leaks internal details
+- Chat email notification sends full message (inconsistent truncation)
+
+### Database
+- Account.userId and Session.userId have no index (NextAuth per-request queries)
+- No CHECK constraints on Listing.price (>=0) or slots (>0)
+- SearchDoc table not in Prisma schema (no type safety)
+- FTS backfill migration runs unbatched UPDATE
+- Redundant location deleteMany before cascade delete
+- No index on Notification.createdAt (sort column)
+- No index on Listing.createdAt (V1 sort column)
+
+### Observability
+- No Sentry release/environment tags
+- Metrics endpoint lacks error rate and request duration
+- Sentry client config filters too aggressively (drops "fetch" errors)
+- Graceful shutdown Sentry flush timeout too short (2s)
+- Docker compose lacks resource limits and health check
+- No retry logic for cron job DB operations
+- `verify/route.ts` leaks raw error in response
+
+### Frontend
+- Minimal a11y test coverage (2 files)
+- SearchResultsClient missing `role="article"` on feed items
+- Map popup not keyboard-dismissible (Escape)
+- `FeaturedListings.tsx` uses `'use server'` incorrectly
+- Map tile loading flicker on cached tiles
+- Missing route-specific `not-found.tsx` for listings
+- BookingForm logs idempotency key to console
+
+### Performance
+- search-count endpoint has no caching
+- `getListingsPaginated` runs separate COUNT query
+- O(n) `savedListingIds.includes()` per card (should be Set)
+- `toggleSaveListing` find-then-delete (2 round-trips vs upsert)
+- `getNotifications` runs 3 queries (1 redundant)
+- 1.4MB unoptimized images in /public (hero images)
+- Dead `optimizePackageImports` entries in next.config.ts
+- Large inline config data in nearby route (~450 lines)
+
+---
+
+## P3: LOW — Backlog (40 findings)
+
+Includes: TypingStatus unbounded growth, IdempotencyKey mixed ID formats, sitemap no pagination, SavedSearch.filters untyped JSON, minor ARIA gaps (aria-expanded, skip-to-search), Escape key conflicts between sheet/modals, timezone edge case tests, ServiceWorker interval leak, geocoding cache eager eviction, dead POST export on search-alerts cron, console PII in scripts, response over-sharing on register, process fingerprinting via metrics, minor non-atomic but DB-constrained operations, JWT refresh timing gap.
+
+---
+
+## Top 10 Priority Actions (Ordered by Impact)
+
+| Priority | Action | Effort | Impact |
+|----------|--------|--------|--------|
+| **1** | **Restore `src/middleware.ts`** — wire CSP + security headers | Small | Fixes C1: ALL security headers missing |
+| **2** | **Add Sentry server-side error capture** — create shared API error handler + wire `withSentryConfig` | Medium | Fixes C13-14: blind to all server errors |
+| **3** | **Add missing DB indexes** (Listing.ownerId, Booking.listingId+status, Review.listingId, Listing.status + 5 more) | Small | Fixes C10-12, H34-37: prevents full-table scans |
+| **4** | **Fix password hash exposure** on listing detail page | Tiny | Fixes C18: user passwords leaked to client |
+| **5** | **Add auth to `/api/chat` and `/api/agent`** | Small | Fixes C2, H2: unauthenticated LLM/webhook access |
+| **6** | **Add FocusTrap to booking confirmation + block-user dialogs** | Small | Fixes C19-20: a11y on financial/safety dialogs |
+| **7** | **Add rate limiting to server actions** (password, view count, filters, map bounds) | Medium | Fixes C4, H30-33: brute-force + abuse vectors |
+| **8** | **Fix listing deletion race condition** — wrap in transaction with FOR UPDATE | Small | Fixes C5: orphaned bookings |
+| **9** | **Batch cron upserts** + parallelize filter impact queries | Medium | Fixes C16-17: 100x fewer DB round-trips |
+| **10** | **Migrate Float to Decimal** for monetary values | Medium | Fixes C8: financial precision errors |
+
+---
+
+## Strengths (What's Working Well)
+
+The audit found substantial positive patterns:
+
+- **Booking state machine**: FOR UPDATE locks, serializable isolation, idempotency keys, retry on serialization conflict
+- **Token security**: SHA-256 hashed tokens, constant-time comparison, never storing raw values
+- **Rate limiting architecture**: Dual-layer DB + Redis, in-memory fallback, circuit breaker
+- **Structured logger**: PII redaction, JSON output, request context correlation
+- **Auth configuration**: Turnstile CAPTCHA, email normalization, suspension checks, timing-safe anti-enumeration
+- **Upload security**: Magic bytes validation, MIME allowlist, 5MB max, path traversal prevention
+- **E2E test suite**: 100+ Playwright specs, cross-browser, mobile, a11y, visual regression, performance
+- **Search pagination**: Proper cursor reset, deduplication via seenIdsRef, 60-item cap
+- **Graceful shutdown**: SIGTERM/SIGINT handling, Sentry flush, Prisma disconnect
+- **Health checks**: Liveness + readiness with DB latency timing
+- **CRON auth**: 32-char secret requirement with placeholder rejection
+- **Error type hierarchy**: DataError with Prisma error mapping

--- a/tests/e2e/journeys/04-favorites-saved-searches.spec.ts
+++ b/tests/e2e/journeys/04-favorites-saved-searches.spec.ts
@@ -187,8 +187,17 @@ test.describe("Favorites & Saved Searches Journeys", () => {
         // Select alert frequency if available
         const frequencySelect = page.getByLabel(/frequency|alert/i);
         if (await frequencySelect.isVisible().catch(() => false)) {
-          // @ts-expect-error - Playwright accepts RegExp for label matching at runtime
-          await frequencySelect.selectOption({ label: /daily/i });
+          // SaveSearchButton renders frequency as buttons, not a native <select>.
+          // Prefer clicking "Daily"; fallback to "Instant" if unavailable.
+          const dailyButton = page.getByRole("button", { name: /^Daily$/i }).first();
+          if (await dailyButton.isVisible().catch(() => false)) {
+            await dailyButton.click();
+          } else {
+            const instantButton = page.getByRole("button", { name: /^Instant$/i }).first();
+            if (await instantButton.isVisible().catch(() => false)) {
+              await instantButton.click();
+            }
+          }
         }
 
         // Save — confirm button may match multiple elements or be blocked by overlay in CI


### PR DESCRIPTION
## Scope

Implements Search Page production-readiness fixes from:
- `docs/SEARCH_PAGE_PRODUCTION_AUDIT.md`
- `tasks/MASTER_EXECUTION_SPEC.md`

Review scope requested: **P0 + P1** (`C1–C9`, `H1–H5`).

## Key Fixes

- C1: `generateMetadata` now includes Twitter metadata and conditional `noindex` for paginated/highly-filtered pages (`src/app/search/page.tsx`).
- C2/H4/H5: timeout protections + shared page-size constant in search paths (`src/app/search/page.tsx`, `src/app/search/actions.ts`).
- C3: `$queryRawUnsafe` parameterization guards/comments (`src/lib/search/search-doc-queries.ts`, `src/app/api/search/facets/route.ts`).
- C4: HMAC cursor signing/verification with env-backed secret (`src/lib/search/cursor.ts`, `src/lib/search/hash.ts`, `src/lib/env.ts`, `.env.example`).
- C5/C6/C7/C8: modal a11y, focus trap, switch ARIA, body scroll lock (`src/components/SaveSearchButton.tsx`).
- C9: WebGL context-loss recovery + remount fallback (`src/components/Map.tsx`) with explicit test coverage (`src/__tests__/components/Map.test.tsx`).
- H1/H2/H3: input normalization/query cap and real 429 middleware behavior (`src/lib/search-params.ts`, `src/middleware.ts`).

## Validation

- `pnpm test -- src/__tests__/lib/search-params.test.ts src/__tests__/api/listings.test.ts src/__tests__/components/map/MapErrorBoundary.test.tsx src/__tests__/lib/search/cursor.test.ts src/__tests__/components/Map.test.tsx --runInBand`
- Result: **5/5 suites passed, 266/266 tests passed**.