### PR TITLE
Virtualize search results and coordinate map scroll; prioritize in-viewport media

### DIFF
--- a/src/components/listings/ImageCarousel.tsx
+++ b/src/components/listings/ImageCarousel.tsx
@@ -9,6 +9,7 @@ interface ImageCarouselProps {
   images: string[];
   alt: string;
   priority?: boolean;
+  loading?: 'eager' | 'lazy';
   className?: string;
   onImageError?: (index: number) => void;
   /** Called when drag/swipe state changes — use to block parent click */
@@ -32,6 +33,7 @@ export function ImageCarousel({
   images,
   alt,
   priority = false,
+  loading = 'lazy',
   className = '',
   onImageError,
   onDragStateChange,
@@ -137,6 +139,7 @@ export function ImageCarousel({
           className="object-cover"
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
           priority={priority}
+          loading={priority ? undefined : loading}
           onError={() => onImageError?.(0)}
         />
       </div>
@@ -178,7 +181,7 @@ export function ImageCarousel({
                 className="object-cover"
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                 priority={priority && index === 0}
-                loading={index === 0 ? undefined : 'lazy'}
+                loading={priority && index === 0 ? undefined : index === 0 ? loading : 'lazy'}
                 placeholder="blur"
                 blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAwIiBoZWlnaHQ9IjMwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTRlNGU3Ii8+PC9zdmc+"
                 onError={() => onImageError?.(index)}

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -92,9 +92,11 @@ interface ListingCardProps {
     showTotalPrice?: boolean;
     /** Number of months for total price calculation */
     estimatedMonths?: number;
+    /** Prefer eager media loading for visible rows; lazy for deferred rows. */
+    mediaLoading?: 'eager' | 'lazy';
 }
 
-export default function ListingCard({ listing, isSaved, className, priority = false, showTotalPrice = false, estimatedMonths = 1 }: ListingCardProps) {
+export default function ListingCard({ listing, isSaved, className, priority = false, showTotalPrice = false, estimatedMonths = 1, mediaLoading = 'lazy' }: ListingCardProps) {
     const [imageErrors, setImageErrors] = useState<Set<number>>(new Set());
     const [isDragging, setIsDragging] = useState(false);
     const { setHovered, setActive, focusSource } = useListingFocus();
@@ -141,6 +143,7 @@ export default function ListingCard({ listing, isSaved, className, priority = fa
             role="article"
             aria-label={ariaLabel}
             data-testid="listing-card"
+            data-listing-card-id={listing.id}
             data-listing-id={listing.id}
             data-focus-state={isActive ? "active" : isHovered ? "hovered" : "none"}
             onMouseEnter={() => {
@@ -192,6 +195,7 @@ export default function ListingCard({ listing, isSaved, className, priority = fa
                         images={displayImages}
                         alt={displayTitle}
                         priority={priority}
+                        loading={mediaLoading}
                         className="h-full w-full group-hover:scale-110 transition-transform duration-[2s] ease-out"
                         onImageError={handleImageError}
                         onDragStateChange={setIsDragging}


### PR DESCRIPTION
### Motivation
- Reduce DOM work and improve scroll performance by windowing the search results feed while keeping existing card semantics.  
- Ensure map→list scroll-to-listing still works when rows are virtualized by coordinating a jump-to-row then aligning the mounted card.  
- Defer heavy media for off-screen cards and prioritize media for visible cards to improve LCP and bandwidth usage.

### Description
- Implement windowed rendering in `SearchResultsClient` by computing row/column math, a fixed `ROW_HEIGHT` and `ROW_OVERSCAN`, and rendering only the visible rows using absolute-positioned cards; responsive column count follows the same breakpoint as the grid. (See `src/components/search/SearchResultsClient.tsx`.)
- Add a virtual scroll coordination event (`listing-virtual-scroll-to`) and handler in `SearchResultsClient` that jumps the virtual window to the target row before the bridge aligns the card. (See `src/components/search/SearchResultsClient.tsx`.)
- Update `ListScrollBridge` to dispatch the virtual jump event, then retry lookup over animation frames until the card mounts, smooth-scroll it into center, and only then acknowledge the request to avoid races with virtualization. (See `src/components/listings/ListScrollBridge.tsx`.)
- Add a `mediaLoading` prop to `ListingCard` and a stable `data-listing-card-id` attribute used by the bridge for robust selection; pass viewport-aware `mediaLoading` from the virtualizer so visible rows load media eagerly while off-screen rows use lazy loading. (See `src/components/listings/ListingCard.tsx`.)
- Extend `ImageCarousel` to accept a `loading` mode and apply it to the single-image path and the first slide, preserving existing `priority` behavior while enabling eager/lazy switching. (See `src/components/listings/ImageCarousel.tsx`.)

### Testing
- Ran linting: `pnpm -s eslint src/components/search/SearchResultsClient.tsx src/components/listings/ListScrollBridge.tsx src/components/listings/ListingCard.tsx src/components/listings/ImageCarousel.tsx`, which completed with repository warnings but no new errors.  
- Type-check: `pnpm -s tsc --noEmit` completed successfully.  
- Unit test: `pnpm -s jest src/__tests__/components/ListScrollBridge.test.tsx` passed.  
- Dev server launched and a headless UI check captured `/search` to validate rendering after virtualization (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f73f36d2083319a417c5ade67f55b)