### PR TITLE
fix(security): 14 search page security & logic fixes

### DIFF
--- a/src/__tests__/api/search/v2/route.test.ts
+++ b/src/__tests__/api/search/v2/route.test.ts
@@ -135,7 +135,7 @@ function createMockMapListingData(
     title: `Listing ${id}`,
     price: 1500,
     availableSlots: 1,
-    ownerId: "owner-1",
+
     images: ["img.jpg"],
     location: { lat, lng },
   };

--- a/src/__tests__/components/ListScrollBridge.test.tsx
+++ b/src/__tests__/components/ListScrollBridge.test.tsx
@@ -1,0 +1,14 @@
+describe("ListScrollBridge CSS safety", () => {
+  it("strips non-word characters when CSS.escape is unavailable", () => {
+    const originalEscape = globalThis.CSS?.escape;
+    if (globalThis.CSS) globalThis.CSS.escape = undefined as any;
+
+    const maliciousId = '"]){color:red}*{';
+    const safeId = maliciousId.replace(/[^\w-]/g, "");
+    expect(safeId).toBe("colorred");
+    expect(safeId).not.toContain('"');
+    expect(safeId).not.toContain("}");
+
+    if (globalThis.CSS && originalEscape) globalThis.CSS.escape = originalEscape;
+  });
+});

--- a/src/__tests__/lib/env.test.ts
+++ b/src/__tests__/lib/env.test.ts
@@ -1,0 +1,40 @@
+describe("getCursorSecret", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset module cache so _cursorSecretDevWarned is fresh
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns the secret when CURSOR_SECRET is set", () => {
+    process.env.CURSOR_SECRET = "test-secret-value";
+    const { getCursorSecret: fn } = require("@/lib/env");
+    expect(fn()).toBe("test-secret-value");
+  });
+
+  it("throws on EVERY call in production when CURSOR_SECRET is missing", () => {
+    delete process.env.CURSOR_SECRET;
+    delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+    (process.env as { NODE_ENV?: string }).NODE_ENV = "production";
+    const { getCursorSecret: fn } = require("@/lib/env");
+
+    // First call should throw
+    expect(() => fn()).toThrow("[SECURITY] CURSOR_SECRET is required in production");
+
+    // Second call should ALSO throw (no silent degradation)
+    expect(() => fn()).toThrow("[SECURITY] CURSOR_SECRET is required in production");
+  });
+
+  it("returns empty string in development when CURSOR_SECRET is missing", () => {
+    delete process.env.CURSOR_SECRET;
+    delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+    (process.env as { NODE_ENV?: string }).NODE_ENV = "development";
+    const { getCursorSecret: fn } = require("@/lib/env");
+    expect(fn()).toBe("");
+  });
+});

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -272,7 +272,7 @@ function makeMapListingData(
     title: "Map Listing",
     price: 1500,
     availableSlots: 1,
-    ownerId: "owner-1",
+
     images: ["img1.jpg"],
     location: { lat: 37.77, lng: -122.42 },
     ...overrides,

--- a/src/__tests__/lib/search/transform.test.ts
+++ b/src/__tests__/lib/search/transform.test.ts
@@ -189,7 +189,7 @@ describe("search/transform", () => {
       images: ["img.jpg"],
       location: { lat, lng },
       availableSlots: 1,
-      ownerId: "owner-1",
+
     });
 
     it("should return valid FeatureCollection", () => {
@@ -233,7 +233,7 @@ describe("search/transform", () => {
           images: ["first.jpg", "second.jpg"],
           location: { lat: 37.7749, lng: -122.4194 },
           availableSlots: 1,
-          ownerId: "owner",
+
         },
       ];
 
@@ -255,7 +255,7 @@ describe("search/transform", () => {
           images: [],
           location: { lat: 37.7749, lng: -122.4194 },
           availableSlots: 1,
-          ownerId: "owner",
+
         },
       ];
 
@@ -284,7 +284,7 @@ describe("search/transform", () => {
       images: ["img.jpg"],
       location: { lat, lng },
       availableSlots: 1,
-      ownerId: "owner-1",
+
     });
 
     it("should return empty array for empty input", () => {
@@ -377,7 +377,7 @@ describe("search/transform", () => {
       images: ["img.jpg"],
       location: { lat, lng },
       availableSlots: 1,
-      ownerId: "owner-1",
+
     });
 
     it("should always include geojson", () => {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -18,6 +18,7 @@ import { features } from '@/lib/env';
 import { preload } from 'react-dom';
 import { withTimeout, DEFAULT_TIMEOUTS } from '@/lib/timeout-wrapper';
 import { DEFAULT_PAGE_SIZE } from '@/lib/constants';
+import { sanitizeErrorMessage } from '@/lib/logger';
 import type { Metadata } from 'next';
 
 type SearchPageSearchParams = {
@@ -252,12 +253,12 @@ export default async function SearchPage({
                 };
             } else if (v2Result.error) {
                 // V2 returned error without throwing - log it before falling through to V1
-                console.warn('[search/page] V2 returned error:', v2Result.error);
+                console.warn('[search/page] V2 returned error:', sanitizeErrorMessage(v2Result.error));
             }
         } catch (err) {
             // V2 failed - will fall back to v1 below
             console.warn('[search/page] V2 orchestration failed, falling back to v1:', {
-                error: err instanceof Error ? err.message : 'Unknown error',
+                error: sanitizeErrorMessage(err),
             });
         }
     }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -2180,18 +2180,6 @@ export default function MapComponent({
                                             View Details
                                         </Button>
                                     </Link>
-                                    <Link href={`/listings/${selectedListing.id}`} className="flex-1">
-                                        <Button
-                                            size="sm"
-                                            variant="outline"
-                                            className={`w-full h-9 text-xs-plus font-medium rounded-lg ${isDarkMode
-                                                ? 'border-zinc-700 text-white hover:bg-zinc-800'
-                                                : 'border-zinc-300 text-zinc-900 hover:bg-zinc-100'
-                                                }`}
-                                        >
-                                            View Listing
-                                        </Button>
-                                    </Link>
                                 </div>
                             </div>
                         </div>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -48,7 +48,6 @@ interface Listing {
     title: string;
     price: number;
     availableSlots: number;
-    ownerId?: string;
     images?: string[];
     location: {
         lat: number;
@@ -69,7 +68,6 @@ interface ClusterFeatureProperties {
     title: string;
     price: number;
     availableSlots: number;
-    ownerId?: string;
     images?: string;
     lat: number;
     lng: number;
@@ -523,7 +521,6 @@ export default function MapComponent({
                 title: listing.title,
                 price: listing.price,
                 availableSlots: listing.availableSlots,
-                ownerId: listing.ownerId || '',
                 images: JSON.stringify(listing.images || []),
                 lat: listing.location.lat,
                 lng: listing.location.lng,
@@ -614,7 +611,6 @@ export default function MapComponent({
                     title: properties.title ?? '',
                     price: Number(properties.price) || 0,
                     availableSlots: Number(properties.availableSlots) || 0,
-                    ownerId: properties.ownerId,
                     images,
                     location: {
                         lat: Number(properties.lat) || 0,
@@ -2184,20 +2180,18 @@ export default function MapComponent({
                                             View Details
                                         </Button>
                                     </Link>
-                                    {selectedListing.ownerId && (
-                                        <Link href={`/messages?userId=${selectedListing.ownerId}`} className="flex-1">
-                                            <Button
-                                                size="sm"
-                                                variant="outline"
-                                                className={`w-full h-9 text-xs-plus font-medium rounded-lg ${isDarkMode
-                                                    ? 'border-zinc-700 text-white hover:bg-zinc-800'
-                                                    : 'border-zinc-300 text-zinc-900 hover:bg-zinc-100'
-                                                    }`}
-                                            >
-                                                Message
-                                            </Button>
-                                        </Link>
-                                    )}
+                                    <Link href={`/listings/${selectedListing.id}`} className="flex-1">
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className={`w-full h-9 text-xs-plus font-medium rounded-lg ${isDarkMode
+                                                ? 'border-zinc-700 text-white hover:bg-zinc-800'
+                                                : 'border-zinc-300 text-zinc-900 hover:bg-zinc-100'
+                                                }`}
+                                        >
+                                            View Listing
+                                        </Button>
+                                    </Link>
                                 </div>
                             </div>
                         </div>

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -247,7 +247,6 @@ function MapDataLoadingBar() {
  * - price: for pin label
  * - title: for popup/tooltip
  * - availableSlots: for "N Available" / "Filled" badge in popup
- * - ownerId: for showing "Message" button in popup
  * - tier: for differentiated pin styling (primary = larger, mini = smaller)
  */
 function v2MapDataToListings(v2MapData: V2MapData): MapListingData[] {
@@ -280,7 +279,6 @@ function v2MapDataToListings(v2MapData: V2MapData): MapListingData[] {
         title: feature.properties.title ?? "",
         price: feature.properties.price ?? 0,
         availableSlots: feature.properties.availableSlots,
-        ownerId: feature.properties.ownerId,
         images: feature.properties.image ? [feature.properties.image] : [],
         location: { lng, lat },
         // Add tier from pins lookup (defaults to undefined if not in pins mode)

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -265,7 +265,13 @@ function v2MapDataToListings(v2MapData: V2MapData): MapListingData[] {
   return v2MapData.geojson.features
     .filter((feature) => {
       const coordinates = feature.geometry?.coordinates;
-      return Array.isArray(coordinates) && coordinates.length >= 2;
+      if (!Array.isArray(coordinates) || coordinates.length < 2) return false;
+      const [lng, lat] = coordinates;
+      return (
+        Number.isFinite(lng) && Number.isFinite(lat) &&
+        lat >= -90 && lat <= 90 &&
+        lng >= -180 && lng <= 180
+      );
     })
     .map((feature) => {
       const [lng, lat] = feature.geometry.coordinates;

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -138,8 +138,8 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
     // Navigation version counter - ensures only the latest search executes navigation
     // Incremented on each new search to invalidate stale timeout callbacks
     const navigationVersionRef = useRef(0);
-    // AbortController for canceling in-flight async operations on rapid filter changes
-    const abortControllerRef = useRef<AbortController | null>(null);
+    // Track the isSearching reset timeout so it can be cleaned up on unmount
+    const resetSearchingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
     // Recent searches from canonical hook (handles localStorage, migration, enhanced format)
     const { recentSearches, saveRecentSearch, clearRecentSearches } = useRecentSearches();
@@ -301,13 +301,6 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
         // This prevents race conditions when filters change rapidly
         navigationVersionRef.current++;
 
-        // Cancel any in-flight async operations from previous filter changes
-        if (abortControllerRef.current) {
-            abortControllerRef.current.abort();
-        }
-        // Create new AbortController for this search operation
-        abortControllerRef.current = new AbortController();
-
         // Clone existing URL params to preserve bounds, nearMatches, and sort
         // These are set by the map and should persist across filter changes
         const params = new URLSearchParams(searchParams.toString());
@@ -424,20 +417,20 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
             } else {
                 router.push(searchUrl);
             }
-            // Reset searching state after navigation starts
-            setTimeout(() => setIsSearching(false), 500);
+            // Reset searching state after navigation starts (tracked for cleanup)
+            if (resetSearchingTimeoutRef.current) clearTimeout(resetSearchingTimeoutRef.current);
+            resetSearchingTimeoutRef.current = setTimeout(() => setIsSearching(false), 500);
         }, SEARCH_DEBOUNCE_MS);
     }, [location, minPrice, maxPrice, selectedCoords, moveInDate, leaseDuration, roomType, amenities, houseRules, languages, genderPreference, householdGender, router, isSearching, saveRecentSearch, searchParams]);
 
-    // Cleanup timeout and abort controller on unmount
+    // Cleanup timeouts on unmount
     useEffect(() => {
         return () => {
             if (searchTimeoutRef.current) {
                 clearTimeout(searchTimeoutRef.current);
             }
-            // Cancel any in-flight operations
-            if (abortControllerRef.current) {
-                abortControllerRef.current.abort();
+            if (resetSearchingTimeoutRef.current) {
+                clearTimeout(resetSearchingTimeoutRef.current);
             }
         };
     }, []);

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -104,11 +104,11 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
     };
     const [location, setLocation] = useState(searchParams.get('q') || '');
     // Batched filter state — single hook manages pending vs committed
-    const { pending, isDirty: filtersDirty, setPending, commit: commitFilters } = useBatchedFilters();
+    const [showFilters, setShowFilters] = useState(false);
+
+    const { pending, isDirty: filtersDirty, setPending, commit: commitFilters } = useBatchedFilters({ isDrawerOpen: showFilters });
     // Destructure for convenient access (read-only aliases)
     const { minPrice, maxPrice, moveInDate, leaseDuration, roomType, amenities, houseRules, languages, genderPreference, householdGender } = pending;
-
-    const [showFilters, setShowFilters] = useState(false);
 
     const [selectedCoords, setSelectedCoords] = useState<{ lat: number; lng: number; bbox?: [number, number, number, number] } | null>(parseCoords);
     const [geoLoading, setGeoLoading] = useState(false);

--- a/src/components/listings/ListScrollBridge.tsx
+++ b/src/components/listings/ListScrollBridge.tsx
@@ -30,7 +30,9 @@ export default function ListScrollBridge() {
 
     // Escape ID for safe use in CSS selectors (handles special characters)
     const safeId =
-      typeof CSS !== "undefined" && CSS.escape ? CSS.escape(id) : id;
+      typeof CSS !== "undefined" && CSS.escape
+        ? CSS.escape(id)
+        : id.replace(/[^\w-]/g, "");
 
     // Find target card using data-testid (preferred) with fallback to data-listing-id
     const targetCard =

--- a/src/components/search/MobileBottomSheet.tsx
+++ b/src/components/search/MobileBottomSheet.tsx
@@ -126,7 +126,7 @@ export default function MobileBottomSheet({
       }
       return rawOffset;
     },
-    [currentSnap],
+    [currentSnap, viewportHeight],
   );
 
   const displayOffset = isDragging ? getRubberbandOffset(dragOffset) : 0;

--- a/src/components/search/MobileBottomSheet.tsx
+++ b/src/components/search/MobileBottomSheet.tsx
@@ -233,6 +233,27 @@ export default function MobileBottomSheet({
     setDragOffset(0);
   }, []);
 
+  // Safety net: clear drag state when touch ends outside the handle
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleDocumentTouchEnd = () => {
+      if (isDraggingRef.current) {
+        isDraggingRef.current = false;
+        setIsDragging(false);
+        setDragOffset(0);
+      }
+    };
+
+    document.addEventListener("touchend", handleDocumentTouchEnd);
+    document.addEventListener("touchcancel", handleDocumentTouchEnd);
+
+    return () => {
+      document.removeEventListener("touchend", handleDocumentTouchEnd);
+      document.removeEventListener("touchcancel", handleDocumentTouchEnd);
+    };
+  }, [isDragging]);
+
   // Content area touch start — track that drag originated from content
   const handleContentTouchStart = useCallback(
     (e: React.TouchEvent) => {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -741,7 +741,6 @@ export async function getMapListings(
             l.title,
             l.price,
             l."availableSlots",
-            l."ownerId",
             l.images,
             ST_X(loc.coords::geometry) as lng,
             ST_Y(loc.coords::geometry) as lat

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -264,14 +264,18 @@ export const clientEnv: ClientEnv = new Proxy({} as ClientEnv, {
 });
 
 // Lazy getter — avoids throwing at import time during `next build` static generation
-let _cursorSecretChecked = false;
+let _cursorSecretDevWarned = false;
 export function getCursorSecret(): string {
   const secret = process.env.CURSOR_SECRET ?? "";
-  if (!secret && process.env.NODE_ENV === "production" && !_cursorSecretChecked) {
-    _cursorSecretChecked = true;
-    throw new Error("[SECURITY] CURSOR_SECRET is required in production — cursor tokens cannot be verified without it");
+  if (!secret) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("[SECURITY] CURSOR_SECRET is required in production — cursor tokens cannot be verified without it");
+    }
+    if (!_cursorSecretDevWarned) {
+      _cursorSecretDevWarned = true;
+      console.warn("[DEV] CURSOR_SECRET not set — cursors will not be HMAC-verified");
+    }
   }
-  _cursorSecretChecked = true;
   return secret;
 }
 // Backward-compatible export — defers check to first access

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -75,6 +75,10 @@ const REDACT_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
   // Street addresses - matches "123 Main Street", "456 Oak Ave", etc.
   // Pattern: number + street name + common suffix (with optional apartment/unit)
   { pattern: /\b\d+\s+[A-Za-z]+(?:\s+[A-Za-z]+)*\s+(?:Street|St|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Road|Rd|Lane|Ln|Court|Ct|Circle|Cir|Way|Place|Pl|Terrace|Ter|Trail|Trl|Parkway|Pkwy|Highway|Hwy|Alley|Aly)\.?(?:\s*,?\s*(?:Apt|Apartment|Suite|Ste|Unit|#|No\.?)\s*\w+)?\b/gi, replacement: '[REDACTED_ADDRESS]' },
+  // Bare IPv4:port (e.g. ECONNREFUSED 192.168.1.5:5432)
+  { pattern: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d{1,5})?\b/g, replacement: '[REDACTED_HOST]' },
+  // DB auth failure messages (e.g. "password authentication failed for user \"dbuser\"")
+  { pattern: /password authentication failed(?:\s+for\s+user\s+[^\s,;)}\]]+)?/gi, replacement: '[REDACTED_AUTH]' },
 ];
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -290,22 +290,25 @@ export function getClientIP(request: Request): string {
     return realIP;
   }
 
-  const cloudflareIp = request.headers.get("cf-connecting-ip");
-  if (cloudflareIp) {
-    return cloudflareIp;
-  }
+  // CDN headers (Cloudflare) — only trust when explicitly configured
+  const trustCdnHeaders = process.env.TRUST_CDN_HEADERS === "true";
+  if (trustCdnHeaders) {
+    const cloudflareIp = request.headers.get("cf-connecting-ip");
+    if (cloudflareIp) {
+      return cloudflareIp;
+    }
 
-  const trueClientIp = request.headers.get("true-client-ip");
-  if (trueClientIp) {
-    return trueClientIp;
+    const trueClientIp = request.headers.get("true-client-ip");
+    if (trueClientIp) {
+      return trueClientIp;
+    }
   }
 
   // Proxy fallback for non-Vercel environments.
   const forwarded = getFirstForwardedIp(request.headers.get("x-forwarded-for"));
   const shouldTrustForwarded =
     process.env.NODE_ENV === "development"
-    || process.env.TRUST_PROXY === "true"
-    || Boolean(request.headers.get("x-forwarded-proto"));
+    || process.env.TRUST_PROXY === "true";
 
   if (forwarded && shouldTrustForwarded) {
     return forwarded;
@@ -329,21 +332,24 @@ export function getClientIPFromHeaders(headersList: Headers): string {
     return realIP;
   }
 
-  const cloudflareIp = headersList.get("cf-connecting-ip");
-  if (cloudflareIp) {
-    return cloudflareIp;
-  }
+  // CDN headers (Cloudflare) — only trust when explicitly configured
+  const trustCdnHeaders = process.env.TRUST_CDN_HEADERS === "true";
+  if (trustCdnHeaders) {
+    const cloudflareIp = headersList.get("cf-connecting-ip");
+    if (cloudflareIp) {
+      return cloudflareIp;
+    }
 
-  const trueClientIp = headersList.get("true-client-ip");
-  if (trueClientIp) {
-    return trueClientIp;
+    const trueClientIp = headersList.get("true-client-ip");
+    if (trueClientIp) {
+      return trueClientIp;
+    }
   }
 
   const forwarded = getFirstForwardedIp(headersList.get("x-forwarded-for"));
   const shouldTrustForwarded =
     process.env.NODE_ENV === "development"
-    || process.env.TRUST_PROXY === "true"
-    || Boolean(headersList.get("x-forwarded-proto"));
+    || process.env.TRUST_PROXY === "true";
 
   if (forwarded && shouldTrustForwarded) {
     return forwarded;

--- a/src/lib/search-types.ts
+++ b/src/lib/search-types.ts
@@ -111,7 +111,6 @@ export interface MapListingData {
   title: string;
   price: number;
   availableSlots: number;
-  ownerId?: string;
   images: string[];
   location: {
     lat: number;

--- a/src/lib/search/search-orchestrator.ts
+++ b/src/lib/search/search-orchestrator.ts
@@ -7,7 +7,7 @@
 
 import { executeSearchV2 } from "./search-v2-service";
 import { getListingsPaginated } from "@/lib/data";
-import { logger } from "@/lib/logger";
+import { logger, sanitizeErrorMessage } from "@/lib/logger";
 import type { PaginatedResultHybrid, ListingData } from "@/lib/data";
 import type { V2MapData } from "@/contexts/SearchV2DataContext";
 import type { FilterParams } from "@/lib/search-params";
@@ -79,7 +79,7 @@ export async function orchestrateSearch(
     } catch (err) {
       logger.sync.error("Search listings fetch failed", {
         action: "getListingsPaginated",
-        error: err instanceof Error ? err.message : "Unknown error",
+        error: sanitizeErrorMessage(err),
       });
       // Security: Always use generic message for user-facing fetchError.
       // Raw err.message may contain DB connection strings or internal IPs.

--- a/src/lib/search/search-orchestrator.ts
+++ b/src/lib/search/search-orchestrator.ts
@@ -81,11 +81,9 @@ export async function orchestrateSearch(
         action: "getListingsPaginated",
         error: err instanceof Error ? err.message : "Unknown error",
       });
-      // M4 fix: error details already sanitized in logger above; fetchError
-      // is internal (not in API response body), so preserve message for page UI
-      fetchError = err instanceof Error
-        ? err.message
-        : "Unable to load listings. Please try again.";
+      // Security: Always use generic message for user-facing fetchError.
+      // Raw err.message may contain DB connection strings or internal IPs.
+      fetchError = "Unable to load listings. Please try again.";
       // Provide empty fallback to render gracefully
       paginatedResult = {
         items: [],


### PR DESCRIPTION
## Summary

Fixes all 14 security and logic issues (1 CRITICAL, 13 HIGH) identified in a 5-agent Opus 4.6 security audit of ~80 search-related files. No DB migrations. All fixes are backward-compatible.

### Security Hardening (T1-T5)
- **T1**: Sanitize CSS selector fallback in `ListScrollBridge` when `CSS.escape` unavailable
- **T2**: Gate CDN IP headers (`cf-connecting-ip`, `true-client-ip`) behind `TRUST_CDN_HEADERS` env var to prevent rate-limit bypass
- **T3**: Use `crypto.timingSafeEqual` for cron Bearer token comparison (both cron routes)
- **T4 (CRITICAL)**: Remove `ownerId` from entire map pipeline (interface, SQL, GeoJSON, popup) to prevent user enumeration via map markers
- **T5**: `getCursorSecret()` now throws on every call in production when missing (not just first)

### Search Logic Fixes (T6-T9)
- **T6**: Replace raw `err.message` with generic user-facing error; sanitize server logs with `sanitizeErrorMessage`
- **T7**: Skip `ts_rank_cd` in ORDER BY for keyset pagination queries (cursor doesn't capture rank)
- **T8**: Remove redundant `withRetry` wrapper — V1 fallback IS the retry mechanism
- **T9**: Return empty facets early for unbounded requests (no bounds + no query) to prevent DoS

### Client UX Fixes (T10-T14)
- **T10**: Validate GeoJSON coordinates for NaN/Infinity/out-of-range before rendering map markers
- **T11**: Add `viewportHeight` to `getRubberbandOffset` useCallback deps (stale closure fix)
- **T12**: Add document-level `touchend`/`touchcancel` to prevent stuck drag state in bottom sheet
- **T13**: Guard force-sync with `isDrawerOpen` to preserve pending filter edits
- **T14**: Track `isSearching` setTimeout in ref; remove dead `AbortController` code

### Review Fixes
- Sanitize server-side error log in search orchestrator (was passing raw `err.message`)
- Remove duplicate "View Listing" button from map popup (UX regression from T4)
- Add IP:port and auth-failure redaction patterns to `sanitizeErrorMessage`

## Verification

- **Lint**: 0 errors (220 pre-existing warnings)
- **Typecheck**: Clean pass
- **Tests**: 232 suites, 5417 tests passed
- **Codex review**: 2 rounds — all HIGH findings resolved

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 5417 tests pass
- [x] search-orchestrator security test confirms no raw error leak
- [x] Logger redaction patterns verified for IP:port and auth failures
- [ ] CI pipeline full suite
- [ ] Manual smoke test: search page map popups no longer expose ownerId

🤖 Generated with [Claude Code](https://claude.com/claude-code)