### PR TITLE
Return compact map-listing shape with dedicated thumbnail URL

### DIFF
--- a/src/__tests__/api/search/v2/route.test.ts
+++ b/src/__tests__/api/search/v2/route.test.ts
@@ -132,11 +132,11 @@ function createMockMapListingData(
 ): MapListingData {
   return {
     id,
-    title: `Listing ${id}`,
+    compactTitle: `Listing ${id}`,
     price: 1500,
     availableSlots: 1,
 
-    images: ["img.jpg"],
+    thumbnailUrl: "img.jpg",
     location: { lat, lng },
   };
 }

--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -63,11 +63,11 @@ jest.mock('next/navigation', () => ({
 let mockQuerySourceFeaturesData: Array<{
   properties: {
     id: string;
-    title: string;
+    compactTitle: string;
     price: number;
     availableSlots: number;
     ownerId: string;
-    images: string;
+    thumbnailUrl?: string;
     lat: number;
     lng: number;
     tier?: string;
@@ -130,11 +130,11 @@ function listingsToFeatures(listings: typeof mockListings) {
   return listings.map(listing => ({
     properties: {
       id: listing.id,
-      title: listing.title,
+      compactTitle: listing.compactTitle,
       price: listing.price,
       availableSlots: listing.availableSlots,
       ownerId: listing.ownerId || '',
-      images: JSON.stringify(listing.images || []),
+      thumbnailUrl: listing.thumbnailUrl ?? undefined,
       lat: listing.location.lat,
       lng: listing.location.lng,
       tier: listing.tier,
@@ -370,31 +370,31 @@ import { triggerHaptic } from '@/lib/haptics';
 const mockListings = [
   {
     id: 'listing-1',
-    title: 'Cozy Room in SF',
+    compactTitle: 'Cozy Room in SF',
     price: 1200,
     availableSlots: 2,
     ownerId: 'owner-1',
-    images: ['https://example.com/img1.jpg'],
+    thumbnailUrl: 'https://example.com/img1.jpg',
     location: { lat: 37.7749, lng: -122.4194 },
     tier: 'primary' as const,
   },
   {
     id: 'listing-2',
-    title: 'Studio Apartment',
+    compactTitle: 'Studio Apartment',
     price: 1800,
     availableSlots: 1,
     ownerId: 'owner-2',
-    images: ['https://example.com/img2.jpg'],
+    thumbnailUrl: 'https://example.com/img2.jpg',
     location: { lat: 37.7849, lng: -122.4094 },
     tier: 'mini' as const,
   },
   {
     id: 'listing-3',
-    title: 'Shared Space',
+    compactTitle: 'Shared Space',
     price: 900,
     availableSlots: 0,
     ownerId: 'owner-3',
-    images: [],
+    thumbnailUrl: null,
     location: { lat: 37.7649, lng: -122.4294 },
   },
 ];
@@ -891,20 +891,20 @@ describe('Map Component', () => {
       const overlappingListings = [
         {
           id: 'overlap-1',
-          title: 'Overlap 1',
+          compactTitle: 'Overlap 1',
           price: 1000,
           availableSlots: 1,
           ownerId: 'owner-1',
-          images: [],
+          thumbnailUrl: null,
           location: { lat: 37.7749, lng: -122.4194 },
         },
         {
           id: 'overlap-2',
-          title: 'Overlap 2',
+          compactTitle: 'Overlap 2',
           price: 1100,
           availableSlots: 1,
           ownerId: 'owner-2',
-          images: [],
+          thumbnailUrl: null,
           location: { lat: 37.7749, lng: -122.4194 },
         },
       ];
@@ -1368,31 +1368,31 @@ describe('Map Component', () => {
     const listingsWithTiers = [
       {
         id: 'primary-1',
-        title: 'Primary Listing',
+        compactTitle: 'Primary Listing',
         price: 1200,
         availableSlots: 2,
         ownerId: 'owner-1',
-        images: ['https://example.com/img1.jpg'],
+        thumbnailUrl: 'https://example.com/img1.jpg',
         location: { lat: 37.7749, lng: -122.4194 },
         tier: 'primary' as const,
       },
       {
         id: 'mini-1',
-        title: 'Mini Listing',
+        compactTitle: 'Mini Listing',
         price: 900,
         availableSlots: 1,
         ownerId: 'owner-2',
-        images: ['https://example.com/img2.jpg'],
+        thumbnailUrl: 'https://example.com/img2.jpg',
         location: { lat: 37.7849, lng: -122.4094 },
         tier: 'mini' as const,
       },
       {
         id: 'mini-2',
-        title: 'Another Mini',
+        compactTitle: 'Another Mini',
         price: 800,
         availableSlots: 3,
         ownerId: 'owner-3',
-        images: [],
+        thumbnailUrl: null,
         location: { lat: 37.7649, lng: -122.4294 },
         tier: 'mini' as const,
       },
@@ -1403,11 +1403,11 @@ describe('Map Component', () => {
       mockQuerySourceFeaturesData = listingsWithTiers.map(listing => ({
         properties: {
           id: listing.id,
-          title: listing.title,
+          compactTitle: listing.compactTitle,
           price: listing.price,
           availableSlots: listing.availableSlots,
           ownerId: listing.ownerId || '',
-          images: JSON.stringify(listing.images || []),
+          thumbnailUrl: listing.thumbnailUrl ?? undefined,
           lat: listing.location.lat,
           lng: listing.location.lng,
           tier: listing.tier,

--- a/src/__tests__/components/map/touch-gestures.test.tsx
+++ b/src/__tests__/components/map/touch-gestures.test.tsx
@@ -65,11 +65,11 @@ const onCallbacks: Record<string, ((...args: unknown[]) => void)[]> = {};
 let mockQuerySourceFeaturesData: Array<{
   properties: {
     id: string;
-    title: string;
+    compactTitle: string;
     price: number;
     availableSlots: number;
     ownerId: string;
-    images: string;
+    thumbnailUrl?: string;
     lat: number;
     lng: number;
     tier?: string;
@@ -127,11 +127,11 @@ function listingsToFeatures(listings: typeof mockListings) {
   return listings.map(listing => ({
     properties: {
       id: listing.id,
-      title: listing.title,
+      compactTitle: listing.compactTitle,
       price: listing.price,
       availableSlots: listing.availableSlots,
       ownerId: listing.ownerId || '',
-      images: JSON.stringify(listing.images || []),
+      thumbnailUrl: listing.thumbnailUrl ?? undefined,
       lat: listing.location.lat,
       lng: listing.location.lng,
       tier: listing.tier,
@@ -391,21 +391,21 @@ import MapComponent from '@/components/Map';
 const mockListings = [
   {
     id: 'listing-1',
-    title: 'Cozy Room in SF',
+    compactTitle: 'Cozy Room in SF',
     price: 1200,
     availableSlots: 2,
     ownerId: 'owner-1',
-    images: ['https://example.com/img1.jpg'],
+    thumbnailUrl: 'https://example.com/img1.jpg',
     location: { lat: 37.7749, lng: -122.4194 },
     tier: 'primary' as const,
   },
   {
     id: 'listing-2',
-    title: 'Studio Apartment',
+    compactTitle: 'Studio Apartment',
     price: 1800,
     availableSlots: 1,
     ownerId: 'owner-2',
-    images: ['https://example.com/img2.jpg'],
+    thumbnailUrl: 'https://example.com/img2.jpg',
     location: { lat: 37.7849, lng: -122.4094 },
     tier: 'mini' as const,
   },

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -269,11 +269,11 @@ function makeMapListingData(
 ): MapListingData {
   return {
     id: "map-listing-1",
-    title: "Map Listing",
+    compactTitle: "Map Listing",
     price: 1500,
     availableSlots: 1,
 
-    images: ["img1.jpg"],
+    thumbnailUrl: "img1.jpg",
     location: { lat: 37.77, lng: -122.42 },
     ...overrides,
   };

--- a/src/__tests__/lib/search/transform.test.ts
+++ b/src/__tests__/lib/search/transform.test.ts
@@ -184,9 +184,9 @@ describe("search/transform", () => {
       lng: number,
     ): MapListingData => ({
       id,
-      title: `Listing ${id}`,
+      compactTitle: `Listing ${id}`,
       price: 1000,
-      images: ["img.jpg"],
+      thumbnailUrl: "img.jpg",
       location: { lat, lng },
       availableSlots: 1,
 
@@ -228,9 +228,9 @@ describe("search/transform", () => {
       const listings: MapListingData[] = [
         {
           id: "test-id",
-          title: "Test Title",
+          compactTitle: "Test Title",
           price: 1500,
-          images: ["first.jpg", "second.jpg"],
+          thumbnailUrl: "first.jpg",
           location: { lat: 37.7749, lng: -122.4194 },
           availableSlots: 1,
 
@@ -250,9 +250,9 @@ describe("search/transform", () => {
       const listings: MapListingData[] = [
         {
           id: "1",
-          title: "No Images",
+          compactTitle: "No Images",
           price: 1000,
-          images: [],
+          thumbnailUrl: null,
           location: { lat: 37.7749, lng: -122.4194 },
           availableSlots: 1,
 
@@ -279,9 +279,9 @@ describe("search/transform", () => {
       price: number = 1000,
     ): MapListingData => ({
       id,
-      title: `Listing ${id}`,
+      compactTitle: `Listing ${id}`,
       price,
-      images: ["img.jpg"],
+      thumbnailUrl: "img.jpg",
       location: { lat, lng },
       availableSlots: 1,
 
@@ -372,9 +372,9 @@ describe("search/transform", () => {
       lng: number = -122.4194,
     ): MapListingData => ({
       id,
-      title: `Listing ${id}`,
+      compactTitle: `Listing ${id}`,
       price: 1000,
-      images: ["img.jpg"],
+      thumbnailUrl: "img.jpg",
       location: { lat, lng },
       availableSlots: 1,
 

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -333,8 +333,8 @@ function MapDataLoadingBar() {
  * - id: for key and click handling
  * - location: for pin placement
  * - price: for pin label
- * - title: for popup/tooltip
- * - availableSlots: for "N Available" / "Filled" badge in popup
+ * - compactTitle: for popup/tooltip
+ * - thumbnailUrl: for popup image preview
  * - tier: for differentiated pin styling (primary = larger, mini = smaller)
  */
 function v2MapDataToListings(v2MapData: V2MapData): MapListingData[] {
@@ -364,10 +364,10 @@ function v2MapDataToListings(v2MapData: V2MapData): MapListingData[] {
       const [lng, lat] = feature.geometry.coordinates;
       return {
         id: feature.properties.id,
-        title: feature.properties.title ?? "",
+        compactTitle: feature.properties.title ?? "",
         price: feature.properties.price ?? 0,
         availableSlots: feature.properties.availableSlots,
-        images: feature.properties.image ? [feature.properties.image] : [],
+        thumbnailUrl: feature.properties.image ?? null,
         location: { lng, lat },
         // Add tier from pins lookup (defaults to undefined if not in pins mode)
         tier: pinTierMap.get(feature.properties.id),

--- a/src/lib/search-types.ts
+++ b/src/lib/search-types.ts
@@ -108,10 +108,10 @@ export type PaginatedResultHybrid<T> = {
 // Map-optimized listing interface (minimal fields for markers)
 export interface MapListingData {
   id: string;
-  title: string;
+  compactTitle: string;
   price: number;
   availableSlots: number;
-  images: string[];
+  thumbnailUrl: string | null;
   location: {
     lat: number;
     lng: number;

--- a/src/lib/search/transform.ts
+++ b/src/lib/search/transform.ts
@@ -122,9 +122,9 @@ export function transformToGeoJSON(
     },
     properties: {
       id: listing.id,
-      title: listing.title,
+      title: listing.compactTitle,
       price: listing.price,
-      image: listing.images[0] ?? null,
+      image: listing.thumbnailUrl,
       availableSlots: listing.availableSlots,
     } satisfies SearchV2FeatureProperties,
   }));
@@ -145,10 +145,9 @@ export function transformToGeoJSON(
 function adaptToMarkerListing(listing: MapListingData): MapMarkerListing {
   return {
     id: listing.id,
-    title: listing.title,
+    title: listing.compactTitle,
     price: listing.price,
     availableSlots: listing.availableSlots,
-    images: listing.images,
     location: listing.location,
   };
 }


### PR DESCRIPTION
### Motivation
- Reduce map endpoint payload and client parsing work by returning only map-essential fields for marker rendering instead of full `images` arrays.
- Provide a stable compact title and a single `thumbnailUrl` so the map UI can efficiently render marker popups and thumbnails without fetching full listing media.
- Keep both SearchDoc-backed and legacy DB map paths consistent so the map consumers receive the same compact shape from either source.

### Description
- Updated the map-optimized type to `MapListingData` with `compactTitle`, `price`, `availableSlots`, `thumbnailUrl`, `location`, and optional `tier` by changing `src/lib/search-types.ts`.
- Refactored `getMapListings` in `src/lib/data.ts` to select a compacted `compactTitle` (truncated at 80 chars) and the first image as `thumbnailUrl` at the SQL level and map rows to the new compact shape.
- Aligned the SearchDoc path in `src/lib/search/search-doc-queries.ts` to return `compactTitle`/`thumbnailUrl` and updated mapping logic to produce the compact listing objects.
- Changed transforms and consumers to the compact shape: `src/lib/search/transform.ts` (geojson & pin transforms), `src/components/Map.tsx` (types, GeoJSON properties, unclustered listing extraction, popup rendering), and `src/components/PersistentMapWrapper.tsx` (v2 feature -> MapListingData conversion).
- Removed shipping/parsing of full `images` arrays in map flows and replaced fallback logic with `thumbnailUrl` usage and icon fallback in popups.
- Updated test fixtures and mocks across affected tests to use the new `compactTitle`/`thumbnailUrl` fields.

### Testing
- Ran type checking with `npm run typecheck` which completed successfully.
- Ran unit tests for the changed map/transform paths with `npm test -- src/__tests__/lib/search/transform.test.ts src/__tests__/api/map-listings.test.ts` and both suites passed (`PASS` for both files, total 45 tests in those suites passed).
- Launched the dev server and captured a Playwright screenshot of the `/search` map to validate the popup thumbnail rendering (artifact saved during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f73f18da88331a1bffe996538d5ac)