### PR TITLE
feat: Airbnb-style zero-result prevention for map & filter drawer

### DIFF
--- a/src/__tests__/components/filters/filter-chip-utils.test.ts
+++ b/src/__tests__/components/filters/filter-chip-utils.test.ts
@@ -3,6 +3,7 @@ import {
   removeFilterFromUrl,
   clearAllFilters,
   hasFilterChips,
+  hasAnyFilter,
   type FilterChipData,
 } from "@/components/filters/filter-chip-utils";
 
@@ -567,6 +568,38 @@ describe("filter-chip-utils", () => {
       expect(preserved.get("minPrice")).toBeNull();
       expect(preserved.get("amenities")).toBeNull();
       expect(preserved.get("nearMatches")).toBeNull();
+    });
+  });
+
+  describe("hasAnyFilter", () => {
+    it("returns false for empty params", () => {
+      expect(hasAnyFilter(new URLSearchParams())).toBe(false);
+    });
+
+    it("returns true for a price filter", () => {
+      expect(hasAnyFilter(new URLSearchParams("maxPrice=1500"))).toBe(true);
+    });
+
+    it("returns false for nearMatches=0", () => {
+      expect(hasAnyFilter(new URLSearchParams("nearMatches=0"))).toBe(false);
+    });
+
+    it("returns false for nearMatches=false", () => {
+      expect(hasAnyFilter(new URLSearchParams("nearMatches=false"))).toBe(
+        false,
+      );
+    });
+
+    it("returns true for nearMatches=1", () => {
+      expect(hasAnyFilter(new URLSearchParams("nearMatches=1"))).toBe(true);
+    });
+
+    it("returns false for roomType=any", () => {
+      expect(hasAnyFilter(new URLSearchParams("roomType=any"))).toBe(false);
+    });
+
+    it("returns false for empty string values", () => {
+      expect(hasAnyFilter(new URLSearchParams("maxPrice="))).toBe(false);
     });
   });
 

--- a/src/__tests__/components/filters/filter-chip-utils.test.ts
+++ b/src/__tests__/components/filters/filter-chip-utils.test.ts
@@ -2,7 +2,6 @@ import {
   urlToFilterChips,
   removeFilterFromUrl,
   clearAllFilters,
-  hasFilterChips,
   hasAnyFilter,
   type FilterChipData,
 } from "@/components/filters/filter-chip-utils";
@@ -603,35 +602,4 @@ describe("filter-chip-utils", () => {
     });
   });
 
-  describe("hasFilterChips", () => {
-    it("returns true when filters are present", () => {
-      const params = new URLSearchParams("minPrice=500");
-
-      expect(hasFilterChips(params)).toBe(true);
-    });
-
-    it("returns false when no filters present", () => {
-      const params = new URLSearchParams("");
-
-      expect(hasFilterChips(params)).toBe(false);
-    });
-
-    it("returns false when only preserved params present", () => {
-      const params = new URLSearchParams("q=downtown&sort=newest&lat=37.7");
-
-      expect(hasFilterChips(params)).toBe(false);
-    });
-
-    it("returns false when only UI state params present", () => {
-      const params = new URLSearchParams("page=3&view=map");
-
-      expect(hasFilterChips(params)).toBe(false);
-    });
-
-    it("returns true when filters mixed with preserved params", () => {
-      const params = new URLSearchParams("q=downtown&minPrice=500");
-
-      expect(hasFilterChips(params)).toBe(true);
-    });
-  });
 });

--- a/src/__tests__/components/map/MapEmptyState.test.tsx
+++ b/src/__tests__/components/map/MapEmptyState.test.tsx
@@ -144,4 +144,36 @@ describe("MapEmptyState", () => {
     render(<MapEmptyState {...defaultProps} searchParams={params} />);
     expect(screen.getByText("Include near matches")).toBeInTheDocument();
   });
+
+  // --- Task 1.4: Smart filter removal suggestions ---
+
+  it("shows up to 2 filter suggestions when filters active", () => {
+    const params = new URLSearchParams("maxPrice=1500&roomType=Private+Room");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    const suggestions = screen.getByTestId("filter-suggestions");
+    const pills = suggestions.querySelectorAll("[data-testid='suggestion-pill']");
+    expect(pills.length).toBeGreaterThanOrEqual(1);
+    expect(pills.length).toBeLessThanOrEqual(2);
+  });
+
+  it("clicking a suggestion removes that filter from URL", () => {
+    const params = new URLSearchParams("maxPrice=1500&roomType=Private+Room&q=Austin");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    // First suggestion should be price (highest priority)
+    const suggestions = screen.getByTestId("filter-suggestions");
+    const firstPill = suggestions.querySelector("[data-testid='suggestion-pill']");
+    expect(firstPill).toBeTruthy();
+    fireEvent.click(firstPill!);
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const pushedUrl = mockPush.mock.calls[0][0];
+    // Price should be removed
+    expect(pushedUrl).not.toContain("maxPrice");
+    // Other filters preserved
+    expect(pushedUrl).toContain("roomType");
+  });
+
+  it("shows no suggestions when no filters active", () => {
+    render(<MapEmptyState {...defaultProps} searchParams={new URLSearchParams()} />);
+    expect(screen.queryByTestId("filter-suggestions")).not.toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/map/MapEmptyState.test.tsx
+++ b/src/__tests__/components/map/MapEmptyState.test.tsx
@@ -104,4 +104,44 @@ describe("MapEmptyState", () => {
     expect(chips.length).toBeLessThanOrEqual(3);
     expect(screen.getByText(/\+\d+ more/)).toBeInTheDocument();
   });
+
+  // --- Task 1.3: Near matches toggle ---
+
+  it('shows "Include near matches" when price filter active and nearMatches not set', () => {
+    const params = new URLSearchParams("maxPrice=1500");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    expect(screen.getByText("Include near matches")).toBeInTheDocument();
+  });
+
+  it("hides near matches button when nearMatches=1 already in URL", () => {
+    const params = new URLSearchParams("maxPrice=1500&nearMatches=1");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    expect(screen.queryByText("Include near matches")).not.toBeInTheDocument();
+  });
+
+  it("hides near matches button when no price or date filters", () => {
+    const params = new URLSearchParams("roomType=Private+Room");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    expect(screen.queryByText("Include near matches")).not.toBeInTheDocument();
+  });
+
+  it("clicking near matches adds nearMatches=1 to URL", () => {
+    const params = new URLSearchParams("maxPrice=1500&q=Austin");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    fireEvent.click(screen.getByText("Include near matches"));
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const pushedUrl = mockPush.mock.calls[0][0];
+    expect(pushedUrl).toContain("nearMatches=1");
+    expect(pushedUrl).toContain("maxPrice=1500");
+  });
+
+  it('shows "Include near matches" when moveInDate filter active', () => {
+    // Use a future date to pass validation
+    const futureDate = new Date();
+    futureDate.setMonth(futureDate.getMonth() + 1);
+    const dateStr = futureDate.toISOString().split("T")[0];
+    const params = new URLSearchParams(`moveInDate=${dateStr}`);
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    expect(screen.getByText("Include near matches")).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/map/MapEmptyState.test.tsx
+++ b/src/__tests__/components/map/MapEmptyState.test.tsx
@@ -55,4 +55,53 @@ describe("MapEmptyState", () => {
     fireEvent.click(screen.getByText("Zoom out"));
     expect(onZoomOut).toHaveBeenCalledTimes(1);
   });
+
+  // --- Task 1.2: Filter chips and clear-filters ---
+
+  it("shows active filter chips when URL has filters", () => {
+    const params = new URLSearchParams("maxPrice=1500&roomType=Private+Room");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    expect(screen.getByText("Max $1,500")).toBeInTheDocument();
+    expect(screen.getByText("Private Room")).toBeInTheDocument();
+  });
+
+  it("shows no filter section when no filters active", () => {
+    render(<MapEmptyState {...defaultProps} searchParams={new URLSearchParams()} />);
+    expect(screen.queryByText("Clear filters")).not.toBeInTheDocument();
+  });
+
+  it('renders "Clear filters" button when filters are active', () => {
+    const params = new URLSearchParams("maxPrice=1500");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    expect(screen.getByText("Clear filters")).toBeInTheDocument();
+  });
+
+  it('does NOT render "Clear filters" when no filters', () => {
+    render(<MapEmptyState {...defaultProps} searchParams={new URLSearchParams()} />);
+    expect(screen.queryByText("Clear filters")).not.toBeInTheDocument();
+  });
+
+  it('clicking "Clear filters" navigates to cleared URL', () => {
+    const params = new URLSearchParams("maxPrice=1500&q=Austin&lat=30&lng=-97");
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    fireEvent.click(screen.getByText("Clear filters"));
+    // Should preserve q, lat, lng but remove maxPrice
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const pushedUrl = mockPush.mock.calls[0][0];
+    expect(pushedUrl).toContain("q=Austin");
+    expect(pushedUrl).toContain("lat=30");
+    expect(pushedUrl).not.toContain("maxPrice");
+  });
+
+  it("shows max 3 chips with overflow indicator", () => {
+    const params = new URLSearchParams(
+      "maxPrice=1500&roomType=Private+Room&leaseDuration=6+months&amenities=Wifi&amenities=AC"
+    );
+    render(<MapEmptyState {...defaultProps} searchParams={params} />);
+    // Should show 3 chips + overflow
+    const chipContainer = screen.getByTestId("filter-chips");
+    const chips = chipContainer.querySelectorAll("[data-testid='filter-chip']");
+    expect(chips.length).toBeLessThanOrEqual(3);
+    expect(screen.getByText(/\+\d+ more/)).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/map/MapEmptyState.test.tsx
+++ b/src/__tests__/components/map/MapEmptyState.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    [key: string]: unknown;
+  }) => <button {...props}>{children}</button>,
+}));
+
+import { MapEmptyState } from "@/components/map/MapEmptyState";
+
+describe("MapEmptyState", () => {
+  const defaultProps = {
+    onZoomOut: jest.fn(),
+    searchParams: new URLSearchParams(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it('renders heading "No listings in this area"', () => {
+    render(<MapEmptyState {...defaultProps} />);
+    expect(screen.getByText("No listings in this area")).toBeInTheDocument();
+  });
+
+  it('renders "Zoom out" button', () => {
+    render(<MapEmptyState {...defaultProps} />);
+    expect(screen.getByText("Zoom out")).toBeInTheDocument();
+  });
+
+  it("calls onZoomOut when zoom button clicked", () => {
+    const onZoomOut = jest.fn();
+    render(<MapEmptyState {...defaultProps} onZoomOut={onZoomOut} />);
+    fireEvent.click(screen.getByText("Zoom out"));
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/components/search/DrawerZeroState.test.tsx
+++ b/src/__tests__/components/search/DrawerZeroState.test.tsx
@@ -65,4 +65,15 @@ describe("DrawerZeroState", () => {
     fireEvent.click(screen.getByText("Remove date filter"));
     expect(mockOnRemove).toHaveBeenCalledWith(suggestions[1]);
   });
+
+  it("has role=status and aria-live=polite for screen readers", () => {
+    const suggestions: FilterSuggestion[] = [
+      { type: "price", label: "Remove price filter", priority: 1 },
+    ];
+    render(
+      <DrawerZeroState suggestions={suggestions} onRemoveSuggestion={mockOnRemove} />
+    );
+    const container = screen.getByRole("status");
+    expect(container).toHaveAttribute("aria-live", "polite");
+  });
 });

--- a/src/__tests__/components/search/DrawerZeroState.test.tsx
+++ b/src/__tests__/components/search/DrawerZeroState.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DrawerZeroState } from "@/components/search/DrawerZeroState";
+import type { FilterSuggestion } from "@/lib/near-matches";
+
+describe("DrawerZeroState", () => {
+  const mockOnRemove = jest.fn();
+
+  beforeEach(() => {
+    mockOnRemove.mockClear();
+  });
+
+  it("renders nothing when no suggestions", () => {
+    const { container } = render(
+      <DrawerZeroState suggestions={[]} onRemoveSuggestion={mockOnRemove} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders "No exact matches" warning text', () => {
+    const suggestions: FilterSuggestion[] = [
+      { type: "price", label: "Remove price filter", priority: 1 },
+    ];
+    render(
+      <DrawerZeroState
+        suggestions={suggestions}
+        onRemoveSuggestion={mockOnRemove}
+      />
+    );
+    expect(screen.getByText("No exact matches for these filters")).toBeInTheDocument();
+  });
+
+  it("renders at most 2 suggestion pills", () => {
+    const suggestions: FilterSuggestion[] = [
+      { type: "price", label: "Remove price filter", priority: 1 },
+      { type: "date", label: "Remove date filter", priority: 2 },
+      { type: "roomType", label: "Remove room type filter", priority: 3 },
+    ];
+    render(
+      <DrawerZeroState
+        suggestions={suggestions}
+        onRemoveSuggestion={mockOnRemove}
+      />
+    );
+    expect(screen.getByText("Remove price filter")).toBeInTheDocument();
+    expect(screen.getByText("Remove date filter")).toBeInTheDocument();
+    expect(screen.queryByText("Remove room type filter")).not.toBeInTheDocument();
+  });
+
+  it("calls onRemoveSuggestion with correct suggestion on click", () => {
+    const suggestions: FilterSuggestion[] = [
+      { type: "price", label: "Remove price filter", priority: 1 },
+      { type: "date", label: "Remove date filter", priority: 2 },
+    ];
+    render(
+      <DrawerZeroState
+        suggestions={suggestions}
+        onRemoveSuggestion={mockOnRemove}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Remove price filter"));
+    expect(mockOnRemove).toHaveBeenCalledWith(suggestions[0]);
+
+    fireEvent.click(screen.getByText("Remove date filter"));
+    expect(mockOnRemove).toHaveBeenCalledWith(suggestions[1]);
+  });
+});

--- a/src/__tests__/lib/pending-to-filter-params.test.ts
+++ b/src/__tests__/lib/pending-to-filter-params.test.ts
@@ -1,0 +1,93 @@
+import { pendingToFilterParams } from "@/lib/pending-to-filter-params";
+import type { BatchedFilterValues } from "@/hooks/useBatchedFilters";
+
+describe("pendingToFilterParams", () => {
+  it("converts empty BatchedFilterValues to FilterParams with all undefined", () => {
+    const pending: BatchedFilterValues = {
+      minPrice: "",
+      maxPrice: "",
+      roomType: "",
+      leaseDuration: "",
+      moveInDate: "",
+      amenities: [],
+      houseRules: [],
+      languages: [],
+      genderPreference: "",
+      householdGender: "",
+    };
+
+    const result = pendingToFilterParams(pending);
+
+    expect(result.minPrice).toBeUndefined();
+    expect(result.maxPrice).toBeUndefined();
+    expect(result.roomType).toBeUndefined();
+    expect(result.leaseDuration).toBeUndefined();
+    expect(result.moveInDate).toBeUndefined();
+    expect(result.amenities).toBeUndefined();
+    expect(result.houseRules).toBeUndefined();
+  });
+
+  it("converts populated values (strings to numbers for price)", () => {
+    const pending: BatchedFilterValues = {
+      minPrice: "500",
+      maxPrice: "1500",
+      roomType: "Private Room",
+      leaseDuration: "6 months",
+      moveInDate: "2026-06-01",
+      amenities: ["Wifi", "AC"],
+      houseRules: ["No Smoking"],
+      languages: ["en"],
+      genderPreference: "female",
+      householdGender: "ALL_FEMALE",
+    };
+
+    const result = pendingToFilterParams(pending);
+
+    expect(result.minPrice).toBe(500);
+    expect(result.maxPrice).toBe(1500);
+    expect(result.roomType).toBe("Private Room");
+    expect(result.leaseDuration).toBe("6 months");
+    expect(result.moveInDate).toBe("2026-06-01");
+    expect(result.amenities).toEqual(["Wifi", "AC"]);
+    expect(result.houseRules).toEqual(["No Smoking"]);
+  });
+
+  it('handles minPrice="0" correctly (falsy but valid)', () => {
+    const pending: BatchedFilterValues = {
+      minPrice: "0",
+      maxPrice: "1000",
+      roomType: "",
+      leaseDuration: "",
+      moveInDate: "",
+      amenities: [],
+      houseRules: [],
+      languages: [],
+      genderPreference: "",
+      householdGender: "",
+    };
+
+    const result = pendingToFilterParams(pending);
+
+    expect(result.minPrice).toBe(0);
+    expect(result.maxPrice).toBe(1000);
+  });
+
+  it("handles non-numeric price strings gracefully", () => {
+    const pending: BatchedFilterValues = {
+      minPrice: "abc",
+      maxPrice: "",
+      roomType: "",
+      leaseDuration: "",
+      moveInDate: "",
+      amenities: [],
+      houseRules: [],
+      languages: [],
+      genderPreference: "",
+      householdGender: "",
+    };
+
+    const result = pendingToFilterParams(pending);
+
+    expect(result.minPrice).toBeUndefined();
+  });
+});

--- a/src/__tests__/lib/search/map-near-matches.test.ts
+++ b/src/__tests__/lib/search/map-near-matches.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for near-match filter expansion applied to map listings.
+ *
+ * Validates that expandFiltersForNearMatches produces correct expanded
+ * params that would be used in getSearchDocMapListingsInternal when
+ * nearMatches=true is set.
+ */
+import { expandFiltersForNearMatches, NEAR_MATCH_RULES } from "@/lib/near-matches";
+import type { FilterParams } from "@/lib/search-params";
+
+describe("expandFiltersForNearMatches for map listings", () => {
+  it("returns listings in expanded price range when nearMatches=true", () => {
+    const params: FilterParams = {
+      maxPrice: 1000,
+      bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.3 },
+      nearMatches: true,
+    };
+
+    const { expanded, expandedDimension } = expandFiltersForNearMatches(params);
+
+    expect(expandedDimension).toBe("price");
+    // maxPrice should be expanded by +10%: 1000 * 1.1 = 1100
+    expect(expanded.maxPrice).toBe(Math.ceil(1000 * (1 + NEAR_MATCH_RULES.price.expandPercent / 100)));
+    expect(expanded.maxPrice).toBe(1100);
+    // Bounds should be preserved
+    expect(expanded.bounds).toEqual(params.bounds);
+  });
+
+  it("expands minPrice down by percentage", () => {
+    const params: FilterParams = {
+      minPrice: 500,
+      maxPrice: 1000,
+      bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.3 },
+      nearMatches: true,
+    };
+
+    const { expanded } = expandFiltersForNearMatches(params);
+
+    // minPrice should be expanded by -10%: 500 * 0.9 = 450
+    expect(expanded.minPrice).toBe(Math.floor(500 * (1 - NEAR_MATCH_RULES.price.expandPercent / 100)));
+    expect(expanded.minPrice).toBe(450);
+    expect(expanded.maxPrice).toBe(1100);
+  });
+
+  it("expands moveInDate when no price filters", () => {
+    const futureDate = new Date();
+    futureDate.setMonth(futureDate.getMonth() + 2);
+    const dateStr = futureDate.toISOString().split("T")[0];
+
+    const params: FilterParams = {
+      moveInDate: dateStr,
+      bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.3 },
+      nearMatches: true,
+    };
+
+    const { expanded, expandedDimension } = expandFiltersForNearMatches(params);
+
+    expect(expandedDimension).toBe("date");
+    // Date should be expanded back by 7 days
+    const expandedDate = new Date(expanded.moveInDate + "T00:00:00");
+    const originalDate = new Date(dateStr + "T00:00:00");
+    const daysDiff = Math.round(
+      (originalDate.getTime() - expandedDate.getTime()) / (1000 * 60 * 60 * 24)
+    );
+    expect(daysDiff).toBe(NEAR_MATCH_RULES.date.expandDays);
+  });
+
+  it("returns null expansion when no expandable filters", () => {
+    const params: FilterParams = {
+      roomType: "Private Room",
+      bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.3 },
+      nearMatches: true,
+    };
+
+    const { expandedDimension } = expandFiltersForNearMatches(params);
+
+    expect(expandedDimension).toBeNull();
+  });
+
+  it("preserves all non-expanded filter params", () => {
+    const params: FilterParams = {
+      maxPrice: 1000,
+      roomType: "Private Room",
+      amenities: ["Wifi", "AC"],
+      bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.3 },
+      nearMatches: true,
+    };
+
+    const { expanded } = expandFiltersForNearMatches(params);
+
+    expect(expanded.roomType).toBe("Private Room");
+    expect(expanded.amenities).toEqual(["Wifi", "AC"]);
+    expect(expanded.bounds).toEqual(params.bounds);
+  });
+});

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -27,7 +27,7 @@ import { useMapBounds, useMapMovedBanner } from '@/contexts/MapBoundsContext';
 import { MapMovedBanner } from './map/MapMovedBanner';
 import { MapGestureHint } from './map/MapGestureHint';
 import { MapEmptyState } from './map/MapEmptyState';
-import { hasAnyFilter } from './filters/filter-chip-utils';
+import { hasAnyFilter, FILTER_PARAM_KEYS } from './filters/filter-chip-utils';
 import { PrivacyCircle } from './map/PrivacyCircle';
 import { fixMarkerWrapperRole } from './map/fixMarkerA11y';
 import { BoundaryLayer } from './map/BoundaryLayer';
@@ -1026,8 +1026,7 @@ export default function MapComponent({
     // Auto-zoom-out: when map loads empty with no active filters, zoom out once
     // Build a key from non-bounds params so we reset per search context
     const nonBoundsParamsKey = useMemo(() => {
-        const keys = ['q', 'minPrice', 'maxPrice', 'amenities', 'houseRules', 'languages',
-            'roomType', 'leaseDuration', 'moveInDate', 'genderPreference', 'householdGender', 'nearMatches'];
+        const keys = ['q', ...FILTER_PARAM_KEYS];
         return keys.map(k => `${k}=${searchParams.getAll(k).sort().join(',')}`).join('&');
     }, [searchParams]);
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -26,6 +26,7 @@ import { useSearchTransitionSafe } from '@/contexts/SearchTransitionContext';
 import { useMapBounds, useMapMovedBanner } from '@/contexts/MapBoundsContext';
 import { MapMovedBanner } from './map/MapMovedBanner';
 import { MapGestureHint } from './map/MapGestureHint';
+import { MapEmptyState } from './map/MapEmptyState';
 import { PrivacyCircle } from './map/PrivacyCircle';
 import { fixMarkerWrapperRole } from './map/fixMarkerA11y';
 import { BoundaryLayer } from './map/BoundaryLayer';
@@ -2277,33 +2278,22 @@ export default function MapComponent({
 
             {/* Empty state overlay - when map is loaded but no listings in viewport */}
             {isMapLoaded && !areTilesLoading && !isSearching && listings.length === 0 && (
-                <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 bg-white dark:bg-zinc-800 rounded-xl shadow-lg border border-zinc-200 dark:border-zinc-700 px-5 py-4 max-w-[280px] text-center pointer-events-auto">
-                    <MapPin className="w-8 h-8 text-zinc-300 dark:text-zinc-600 mx-auto mb-2" aria-hidden="true" />
-                    <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">No listings in this area</p>
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">Try zooming out or adjusting your filters</p>
-                    <div className="flex gap-2 justify-center">
-                        <Button
-                            size="sm"
-                            variant="outline"
-                            className="text-xs h-8"
-                            onClick={() => {
-                                if (!mapRef.current) return;
-                                const map = mapRef.current.getMap();
-                                if (!map) return;
-                                const currentZoom = map.getZoom();
-                                setProgrammaticMove(true);
-                                // P2-FIX (#167): Add safety timeout to clear programmatic flag if moveEnd doesn't fire
-                                if (programmaticClearTimeoutRef.current) clearTimeout(programmaticClearTimeoutRef.current);
-                                programmaticClearTimeoutRef.current = setTimeout(() => {
-                                    if (isProgrammaticMoveRef.current) setProgrammaticMove(false);
-                                }, PROGRAMMATIC_MOVE_TIMEOUT_MS);
-                                mapRef.current.flyTo({ zoom: Math.max(currentZoom - 2, 1), duration: 800 });
-                            }}
-                        >
-                            Zoom out
-                        </Button>
-                    </div>
-                </div>
+                <MapEmptyState
+                    searchParams={searchParams}
+                    onZoomOut={() => {
+                        if (!mapRef.current) return;
+                        const map = mapRef.current.getMap();
+                        if (!map) return;
+                        const currentZoom = map.getZoom();
+                        setProgrammaticMove(true);
+                        // P2-FIX (#167): Add safety timeout to clear programmatic flag if moveEnd doesn't fire
+                        if (programmaticClearTimeoutRef.current) clearTimeout(programmaticClearTimeoutRef.current);
+                        programmaticClearTimeoutRef.current = setTimeout(() => {
+                            if (isProgrammaticMoveRef.current) setProgrammaticMove(false);
+                        }, PROGRAMMATIC_MOVE_TIMEOUT_MS);
+                        mapRef.current.flyTo({ zoom: Math.max(currentZoom - 2, 1), duration: 800 });
+                    }}
+                />
             )}
         </div>
     );

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -25,7 +25,7 @@ import { useRecentSearches, type RecentSearch, type RecentSearchFilters } from '
 import { useDebouncedFilterCount } from '@/hooks/useDebouncedFilterCount';
 import { useFacets } from '@/hooks/useFacets';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
-import { useBatchedFilters } from '@/hooks/useBatchedFilters';
+import { useBatchedFilters, type BatchedFilterValues } from '@/hooks/useBatchedFilters';
 import { pendingToFilterParams } from '@/lib/pending-to-filter-params';
 import { generateFilterSuggestions, type FilterSuggestion } from '@/lib/near-matches';
 
@@ -36,9 +36,9 @@ const SEARCH_DEBOUNCE_MS = 300;
 const AMENITY_OPTIONS = VALID_AMENITIES;
 const HOUSE_RULE_OPTIONS = VALID_HOUSE_RULES;
 
-const ARRAY_PENDING_KEYS = new Set<string>(['amenities', 'houseRules', 'languages']);
+const ARRAY_PENDING_KEYS = new Set<keyof BatchedFilterValues>(['amenities', 'houseRules', 'languages']);
 
-const SUGGESTION_TYPE_TO_PENDING_KEYS: Record<string, string[]> = {
+const SUGGESTION_TYPE_TO_PENDING_KEYS: Record<FilterSuggestion['type'], Array<keyof BatchedFilterValues>> = {
     price: ['minPrice', 'maxPrice'],
     date: ['moveInDate'],
     roomType: ['roomType'],
@@ -594,12 +594,11 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
     // P4: Handle removing a filter suggestion from the drawer
     const handleRemoveFilterSuggestion = useCallback((suggestion: FilterSuggestion) => {
         const keys = SUGGESTION_TYPE_TO_PENDING_KEYS[suggestion.type];
-        if (!keys) return;
-        const updates: Record<string, string | string[]> = {};
+        const updates: Partial<BatchedFilterValues> = {};
         for (const key of keys) {
-            updates[key] = ARRAY_PENDING_KEYS.has(key) ? [] : '';
+            (updates as Record<string, string | string[]>)[key] = ARRAY_PENDING_KEYS.has(key) ? [] : '';
         }
-        setPending(updates as Partial<typeof pending>);
+        setPending(updates);
     }, [setPending]);
 
     // Show warning when user has typed location but not selected from dropdown

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -584,12 +584,20 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
         });
     }, [priceAbsoluteMin, priceAbsoluteMax, setPending]);
 
+    // Snapshot pending when count drops to 0 — prevents stale suggestions during rapid filter changes
+    const pendingAtZeroRef = useRef(pending);
+    useEffect(() => {
+        if (count === 0 && !isCountLoading) {
+            pendingAtZeroRef.current = pending;
+        }
+    }, [count, isCountLoading, pending]);
+
     // P4: Compute drawer suggestions when count drops to 0
     const drawerSuggestions = useMemo(() => {
         if (count !== 0 || isCountLoading) return [];
-        const fp = pendingToFilterParams(pending);
+        const fp = pendingToFilterParams(pendingAtZeroRef.current);
         return generateFilterSuggestions(fp, count).slice(0, 2);
-    }, [count, isCountLoading, pending]);
+    }, [count, isCountLoading]);
 
     // P4: Handle removing a filter suggestion from the drawer
     const handleRemoveFilterSuggestion = useCallback((suggestion: FilterSuggestion) => {

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -26,6 +26,8 @@ import { useDebouncedFilterCount } from '@/hooks/useDebouncedFilterCount';
 import { useFacets } from '@/hooks/useFacets';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useBatchedFilters } from '@/hooks/useBatchedFilters';
+import { pendingToFilterParams } from '@/lib/pending-to-filter-params';
+import { generateFilterSuggestions, type FilterSuggestion } from '@/lib/near-matches';
 
 // Debounce delay in milliseconds
 const SEARCH_DEBOUNCE_MS = 300;
@@ -538,6 +540,7 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
     // P3-NEW-b: Get dynamic count for FilterModal button
     // filtersDirty is now computed by useBatchedFilters
     const {
+        count,
         formattedCount,
         isLoading: isCountLoading,
         boundsRequired,
@@ -570,6 +573,31 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
             });
         });
     }, [priceAbsoluteMin, priceAbsoluteMax, setPending]);
+
+    // P4: Compute drawer suggestions when count drops to 0
+    const drawerSuggestions = useMemo(() => {
+        if (count === null || count >= 5 || isCountLoading) return [];
+        const fp = pendingToFilterParams(pending);
+        return generateFilterSuggestions(fp, count).slice(0, 2);
+    }, [count, isCountLoading, pending]);
+
+    // P4: Handle removing a filter suggestion from the drawer
+    const handleRemoveFilterSuggestion = useCallback((suggestion: FilterSuggestion) => {
+        const SUGGESTION_TYPE_TO_PENDING_KEYS: Record<FilterSuggestion['type'], (keyof typeof pending)[]> = {
+            price: ['minPrice', 'maxPrice'],
+            date: ['moveInDate'],
+            roomType: ['roomType'],
+            amenities: ['amenities'],
+            leaseDuration: ['leaseDuration'],
+        };
+        const keys = SUGGESTION_TYPE_TO_PENDING_KEYS[suggestion.type];
+        if (!keys) return;
+        const updates: Record<string, string | string[]> = {};
+        for (const key of keys) {
+            updates[key] = Array.isArray(pending[key]) ? [] : '';
+        }
+        setPending(updates as Partial<typeof pending>);
+    }, [pending, setPending]);
 
     // Show warning when user has typed location but not selected from dropdown
     const showLocationWarning = location.trim().length > 2 && !selectedCoords;
@@ -893,6 +921,10 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
                 formattedCount={formattedCount}
                 isCountLoading={isCountLoading}
                 boundsRequired={boundsRequired}
+                // P4: Zero-count warning
+                count={count}
+                drawerSuggestions={drawerSuggestions}
+                onRemoveFilterSuggestion={handleRemoveFilterSuggestion}
             />
         </div>
     );

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -36,6 +36,16 @@ const SEARCH_DEBOUNCE_MS = 300;
 const AMENITY_OPTIONS = VALID_AMENITIES;
 const HOUSE_RULE_OPTIONS = VALID_HOUSE_RULES;
 
+const ARRAY_PENDING_KEYS = new Set<string>(['amenities', 'houseRules', 'languages']);
+
+const SUGGESTION_TYPE_TO_PENDING_KEYS: Record<string, string[]> = {
+    price: ['minPrice', 'maxPrice'],
+    date: ['moveInDate'],
+    roomType: ['roomType'],
+    amenities: ['amenities'],
+    leaseDuration: ['leaseDuration'],
+};
+
 // Room type options for inline filter tabs
 const ROOM_TYPE_TABS = [
     { value: 'any', label: 'All', icon: LayoutGrid },
@@ -576,28 +586,21 @@ export default function SearchForm({ variant = 'default' }: { variant?: 'default
 
     // P4: Compute drawer suggestions when count drops to 0
     const drawerSuggestions = useMemo(() => {
-        if (count === null || count >= 5 || isCountLoading) return [];
+        if (count !== 0 || isCountLoading) return [];
         const fp = pendingToFilterParams(pending);
         return generateFilterSuggestions(fp, count).slice(0, 2);
     }, [count, isCountLoading, pending]);
 
     // P4: Handle removing a filter suggestion from the drawer
     const handleRemoveFilterSuggestion = useCallback((suggestion: FilterSuggestion) => {
-        const SUGGESTION_TYPE_TO_PENDING_KEYS: Record<FilterSuggestion['type'], (keyof typeof pending)[]> = {
-            price: ['minPrice', 'maxPrice'],
-            date: ['moveInDate'],
-            roomType: ['roomType'],
-            amenities: ['amenities'],
-            leaseDuration: ['leaseDuration'],
-        };
         const keys = SUGGESTION_TYPE_TO_PENDING_KEYS[suggestion.type];
         if (!keys) return;
         const updates: Record<string, string | string[]> = {};
         for (const key of keys) {
-            updates[key] = Array.isArray(pending[key]) ? [] : '';
+            updates[key] = ARRAY_PENDING_KEYS.has(key) ? [] : '';
         }
         setPending(updates as Partial<typeof pending>);
-    }, [pending, setPending]);
+    }, [setPending]);
 
     // Show warning when user has typed location but not selected from dropdown
     const showLocationWarning = location.trim().length > 2 && !selectedCoords;

--- a/src/components/filters/filter-chip-utils.ts
+++ b/src/components/filters/filter-chip-utils.ts
@@ -374,7 +374,9 @@ const FILTER_PARAM_KEYS = [
 export function hasAnyFilter(searchParams: URLSearchParams): boolean {
   return FILTER_PARAM_KEYS.some(k => {
     const v = searchParams.get(k);
-    return v !== null && v !== '' && v !== 'any';
+    if (v === null || v === '' || v === 'any') return false;
+    if (k === 'nearMatches' && (v === '0' || v === 'false')) return false;
+    return true;
   });
 }
 

--- a/src/components/filters/filter-chip-utils.ts
+++ b/src/components/filters/filter-chip-utils.ts
@@ -39,32 +39,6 @@ const PRESERVED_PARAMS = [
 ] as const;
 
 /**
- * Parameters that are UI state, not filters - should be ignored for chips.
- * Kept for documentation; prefixed to avoid unused variable warnings.
- */
-const _UI_STATE_PARAMS = ["page", "view", "drawerOpen"] as const;
-
-/**
- * Parameters that represent filter state (eligible for chips).
- * Used for reference; prefixed to avoid unused variable warnings.
- */
-const _FILTER_PARAMS = [
-  "minPrice",
-  "maxPrice",
-  "amenities",
-  "houseRules",
-  "languages",
-  "roomType",
-  "leaseDuration",
-  "moveInDate",
-  "nearMatches",
-  "genderPreference",
-  "householdGender",
-] as const;
-
-type _FilterParamKey = (typeof _FILTER_PARAMS)[number];
-
-/**
  * Format a price value for display
  */
 function formatPrice(value: number | string): string {
@@ -364,7 +338,7 @@ export function clearAllFilters(searchParams: URLSearchParams): string {
 }
 
 /** Quick check — returns true if any filter param is set (no chip construction) */
-const FILTER_PARAM_KEYS = [
+export const FILTER_PARAM_KEYS = [
   'minPrice', 'maxPrice', 'minBudget', 'maxBudget',
   'moveInDate', 'roomType', 'leaseDuration',
   'amenities', 'houseRules', 'languages',

--- a/src/components/filters/filter-chip-utils.ts
+++ b/src/components/filters/filter-chip-utils.ts
@@ -353,10 +353,3 @@ export function hasAnyFilter(searchParams: URLSearchParams): boolean {
     return true;
   });
 }
-
-/**
- * Check if there are any filter chips to display
- */
-export function hasFilterChips(searchParams: URLSearchParams): boolean {
-  return urlToFilterChips(searchParams).length > 0;
-}

--- a/src/components/filters/filter-chip-utils.ts
+++ b/src/components/filters/filter-chip-utils.ts
@@ -363,6 +363,21 @@ export function clearAllFilters(searchParams: URLSearchParams): string {
   return newParams.toString();
 }
 
+/** Quick check — returns true if any filter param is set (no chip construction) */
+const FILTER_PARAM_KEYS = [
+  'minPrice', 'maxPrice', 'minBudget', 'maxBudget',
+  'moveInDate', 'roomType', 'leaseDuration',
+  'amenities', 'houseRules', 'languages',
+  'genderPreference', 'householdGender', 'nearMatches',
+] as const;
+
+export function hasAnyFilter(searchParams: URLSearchParams): boolean {
+  return FILTER_PARAM_KEYS.some(k => {
+    const v = searchParams.get(k);
+    return v !== null && v !== '' && v !== 'any';
+  });
+}
+
 /**
  * Check if there are any filter chips to display
  */

--- a/src/components/map/MapEmptyState.tsx
+++ b/src/components/map/MapEmptyState.tsx
@@ -1,20 +1,61 @@
 'use client';
 
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import { MapPin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  urlToFilterChips,
+  clearAllFilters,
+} from '@/components/filters/filter-chip-utils';
+
+const MAX_VISIBLE_CHIPS = 3;
 
 interface MapEmptyStateProps {
   onZoomOut: () => void;
   searchParams: URLSearchParams;
 }
 
-export function MapEmptyState({ onZoomOut }: MapEmptyStateProps) {
+export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
+  const router = useRouter();
+
+  const chips = useMemo(() => urlToFilterChips(searchParams), [searchParams]);
+  const filtersActive = chips.length > 0;
+  const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
+  const overflowCount = chips.length - MAX_VISIBLE_CHIPS;
+
+  const handleClearFilters = () => {
+    const cleared = clearAllFilters(searchParams);
+    router.push('/search?' + cleared);
+  };
+
   return (
-    <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 bg-white dark:bg-zinc-800 rounded-xl shadow-lg border border-zinc-200 dark:border-zinc-700 px-5 py-4 max-w-[280px] text-center pointer-events-auto">
+    <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 bg-white dark:bg-zinc-800 rounded-xl shadow-lg border border-zinc-200 dark:border-zinc-700 px-5 py-4 max-w-[320px] text-center pointer-events-auto">
       <MapPin className="w-8 h-8 text-zinc-300 dark:text-zinc-600 mx-auto mb-2" aria-hidden="true" />
       <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">No listings in this area</p>
       <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">Try zooming out or adjusting your filters</p>
-      <div className="flex gap-2 justify-center">
+
+      {/* Active filter chips */}
+      {filtersActive && (
+        <div className="flex flex-wrap gap-1.5 justify-center mb-3" data-testid="filter-chips">
+          {visibleChips.map((chip) => (
+            <span
+              key={chip.id}
+              data-testid="filter-chip"
+              className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300"
+            >
+              {chip.label}
+            </span>
+          ))}
+          {overflowCount > 0 && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-zinc-100 dark:bg-zinc-700 text-zinc-500 dark:text-zinc-400">
+              +{overflowCount} more
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-center flex-wrap">
         <Button
           size="sm"
           variant="outline"
@@ -23,6 +64,16 @@ export function MapEmptyState({ onZoomOut }: MapEmptyStateProps) {
         >
           Zoom out
         </Button>
+        {filtersActive && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="text-xs h-8"
+            onClick={handleClearFilters}
+          >
+            Clear filters
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/map/MapEmptyState.tsx
+++ b/src/components/map/MapEmptyState.tsx
@@ -115,7 +115,7 @@ export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
               onClick={() => handleRemoveSuggestion(suggestion)}
             >
               <X className="w-3 h-3" aria-hidden="true" />
-              Remove {suggestion.type}
+              {suggestion.label}
             </button>
           ))}
         </div>

--- a/src/components/map/MapEmptyState.tsx
+++ b/src/components/map/MapEmptyState.tsx
@@ -2,12 +2,13 @@
 
 import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { MapPin } from 'lucide-react';
+import { MapPin, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   urlToFilterChips,
   clearAllFilters,
 } from '@/components/filters/filter-chip-utils';
+import { getPriceParam } from '@/lib/search-params';
 
 const MAX_VISIBLE_CHIPS = 3;
 
@@ -24,9 +25,24 @@ export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
   const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
   const overflowCount = chips.length - MAX_VISIBLE_CHIPS;
 
+  // Near matches: show toggle when price or date filters are active and nearMatches not already on
+  const hasPriceOrDateFilter = useMemo(() => {
+    const hasPrice = getPriceParam(searchParams, 'min') !== undefined || getPriceParam(searchParams, 'max') !== undefined;
+    const hasDate = !!searchParams.get('moveInDate');
+    return hasPrice || hasDate;
+  }, [searchParams]);
+  const nearMatchesAlreadyOn = searchParams.get('nearMatches') === '1';
+  const showNearMatches = hasPriceOrDateFilter && !nearMatchesAlreadyOn;
+
   const handleClearFilters = () => {
     const cleared = clearAllFilters(searchParams);
     router.push('/search?' + cleared);
+  };
+
+  const handleNearMatches = () => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set('nearMatches', '1');
+    router.push('/search?' + newParams.toString());
   };
 
   return (
@@ -72,6 +88,17 @@ export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
             onClick={handleClearFilters}
           >
             Clear filters
+          </Button>
+        )}
+        {showNearMatches && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="text-xs h-8"
+            onClick={handleNearMatches}
+          >
+            <Sparkles className="w-3 h-3 mr-1" aria-hidden="true" />
+            Include near matches
           </Button>
         )}
       </div>

--- a/src/components/map/MapEmptyState.tsx
+++ b/src/components/map/MapEmptyState.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { MapPin } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface MapEmptyStateProps {
+  onZoomOut: () => void;
+  searchParams: URLSearchParams;
+}
+
+export function MapEmptyState({ onZoomOut }: MapEmptyStateProps) {
+  return (
+    <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 bg-white dark:bg-zinc-800 rounded-xl shadow-lg border border-zinc-200 dark:border-zinc-700 px-5 py-4 max-w-[280px] text-center pointer-events-auto">
+      <MapPin className="w-8 h-8 text-zinc-300 dark:text-zinc-600 mx-auto mb-2" aria-hidden="true" />
+      <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">No listings in this area</p>
+      <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">Try zooming out or adjusting your filters</p>
+      <div className="flex gap-2 justify-center">
+        <Button
+          size="sm"
+          variant="outline"
+          className="text-xs h-8"
+          onClick={onZoomOut}
+        >
+          Zoom out
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/MapEmptyState.tsx
+++ b/src/components/map/MapEmptyState.tsx
@@ -66,7 +66,7 @@ export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
 
   const handleRemoveSuggestion = (suggestion: FilterSuggestion) => {
     const newParams = new URLSearchParams(searchParams);
-    const keysToRemove = SUGGESTION_TYPE_TO_PARAMS[suggestion.type] || [];
+    const keysToRemove = SUGGESTION_TYPE_TO_PARAMS[suggestion.type];
     for (const key of keysToRemove) {
       newParams.delete(key);
     }
@@ -107,9 +107,9 @@ export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
       {/* Smart filter suggestions */}
       {suggestions.length > 0 && (
         <div className="flex flex-wrap gap-1.5 justify-center mb-3" data-testid="filter-suggestions">
-          {suggestions.map((suggestion) => (
+          {suggestions.map((suggestion, i) => (
             <button
-              key={suggestion.type}
+              key={`${suggestion.type}-${i}`}
               data-testid="suggestion-pill"
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-950/60 transition-colors"
               onClick={() => handleRemoveSuggestion(suggestion)}

--- a/src/components/search/DrawerZeroState.tsx
+++ b/src/components/search/DrawerZeroState.tsx
@@ -1,0 +1,43 @@
+import { AlertCircle, X } from "lucide-react";
+import type { FilterSuggestion } from "@/lib/near-matches";
+
+const MAX_PILLS = 2;
+
+interface DrawerZeroStateProps {
+  suggestions: FilterSuggestion[];
+  onRemoveSuggestion: (suggestion: FilterSuggestion) => void;
+}
+
+export function DrawerZeroState({
+  suggestions,
+  onRemoveSuggestion,
+}: DrawerZeroStateProps) {
+  if (suggestions.length === 0) return null;
+
+  const visible = suggestions.slice(0, MAX_PILLS);
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 dark:border-amber-800 dark:bg-amber-950/30">
+      <div className="flex items-center gap-2">
+        <AlertCircle className="h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+        <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+          No exact matches for these filters
+        </p>
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {visible.map((s) => (
+          <button
+            key={s.type}
+            type="button"
+            onClick={() => onRemoveSuggestion(s)}
+            className="inline-flex items-center gap-1 rounded-full border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-200 dark:hover:bg-amber-800/50"
+          >
+            {s.label}
+            <X className="h-3 w-3" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/search/DrawerZeroState.tsx
+++ b/src/components/search/DrawerZeroState.tsx
@@ -17,7 +17,7 @@ export function DrawerZeroState({
   const visible = suggestions.slice(0, MAX_PILLS);
 
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 dark:border-amber-800 dark:bg-amber-950/30">
+    <div role="status" aria-live="polite" className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 dark:border-amber-800 dark:bg-amber-950/30">
       <div className="flex items-center gap-2">
         <AlertCircle className="h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
         <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
@@ -34,7 +34,7 @@ export function DrawerZeroState({
             className="inline-flex items-center gap-1 rounded-full border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-200 dark:hover:bg-amber-800/50"
           >
             {s.label}
-            <X className="h-3 w-3" />
+            <X className="h-3 w-3" aria-hidden="true" />
           </button>
         ))}
       </div>

--- a/src/components/search/DrawerZeroState.tsx
+++ b/src/components/search/DrawerZeroState.tsx
@@ -26,9 +26,9 @@ export function DrawerZeroState({
       </div>
 
       <div className="mt-2 flex flex-wrap gap-1.5">
-        {visible.map((s) => (
+        {visible.map((s, i) => (
           <button
-            key={s.type}
+            key={`${s.type}-${i}`}
             type="button"
             onClick={() => onRemoveSuggestion(s)}
             className="inline-flex items-center gap-1 rounded-full border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-200 dark:hover:bg-amber-800/50"

--- a/src/lib/pending-to-filter-params.ts
+++ b/src/lib/pending-to-filter-params.ts
@@ -1,0 +1,29 @@
+import type { BatchedFilterValues } from "@/hooks/useBatchedFilters";
+import type { FilterParams } from "@/lib/search-params";
+
+/**
+ * Converts string-based BatchedFilterValues (from the filter drawer UI state)
+ * into typed FilterParams (used by search/near-match logic).
+ *
+ * Empty strings and empty arrays become undefined so they are omitted from queries.
+ */
+export function pendingToFilterParams(pending: BatchedFilterValues): FilterParams {
+  const parsePrice = (val: string): number | undefined => {
+    if (val === "") return undefined;
+    const num = Number(val);
+    return Number.isFinite(num) ? num : undefined;
+  };
+
+  return {
+    minPrice: parsePrice(pending.minPrice),
+    maxPrice: parsePrice(pending.maxPrice),
+    roomType: pending.roomType || undefined,
+    leaseDuration: pending.leaseDuration || undefined,
+    moveInDate: pending.moveInDate || undefined,
+    amenities: pending.amenities.length > 0 ? pending.amenities : undefined,
+    houseRules: pending.houseRules.length > 0 ? pending.houseRules : undefined,
+    languages: pending.languages.length > 0 ? pending.languages : undefined,
+    genderPreference: pending.genderPreference || undefined,
+    householdGender: pending.householdGender || undefined,
+  };
+}

--- a/src/lib/search-types.ts
+++ b/src/lib/search-types.ts
@@ -92,7 +92,7 @@ export interface PaginatedResult<T> {
 export type PaginatedResultHybrid<T> = {
   items: T[];
   total: number | null; // null when count is expensive (>100 results)
-  page: number;
+  page: number | null;
   limit: number;
   totalPages: number | null;
   hasNextPage?: boolean;

--- a/src/lib/search/search-doc-queries.ts
+++ b/src/lib/search/search-doc-queries.ts
@@ -751,11 +751,18 @@ async function getSearchDocMapListingsInternal(
     );
   }
 
+  // Apply near-match filter expansion for map markers
+  let effectiveParams = params;
+  if (params.nearMatches) {
+    const { expanded } = expandFiltersForNearMatches(params);
+    effectiveParams = { ...expanded, nearMatches: false }; // prevent recursion
+  }
+
   const {
     conditions,
     params: queryParams,
     paramIndex,
-  } = buildSearchDocWhereConditions(params);
+  } = buildSearchDocWhereConditions(effectiveParams);
   const whereClause = joinWhereClauseWithSecurityInvariant(conditions);
 
   // Query with minimal fields for map markers


### PR DESCRIPTION
## Summary

- **Enhanced Map Empty State**: Extracted `MapEmptyState` component with active filter chips, "Clear filters" button, "Include near matches" toggle, and smart filter removal suggestions
- **Auto-Zoom-Out**: Map automatically zooms out once when results are empty and no filters are active (respects user panning)
- **Near-Match Map Support**: Map query now applies `expandFiltersForNearMatches` when `nearMatches=1` is set, matching the existing list behavior
- **Filter Drawer Zero-Count Warning**: When the filter count drops to 0, the apply button turns amber and a `DrawerZeroState` component shows suggestions to broaden filters

## Files Changed

| Area | Files |
|------|-------|
| New components | `MapEmptyState.tsx`, `DrawerZeroState.tsx` |
| New lib | `pending-to-filter-params.ts` |
| Modified | `Map.tsx`, `FilterModal.tsx`, `SearchForm.tsx`, `search-doc-queries.ts` |
| New tests | `MapEmptyState.test.tsx`, `DrawerZeroState.test.tsx`, `pending-to-filter-params.test.ts`, `map-near-matches.test.ts` |
| Updated tests | `FilterModal.test.tsx`, `Map.test.tsx` |

## Test Plan

- [x] Lint passes
- [x] Typecheck passes
- [x] 127 tests pass across 7 affected test suites (58 new tests)
- [ ] Manual: Navigate to `/search` with restrictive filters → map shows enhanced empty state with chips, suggestions, clear/near-match buttons
- [ ] Manual: Pan map to empty ocean area → auto-zooms out once
- [ ] Manual: Add `nearMatches=1` with price filter → map shows expanded results
- [ ] Manual: Open filter drawer, set very restrictive filters → apply button turns amber, suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)