### PR TITLE
feat(map): smooth Airbnb-like map experience with spatial cache

### DIFF
--- a/src/__tests__/api/map-listings.test.ts
+++ b/src/__tests__/api/map-listings.test.ts
@@ -130,10 +130,10 @@ describe("Map Listings API", () => {
         (getMapListings as jest.Mock).mockResolvedValue(mockListings);
 
         const request = createRequest({
-          minLng: "-130.0",
-          maxLng: "-120.0", // 10 degree span > 5 degree limit
-          minLat: "30.0",
-          maxLat: "42.0", // 12 degree span > 5 degree limit
+          minLng: "-135.0",
+          maxLng: "-120.0", // 15 degree span > 10 degree limit
+          minLat: "28.0",
+          maxLat: "43.0", // 15 degree span > 10 degree limit
         });
 
         const response = await GET(request);
@@ -141,14 +141,13 @@ describe("Map Listings API", () => {
         // P1-5: Should clamp and succeed, not reject
         expect(response.status).toBe(200);
 
-        // Verify bounds were clamped to max span (5 degrees)
+        // Verify bounds were clamped to max span (10 degrees)
         expect(getMapListings).toHaveBeenCalledWith(
           expect.objectContaining({
             bounds: expect.objectContaining({
-              // Center preserved at -125, span reduced to 5
+              // Center preserved, span reduced to 10
               minLng: expect.any(Number),
               maxLng: expect.any(Number),
-              // Center preserved at 36, span reduced to 5
               minLat: expect.any(Number),
               maxLat: expect.any(Number),
             }),
@@ -159,8 +158,8 @@ describe("Map Listings API", () => {
         const call = (getMapListings as jest.Mock).mock.calls[0][0];
         const lngSpan = call.bounds.maxLng - call.bounds.minLng;
         const latSpan = call.bounds.maxLat - call.bounds.minLat;
-        expect(lngSpan).toBeLessThanOrEqual(5); // MAX_LNG_SPAN
-        expect(latSpan).toBeLessThanOrEqual(5); // MAX_LAT_SPAN
+        expect(lngSpan).toBeLessThanOrEqual(10); // MAX_LNG_SPAN
+        expect(latSpan).toBeLessThanOrEqual(10); // MAX_LAT_SPAN
       });
 
       it("returns 400 for latitude out of range", async () => {

--- a/src/__tests__/components/PersistentMapWrapper.networking.test.tsx
+++ b/src/__tests__/components/PersistentMapWrapper.networking.test.tsx
@@ -529,11 +529,11 @@ describe("PersistentMapWrapper - Networking & Race Conditions (P1-7)", () => {
 
   describe("Viewport Validation", () => {
     it("clamps oversized viewport and still fetches (P1-5 client-side check)", async () => {
-      // Set oversized bounds (> MAX_LAT_SPAN/MAX_LNG_SPAN of 5)
-      mockSearchParams.set("minLng", "-130.0");
-      mockSearchParams.set("maxLng", "-120.0"); // 10 degree span
-      mockSearchParams.set("minLat", "30.0");
-      mockSearchParams.set("maxLat", "42.0"); // 12 degree span
+      // Set oversized bounds (> MAX_LAT_SPAN/MAX_LNG_SPAN of 10)
+      mockSearchParams.set("minLng", "-135.0");
+      mockSearchParams.set("maxLng", "-120.0"); // 15 degree span
+      mockSearchParams.set("minLat", "28.0");
+      mockSearchParams.set("maxLat", "43.0"); // 15 degree span
 
       const { queryByRole } = render(
         <PersistentMapWrapper shouldRenderMap={true} />
@@ -553,7 +553,7 @@ describe("PersistentMapWrapper - Networking & Race Conditions (P1-7)", () => {
     });
 
     it("does not show error for valid viewport bounds", async () => {
-      // Valid bounds (within MAX_LAT_SPAN/MAX_LNG_SPAN of 5)
+      // Valid bounds (within MAX_LAT_SPAN/MAX_LNG_SPAN of 10)
       mockSearchParams.set("minLng", "-122.5");
       mockSearchParams.set("maxLng", "-122.0"); // 0.5 degree span
       mockSearchParams.set("minLat", "37.5");

--- a/src/__tests__/lib/bounds-clamping.test.ts
+++ b/src/__tests__/lib/bounds-clamping.test.ts
@@ -178,8 +178,8 @@ describe('clampBoundsToMaxSpan', () => {
   describe('edge cases', () => {
     it('respects latitude limits (-85 to 85)', () => {
       const bounds: MapBounds = {
-        minLat: 80.0,
-        maxLat: 90.0, // Would go above 85 after clamping
+        minLat: 75.0,
+        maxLat: 90.0, // 15° span > MAX_LAT_SPAN, triggers clamping near pole
         minLng: -74.0,
         maxLng: -72.0,
       };

--- a/src/__tests__/lib/data-bounds-clamping.test.ts
+++ b/src/__tests__/lib/data-bounds-clamping.test.ts
@@ -90,9 +90,9 @@ describe('bounds clamping helpers for getListingsPaginated', () => {
     it('returns false when bounds are exactly at limit', () => {
       const exactLimitBounds: MapBounds = {
         minLat: 40.0,
-        maxLat: 40.0 + MAX_LAT_SPAN, // Exactly 5° span
+        maxLat: 40.0 + MAX_LAT_SPAN, // Exactly at span limit
         minLng: -74.0,
-        maxLng: -74.0 + MAX_LNG_SPAN, // Exactly 5° span
+        maxLng: -74.0 + MAX_LNG_SPAN, // Exactly at span limit
       };
 
       expect(shouldClampBounds(exactLimitBounds)).toBe(false);

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -88,7 +88,7 @@ jest.mock("@/lib/search-params", () => ({
 // Mock validation
 jest.mock("@/lib/validation", () => ({
   clampBoundsToMaxSpan: jest.fn(),
-  MAX_LAT_SPAN: 5,
+  MAX_LAT_SPAN: 10,
   MAX_LNG_SPAN: 10,
 }));
 

--- a/src/__tests__/lib/validation.test.ts
+++ b/src/__tests__/lib/validation.test.ts
@@ -52,12 +52,12 @@ describe('Bounds Validation', () => {
     });
 
     it('clamps oversized bounds instead of rejecting (P1-5)', () => {
-      // 10 degree span - larger than MAX_LAT_SPAN (5)
+      // 15 degree span - larger than MAX_LAT_SPAN (10)
       const result = validateAndParseBounds(
-        '-122',
-        '-112', // 10 degree lng span
-        '30',
-        '40'    // 10 degree lat span
+        '-125',
+        '-110', // 15 degree lng span
+        '28',
+        '43'    // 15 degree lat span
       );
 
       // P1-5: Should clamp, not reject
@@ -74,7 +74,7 @@ describe('Bounds Validation', () => {
 
     it('preserves antimeridian crossing when within span limits', () => {
       // minLng > maxLng indicates antimeridian crossing
-      // 178 to -178 = 4 degrees (within MAX_LNG_SPAN of 5)
+      // 178 to -178 = 4 degrees (within MAX_LNG_SPAN of 10)
       const result = validateAndParseBounds('178', '-178', '35', '38');
       expect(result.valid).toBe(true);
       expect(result.bounds?.minLng).toBe(178);
@@ -82,7 +82,7 @@ describe('Bounds Validation', () => {
     });
 
     it('clamps oversized antimeridian crossing bounds', () => {
-      // 170 to -170 = 20 degrees (exceeds MAX_LNG_SPAN of 5)
+      // 170 to -170 = 20 degrees (exceeds MAX_LNG_SPAN of 10)
       const result = validateAndParseBounds('170', '-170', '35', '38');
       expect(result.valid).toBe(true);
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -31,7 +31,7 @@ import { fixMarkerWrapperRole } from './map/fixMarkerA11y';
 import { BoundaryLayer } from './map/BoundaryLayer';
 import { UserMarker, useUserPin } from './map/UserMarker';
 import { POILayer } from './map/POILayer';
-import { PROGRAMMATIC_MOVE_TIMEOUT_MS } from '@/lib/constants';
+import { PROGRAMMATIC_MOVE_TIMEOUT_MS, USA_MAX_BOUNDS, MAP_MIN_ZOOM } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
 /** Parse a string to float and validate it's a finite number within an optional range. */
@@ -445,10 +445,10 @@ export default function MapComponent({
     const hoverScrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
     // Map-move auto-search tuning:
-    // - 300ms debounce keeps panning smooth while staying responsive.
-    // - 1000ms minimum interval prevents request bursts during continuous drag.
-    const MAP_MOVE_SEARCH_DEBOUNCE_MS = 300;
-    const MIN_SEARCH_INTERVAL_MS = 1000;
+    // - 400ms debounce reduces "fetch too soon during momentum scroll"
+    // - 800ms minimum interval allows more responsive intentional panning
+    const MAP_MOVE_SEARCH_DEBOUNCE_MS = 400;
+    const MIN_SEARCH_INTERVAL_MS = 800;
 
     // E2E testing instrumentation - track map instance for persistence tests
     // Only runs when NEXT_PUBLIC_E2E=true to avoid polluting production
@@ -1615,9 +1615,9 @@ export default function MapComponent({
                 </div>
             )}
 
-            {/* Tile loading indicator */}
+            {/* Tile loading indicator - transparent overlay with small centered pill */}
             {isMapLoaded && areTilesLoading && (
-                <div className="absolute inset-0 bg-zinc-100/30 dark:bg-zinc-900/30 backdrop-blur-[1px] z-10 flex items-center justify-center pointer-events-none" role="status" aria-label="Loading map tiles" aria-live="polite">
+                <div className="absolute inset-0 bg-transparent z-10 flex items-center justify-center pointer-events-none" role="status" aria-label="Loading map tiles" aria-live="polite">
                     <div className="flex items-center gap-2 bg-white/90 dark:bg-zinc-800/90 px-4 py-2 rounded-lg shadow-sm">
                         <Loader2 className="w-4 h-4 animate-spin text-zinc-600 dark:text-zinc-300" aria-hidden="true" />
                         <span className="text-sm text-zinc-600 dark:text-zinc-300">Loading tiles...</span>
@@ -1678,6 +1678,8 @@ export default function MapComponent({
                     : { initialViewState }
                 )}
                 style={{ width: '100%', height: '100%' }}
+                maxBounds={USA_MAX_BOUNDS}
+                minZoom={MAP_MIN_ZOOM}
                 scrollZoom={true}
                 dragPan={true}
                 doubleClickZoom={true}

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -392,6 +392,12 @@ export default function PersistentMapWrapper({
   const [error, setError] = useState<string | null>(null);
   // Stale-while-revalidate: keep last successful fetch visible during loading
   const previousListingsRef = useRef<MapListingData[]>([]);
+  // Spatial cache: instant markers from previously-viewed areas on zoom-out/pan-back
+  const spatialCacheRef = useRef<Map<string, SpatialCacheEntry>>(new Map());
+  // Track last-fetched padded bounds for hysteresis (skip fetch when viewport mostly contained)
+  const lastFetchedBoundsRef = useRef<ViewportBounds | null>(null);
+  // Track filter key to invalidate spatial cache on filter change
+  const lastFilterKeyRef = useRef<string>("");
   // P2-FIX (#151): Separate info messages from errors - info is non-blocking (no retry needed)
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
 
@@ -487,13 +493,6 @@ export default function PersistentMapWrapper({
   const abortControllerRef = useRef<AbortController | null>(null);
   const retryCountRef = useRef<number>(0);
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  // Spatial cache: instant markers from previously-viewed areas on zoom-out/pan-back
-  const spatialCacheRef = useRef<Map<string, SpatialCacheEntry>>(new Map());
-  // Track last-fetched padded bounds for hysteresis (skip fetch when viewport mostly contained)
-  const lastFetchedBoundsRef = useRef<ViewportBounds | null>(null);
-  // Track filter key to invalidate spatial cache on filter change
-  const lastFilterKeyRef = useRef<string>("");
 
   const fetchListings = useCallback(
     async (paramsString: string, signal?: AbortSignal, fetchBounds?: ViewportBounds) => {

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -33,17 +33,105 @@ import { buildCanonicalFilterParamsFromSearchParams } from "@/lib/search-params"
 import { useSearchV2Data, type V2MapData } from "@/contexts/SearchV2DataContext";
 import { MapErrorBoundary } from "@/components/map/MapErrorBoundary";
 import { useSearchTransitionSafe } from "@/contexts/SearchTransitionContext";
+import {
+  MAX_LAT_SPAN,
+  MAX_LNG_SPAN,
+  LAT_MIN,
+  LAT_MAX,
+  LNG_MIN,
+  LNG_MAX,
+  BOUNDS_EPSILON,
+} from "@/lib/constants";
 
 // CRITICAL: Lazy import - only loads when component renders
 // This defers the maplibre-gl bundle until user opts to see map
 const LazyDynamicMap = lazy(() => import("./DynamicMap"));
 
-// Maximum viewport span (matches server-side validation)
-// Increased from 2 to 5 (~550km) to allow regional zoom-out views
-// with Mapbox native clustering handling dense markers at wide viewports
-const MAX_LAT_SPAN = 5;
-const MAX_LNG_SPAN = 5;
 const MAP_FETCH_DEBOUNCE_MS = 250;
+
+// Spatial cache constants
+const SPATIAL_CACHE_MAX_ENTRIES = 20;
+const MAX_MAP_MARKERS = 200;
+const FETCH_BOUNDS_PADDING = 0.2;
+
+// ============================================
+// Spatial Cache Types & Utilities
+// ============================================
+
+interface ViewportBounds {
+  minLat: number;
+  maxLat: number;
+  minLng: number;
+  maxLng: number;
+}
+
+interface SpatialCacheEntry {
+  listings: MapListingData[];
+  bounds: ViewportBounds;
+  filterKey: string;
+  timestamp: number;
+}
+
+/** Quantize bounds to BOUNDS_EPSILON precision for cache key */
+function quantizeBounds(bounds: ViewportBounds): string {
+  const q = (n: number) => (Math.round(n / BOUNDS_EPSILON) * BOUNDS_EPSILON).toFixed(3);
+  return `${q(bounds.minLat)},${q(bounds.maxLat)},${q(bounds.minLng)},${q(bounds.maxLng)}`;
+}
+
+/**
+ * Check if inner viewport is mostly contained within outer bounds.
+ * Returns true if overlap >= threshold of inner's area (skip fetch).
+ */
+function isViewportContained(inner: ViewportBounds, outer: ViewportBounds, threshold = 0.9): boolean {
+  const innerArea = (inner.maxLat - inner.minLat) * (inner.maxLng - inner.minLng);
+  if (innerArea <= 0) return false;
+
+  const overlapMinLat = Math.max(inner.minLat, outer.minLat);
+  const overlapMaxLat = Math.min(inner.maxLat, outer.maxLat);
+  const overlapMinLng = Math.max(inner.minLng, outer.minLng);
+  const overlapMaxLng = Math.min(inner.maxLng, outer.maxLng);
+
+  if (overlapMinLat >= overlapMaxLat || overlapMinLng >= overlapMaxLng) return false;
+
+  const overlapArea = (overlapMaxLat - overlapMinLat) * (overlapMaxLng - overlapMinLng);
+  return (overlapArea / innerArea) >= threshold;
+}
+
+/**
+ * Pad viewport bounds by a percentage to pre-fetch nearby listings.
+ * Clamps to LAT/LNG limits and MAX_LAT/LNG_SPAN.
+ */
+function padBounds(bounds: ViewportBounds, padding = FETCH_BOUNDS_PADDING): ViewportBounds {
+  const latSpan = bounds.maxLat - bounds.minLat;
+  const lngSpan = bounds.maxLng - bounds.minLng;
+  const padded = {
+    minLat: Math.max(LAT_MIN, bounds.minLat - latSpan * padding),
+    maxLat: Math.min(LAT_MAX, bounds.maxLat + latSpan * padding),
+    minLng: Math.max(LNG_MIN, bounds.minLng - lngSpan * padding),
+    maxLng: Math.min(LNG_MAX, bounds.maxLng + lngSpan * padding),
+  };
+  // Clamp padded result to MAX_LAT/LNG_SPAN
+  const paddedLatSpan = padded.maxLat - padded.minLat;
+  const paddedLngSpan = padded.maxLng - padded.minLng;
+  if (paddedLatSpan > MAX_LAT_SPAN) {
+    const center = (padded.minLat + padded.maxLat) / 2;
+    padded.minLat = center - MAX_LAT_SPAN / 2;
+    padded.maxLat = center + MAX_LAT_SPAN / 2;
+  }
+  if (paddedLngSpan > MAX_LNG_SPAN) {
+    const center = (padded.minLng + padded.maxLng) / 2;
+    padded.minLng = center - MAX_LNG_SPAN / 2;
+    padded.maxLng = center + MAX_LNG_SPAN / 2;
+  }
+  return padded;
+}
+
+/** Build a filter-only key (excludes viewport params) for cache invalidation */
+function getFilterKey(searchParams: URLSearchParams): string {
+  const filtered = buildCanonicalFilterParamsFromSearchParams(searchParams);
+  filtered.sort();
+  return filtered.toString();
+}
 
 // Legacy map-relevant key list kept as explicit documentation and fallback shape.
 // The active serialization path uses canonical parser output so map/list stay in sync.
@@ -205,7 +293,7 @@ function MapLoadingPlaceholder() {
 function MapTransitionOverlay() {
   return (
     <div
-      className="absolute inset-0 z-10 bg-white/30 dark:bg-zinc-950/30 pointer-events-none flex items-start justify-center pt-20"
+      className="absolute inset-0 z-10 bg-transparent pointer-events-none flex items-start justify-center pt-20"
       role="status"
       aria-label="Updating map results"
     >
@@ -302,6 +390,8 @@ export default function PersistentMapWrapper({
   const [listings, setListings] = useState<MapListingData[]>([]);
   const [isFetchingMapData, setIsFetchingMapData] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Stale-while-revalidate: keep last successful fetch visible during loading
+  const previousListingsRef = useRef<MapListingData[]>([]);
   // P2-FIX (#151): Separate info messages from errors - info is non-blocking (no retry needed)
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
 
@@ -349,14 +439,47 @@ export default function PersistentMapWrapper({
 
   // Compute effective listings based on data source (v2 context or v1 fetch)
   // Memoized for stable reference to prevent unnecessary Map re-renders
+  // During V1 fetch: merge cached listings from overlapping areas for instant display
   const effectiveListings = useMemo(() => {
     // P2-FIX (#124): Use lastV2Data state (not ref) so memo properly recalculates
     const activeV2Data = isV2Enabled ? (v2MapData ?? lastV2Data) : null;
     if (activeV2Data) {
       return v2MapDataToListings(activeV2Data);
     }
+    // During V1 fetch, merge previous data + cached spatial data so markers never disappear
+    if (isFetchingMapData && previousListingsRef.current.length > 0) {
+      // Deduplicate by listing ID, cap at MAX_MAP_MARKERS
+      const seenIds = new Set<string>();
+      const merged: MapListingData[] = [];
+      // Start with current listings (highest priority)
+      for (const l of listings) {
+        if (!seenIds.has(l.id) && merged.length < MAX_MAP_MARKERS) {
+          seenIds.add(l.id);
+          merged.push(l);
+        }
+      }
+      // Add previous listings
+      for (const l of previousListingsRef.current) {
+        if (!seenIds.has(l.id) && merged.length < MAX_MAP_MARKERS) {
+          seenIds.add(l.id);
+          merged.push(l);
+        }
+      }
+      // Add from spatial cache entries that overlap current viewport
+      const currentFilterKey = lastFilterKeyRef.current;
+      for (const entry of spatialCacheRef.current.values()) {
+        if (entry.filterKey !== currentFilterKey) continue;
+        for (const l of entry.listings) {
+          if (!seenIds.has(l.id) && merged.length < MAX_MAP_MARKERS) {
+            seenIds.add(l.id);
+            merged.push(l);
+          }
+        }
+      }
+      return merged;
+    }
     return listings;
-  }, [isV2Enabled, v2MapData, lastV2Data, listings]);
+  }, [isV2Enabled, v2MapData, lastV2Data, listings, isFetchingMapData]);
 
   // Track current params to detect changes for debouncing
   const lastFetchedParamsRef = useRef<string | null>(null);
@@ -365,8 +488,15 @@ export default function PersistentMapWrapper({
   const retryCountRef = useRef<number>(0);
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  // Spatial cache: instant markers from previously-viewed areas on zoom-out/pan-back
+  const spatialCacheRef = useRef<Map<string, SpatialCacheEntry>>(new Map());
+  // Track last-fetched padded bounds for hysteresis (skip fetch when viewport mostly contained)
+  const lastFetchedBoundsRef = useRef<ViewportBounds | null>(null);
+  // Track filter key to invalidate spatial cache on filter change
+  const lastFilterKeyRef = useRef<string>("");
+
   const fetchListings = useCallback(
-    async (paramsString: string, signal?: AbortSignal) => {
+    async (paramsString: string, signal?: AbortSignal, fetchBounds?: ViewportBounds) => {
       setIsFetchingMapData(true);
       setError(null);
 
@@ -405,7 +535,7 @@ export default function PersistentMapWrapper({
 
             // Schedule automatic retry
             retryTimeoutRef.current = setTimeout(() => {
-              fetchListings(paramsString, signal);
+              fetchListings(paramsString, signal, fetchBounds);
             }, retryDelayMs);
 
             return; // Exit without throwing - retry will happen automatically
@@ -438,7 +568,35 @@ export default function PersistentMapWrapper({
         }
 
         const data = await response.json();
-        setListings(data.listings || []);
+        const fetched = data.listings || [];
+        previousListingsRef.current = fetched;
+        setListings(fetched);
+
+        // Store in spatial cache for instant zoom-out/pan-back display
+        if (fetchBounds) {
+          const cacheKey = quantizeBounds(fetchBounds);
+          const filterKey = lastFilterKeyRef.current;
+          spatialCacheRef.current.set(cacheKey, {
+            listings: fetched,
+            bounds: fetchBounds,
+            filterKey,
+            timestamp: Date.now(),
+          });
+          // LRU eviction: remove oldest entries beyond limit
+          if (spatialCacheRef.current.size > SPATIAL_CACHE_MAX_ENTRIES) {
+            let oldestKey: string | null = null;
+            let oldestTime = Infinity;
+            for (const [key, entry] of spatialCacheRef.current) {
+              if (entry.timestamp < oldestTime) {
+                oldestTime = entry.timestamp;
+                oldestKey = key;
+              }
+            }
+            if (oldestKey) spatialCacheRef.current.delete(oldestKey);
+          }
+          // Update last-fetched bounds for hysteresis checks
+          lastFetchedBoundsRef.current = fetchBounds;
+        }
 
         // Reset retry counter on successful fetch
         retryCountRef.current = 0;
@@ -567,6 +725,27 @@ export default function PersistentMapWrapper({
       return;
     }
 
+    // Parse current viewport bounds for spatial cache + hysteresis
+    const currentBounds: ViewportBounds = {
+      minLat: parseFloat(clampedSearchParams.get("minLat") || "0"),
+      maxLat: parseFloat(clampedSearchParams.get("maxLat") || "0"),
+      minLng: parseFloat(clampedSearchParams.get("minLng") || "0"),
+      maxLng: parseFloat(clampedSearchParams.get("maxLng") || "0"),
+    };
+
+    // Invalidate spatial cache when filters change
+    const currentFilterKey = getFilterKey(clampedSearchParams);
+    if (currentFilterKey !== lastFilterKeyRef.current) {
+      spatialCacheRef.current.clear();
+      lastFetchedBoundsRef.current = null;
+      lastFilterKeyRef.current = currentFilterKey;
+    }
+
+    // Viewport hysteresis: skip fetch if new viewport is mostly within last-fetched padded area
+    if (lastFetchedBoundsRef.current && isViewportContained(currentBounds, lastFetchedBoundsRef.current)) {
+      return;
+    }
+
     // Clear any pending fetch timeout
     if (fetchTimeoutRef.current) {
       clearTimeout(fetchTimeoutRef.current);
@@ -583,10 +762,21 @@ export default function PersistentMapWrapper({
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
 
+    // Pad fetch bounds by 20% to pre-fetch nearby listings (reduces fetches on small pans)
+    // Only the map's /api/map-listings fetch uses padded bounds.
+    // URL params (for list/page sync) continue using actual visible viewport — no conflict.
+    const paddedBounds = padBounds(currentBounds);
+    const paddedParams = new URLSearchParams(clampedSearchParams.toString());
+    paddedParams.set("minLat", paddedBounds.minLat.toString());
+    paddedParams.set("maxLat", paddedBounds.maxLat.toString());
+    paddedParams.set("minLng", paddedBounds.minLng.toString());
+    paddedParams.set("maxLng", paddedBounds.maxLng.toString());
+    const paddedParamsString = getMapRelevantParams(paddedParams);
+
     // Small debounce to coalesce rapid URL updates without adding noticeable lag.
     fetchTimeoutRef.current = setTimeout(() => {
       lastFetchedParamsRef.current = paramsString;
-      fetchListings(paramsString, abortController.signal);
+      fetchListings(paddedParamsString, abortController.signal, paddedBounds);
     }, MAP_FETCH_DEBOUNCE_MS);
 
     return () => {
@@ -662,14 +852,7 @@ export default function PersistentMapWrapper({
       {(isFetchingMapData || isListTransitioning || showV2LoadingOverlay) && (
         <MapDataLoadingBar />
       )}
-      {/* Marker loading shimmer - subtle overlay when map data is being fetched */}
-      {(isFetchingMapData || showV2LoadingOverlay) && !isListTransitioning && (
-        <div
-          className="absolute inset-0 z-10 pointer-events-none bg-white/10 dark:bg-zinc-950/10"
-          role="status"
-          aria-label="Loading listings"
-        />
-      )}
+      {/* Marker loading shimmer removed - stale-while-revalidate keeps old markers visible */}
       {/* Coordinated loading overlay - shows when list is transitioning (filter change) */}
       {isListTransitioning && <MapTransitionOverlay />}
       <MapErrorBoundary>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -52,15 +52,16 @@ export const LAT_OFFSET_DEGREES = 0.09;
 
 /**
  * Maximum viewport span for latitude (in degrees).
- * 5° ≈ 550km - allows regional views with clustering.
+ * 10° ≈ 1100km - allows seeing SF+LA or entire Northeast corridor.
+ * MapLibre clustering handles dense markers; DB protected with LIMIT 200.
  */
-export const MAX_LAT_SPAN = 5;
+export const MAX_LAT_SPAN = 10;
 
 /**
  * Maximum viewport span for longitude (in degrees).
- * 5° ≈ 550km at equator, less at higher latitudes.
+ * 10° ≈ 1100km at equator, less at higher latitudes.
  */
-export const MAX_LNG_SPAN = 5;
+export const MAX_LNG_SPAN = 10;
 
 // ============================================
 // Coordinate Limits (Web Mercator practical)
@@ -99,3 +100,16 @@ export const CLUSTER_THRESHOLD = 50;
 
 /** Bounds quantization for cache key normalization (~100m precision) */
 export const BOUNDS_EPSILON = 0.001;
+
+// ============================================
+// Map Viewport Restrictions
+// ============================================
+
+/** USA maxBounds for MapLibre — covers all 50 states including Alaska + Hawaii */
+export const USA_MAX_BOUNDS: [[number, number], [number, number]] = [
+  [-180, 17],  // SW corner: covers Hawaii (19N) + territories with margin
+  [-64, 72],   // NE corner: covers Alaska (71N) + Maine with margin
+];
+
+/** Minimum zoom level to prevent world-view zoom out */
+export const MAP_MIN_ZOOM = 3;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,44 @@
+# Smooth Map Experience (Airbnb-like)
+
+## Goal + Acceptance Criteria
+- Map feels instant and smooth: old markers never disappear during fetch
+- No heavy loading overlays (no blur, no tinted backgrounds)
+- Map restricted to USA bounds
+- Client-side spatial cache for instant zoom-out/pan-back
+- Wider viewport support (10-degree span)
+- All existing tests pass
+
+## Scope
+- `src/lib/constants.ts`
+- `src/components/Map.tsx`
+- `src/components/PersistentMapWrapper.tsx`
+
+## Risks
+- USA maxBounds could exclude territories (mitigated: covers all 50 states)
+- 10-degree viewport could return too many rows (mitigated: LIMIT 200 at SQL)
+- Cache staleness (mitigated: session-scoped, cleared on filter change, 20-entry LRU)
+
+## Plan
+
+### Phase 1: "Never Go Blank"
+- [x] 1.1 Stale-while-revalidate marker pattern (PersistentMapWrapper)
+- [x] 1.2 Remove heavy map loading overlays (Map.tsx + PersistentMapWrapper)
+- [x] 1.3 USA bounds restriction + minZoom (Map.tsx + constants.ts)
+- [x] Phase 1 verification: lint + typecheck + tests (14/14 pass)
+
+### Phase 2: Client-Side Spatial Cache
+- [x] 2.1 Bounds-based listing cache (PersistentMapWrapper)
+- [x] 2.2 Viewport hysteresis - skip unnecessary fetches (PersistentMapWrapper)
+- [x] 2.3 Pad fetch bounds by 20% (PersistentMapWrapper)
+- [x] Phase 2 verification: lint + typecheck + tests (14/14 pass)
+
+### Phase 3: Wider Viewport + Timing Tuning
+- [x] 3.1 Increase MAX_LAT_SPAN / MAX_LNG_SPAN from 5 to 10
+- [x] 3.2 Tune debounce/throttle timing (Map.tsx)
+- [x] Phase 3 verification: lint + typecheck + full test suite (5416/5417 pass; 1 flaky perf benchmark unrelated)
+
+## Results + Verification Story
+All 3 phases implemented. 3 files modified, 6 test files updated for new MAX span.
+- Lint: 0 errors
+- Typecheck: passes
+- Tests: 5416 pass, 1 flaky perf benchmark (pre-existing), 12 skipped


### PR DESCRIPTION
## Summary

- **Stale-while-revalidate markers**: Old markers stay visible during fetch — map never goes blank on zoom/pan
- **Remove heavy loading overlays**: Eliminated backdrop-blur, tinted backgrounds, and shimmer overlays that made the map feel like it was "reloading"
- **USA bounds restriction**: `maxBounds` + `minZoom=3` prevents panning into empty ocean
- **Client-side spatial cache**: 20-entry LRU cache gives instant marker display on zoom-out/pan-back to previously viewed areas
- **Viewport hysteresis**: Skips fetch when 90%+ of new viewport was already covered by last padded fetch
- **Padded fetch bounds**: 20% padding pre-fetches nearby listings so small pans don't need server round-trips
- **Wider viewport**: MAX_LAT/LNG_SPAN increased from 5° to 10° (~1100km) — see SF+LA or entire Northeast corridor
- **Tuned timing**: Debounce 300→400ms (less fetch-during-momentum), throttle 1000→800ms (more responsive panning)

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 5416/5417 pass (1 flaky pre-existing perf benchmark)
- [ ] Manual: Pan from SF to LA with search-as-move ON → old markers stay visible
- [ ] Manual: Zoom out 3 levels quickly → no blur overlay, no white tint
- [ ] Manual: Try panning past Maine → maxBounds prevents it
- [ ] Manual: View SF, zoom out to Oakland → SF listings appear instantly from cache
- [ ] Manual: Pan right 10%, pan back → no fetch triggered (hysteresis)
- [ ] Manual: Change price filter → cache cleared, fresh data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)