### PR TITLE
Add zoom-aware map tile API and tile-based map subscriptions

### DIFF
--- a/src/app/api/map-tiles/[z]/[x]/[y]/route.ts
+++ b/src/app/api/map-tiles/[z]/[x]/[y]/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMapTileListings } from "@/lib/data";
+import { withRateLimitRedis } from "@/lib/with-rate-limit-redis";
+import { withTimeout, DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
+import {
+  createContextFromHeaders,
+  runWithRequestContext,
+  getRequestId,
+} from "@/lib/request-context";
+import {
+  buildRawParamsFromSearchParams,
+  parseSearchParams,
+} from "@/lib/search-params";
+import { logger, sanitizeErrorMessage } from "@/lib/logger";
+import * as Sentry from "@sentry/nextjs";
+import { getSearchRateLimitIdentifier } from "@/lib/search-rate-limit-identifier";
+
+interface RouteParams {
+  params: Promise<{
+    z: string;
+    x: string;
+    y: string;
+  }>;
+}
+
+export async function GET(request: NextRequest, context: RouteParams) {
+  const requestContext = createContextFromHeaders(request.headers);
+
+  return runWithRequestContext(requestContext, async () => {
+    const requestId = getRequestId();
+
+    try {
+      const rateLimitResponse = await withRateLimitRedis(request, {
+        type: "map",
+        getIdentifier: getSearchRateLimitIdentifier,
+      });
+      if (rateLimitResponse) return rateLimitResponse;
+
+      const { z: zParam, x: xParam, y: yParam } = await context.params;
+      const z = Number.parseInt(zParam, 10);
+      const x = Number.parseInt(xParam, 10);
+      const y = Number.parseInt(yParam, 10);
+      if (![z, x, y].every(Number.isFinite) || z < 0 || x < 0 || y < 0) {
+        return NextResponse.json(
+          { error: "Invalid tile coordinates" },
+          { status: 400, headers: { "x-request-id": requestId } },
+        );
+      }
+
+      const maxIndex = 2 ** z;
+      if (x >= maxIndex || y >= maxIndex) {
+        return NextResponse.json(
+          { error: "Tile coordinates out of range for zoom" },
+          { status: 400, headers: { "x-request-id": requestId } },
+        );
+      }
+
+      const searchParams = request.nextUrl.searchParams;
+      const rawParams = buildRawParamsFromSearchParams(searchParams);
+      const parsed = parseSearchParams(rawParams);
+
+      const zoomParam = searchParams.get("zoom");
+      const zoom = zoomParam ? Number.parseInt(zoomParam, 10) : z;
+      const includeDensity = searchParams.get("includeDensity") !== "false";
+
+      const tileResponse = await withTimeout(
+        getMapTileListings({
+          tile: { z, x, y },
+          zoom,
+          query: parsed.filterParams.query,
+          minPrice: parsed.filterParams.minPrice,
+          maxPrice: parsed.filterParams.maxPrice,
+          amenities: parsed.filterParams.amenities,
+          languages: parsed.filterParams.languages,
+          houseRules: parsed.filterParams.houseRules,
+          moveInDate: parsed.filterParams.moveInDate,
+          leaseDuration: parsed.filterParams.leaseDuration,
+          roomType: parsed.filterParams.roomType,
+          genderPreference: parsed.filterParams.genderPreference,
+          householdGender: parsed.filterParams.householdGender,
+        }),
+        DEFAULT_TIMEOUTS.DATABASE,
+        "getMapTileListings",
+      );
+
+      return NextResponse.json(
+        {
+          tileKey: tileResponse.tileKey,
+          mode: tileResponse.mode,
+          zoom: tileResponse.zoom,
+          listings: tileResponse.listings,
+          density: includeDensity ? tileResponse.density : undefined,
+        },
+        {
+          headers: {
+            "Cache-Control":
+              "public, s-maxage=60, max-age=30, stale-while-revalidate=120",
+            "x-request-id": requestId,
+            Vary: "Accept-Encoding",
+          },
+        },
+      );
+    } catch (error) {
+      logger.sync.error("Map tiles API error", {
+        error: sanitizeErrorMessage(error),
+        route: "/api/map-tiles/[z]/[x]/[y]",
+        requestId,
+      });
+      Sentry.captureException(error);
+      return NextResponse.json(
+        { error: "Failed to fetch map tile listings" },
+        {
+          status: 500,
+          headers: { "x-request-id": requestId },
+        },
+      );
+    }
+  });
+}

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -5,7 +5,7 @@
  *
  * This component is designed to live in the layout.tsx so it persists across
  * page navigations (router.replace/push). It reads URL search params and fetches
- * map listings data via the /api/map-listings endpoint.
+ * map listings data via the /api/map-tiles endpoint.
  *
  * Key benefits:
  * - Map stays mounted across /search navigations (no map re-init)
@@ -39,8 +39,7 @@ import {
   LAT_MIN,
   LAT_MAX,
   LNG_MIN,
-  LNG_MAX,
-  BOUNDS_EPSILON,
+  LNG_MAX
 } from "@/lib/constants";
 
 // CRITICAL: Lazy import - only loads when component renders
@@ -49,14 +48,10 @@ const LazyDynamicMap = lazy(() => import("./DynamicMap"));
 
 const MAP_FETCH_DEBOUNCE_MS = 250;
 
-// Spatial cache constants
-const SPATIAL_CACHE_MAX_ENTRIES = 20;
+// Tile cache constants
+const TILE_CACHE_MAX_ENTRIES = 80;
 const MAX_MAP_MARKERS = 200;
 const FETCH_BOUNDS_PADDING = 0.2;
-
-// ============================================
-// Spatial Cache Types & Utilities
-// ============================================
 
 interface ViewportBounds {
   minLat: number;
@@ -65,36 +60,48 @@ interface ViewportBounds {
   maxLng: number;
 }
 
-interface SpatialCacheEntry {
+interface TileCacheEntry {
   listings: MapListingData[];
-  bounds: ViewportBounds;
   filterKey: string;
+  mode: "cluster" | "pins";
+  density?: {
+    listingCount: number;
+    returnedCount: number;
+  };
   timestamp: number;
 }
 
-/** Quantize bounds to BOUNDS_EPSILON precision for cache key */
-function quantizeBounds(bounds: ViewportBounds): string {
-  const q = (n: number) => (Math.round(n / BOUNDS_EPSILON) * BOUNDS_EPSILON).toFixed(3);
-  return `${q(bounds.minLat)},${q(bounds.maxLat)},${q(bounds.minLng)},${q(bounds.maxLng)}`;
+function getZoomForBounds(bounds: ViewportBounds): number {
+  const lngSpan = Math.max(bounds.maxLng - bounds.minLng, 0.000001);
+  return Math.max(0, Math.min(22, Math.floor(Math.log2(360 / lngSpan))));
 }
 
-/**
- * Check if inner viewport is mostly contained within outer bounds.
- * Returns true if overlap >= threshold of inner's area (skip fetch).
- */
-function isViewportContained(inner: ViewportBounds, outer: ViewportBounds, threshold = 0.9): boolean {
-  const innerArea = (inner.maxLat - inner.minLat) * (inner.maxLng - inner.minLng);
-  if (innerArea <= 0) return false;
+function lngToTileX(lng: number, z: number): number {
+  const n = 2 ** z;
+  return Math.floor(((lng + 180) / 360) * n);
+}
 
-  const overlapMinLat = Math.max(inner.minLat, outer.minLat);
-  const overlapMaxLat = Math.min(inner.maxLat, outer.maxLat);
-  const overlapMinLng = Math.max(inner.minLng, outer.minLng);
-  const overlapMaxLng = Math.min(inner.maxLng, outer.maxLng);
+function latToTileY(lat: number, z: number): number {
+  const n = 2 ** z;
+  const rad = (lat * Math.PI) / 180;
+  const merc = Math.log(Math.tan(Math.PI / 4 + rad / 2));
+  return Math.floor(((1 - merc / Math.PI) / 2) * n);
+}
 
-  if (overlapMinLat >= overlapMaxLat || overlapMinLng >= overlapMaxLng) return false;
+function getVisibleTileKeys(bounds: ViewportBounds, zoom: number): string[] {
+  const n = 2 ** zoom;
+  const minX = Math.max(0, Math.min(n - 1, lngToTileX(bounds.minLng, zoom)));
+  const maxX = Math.max(0, Math.min(n - 1, lngToTileX(bounds.maxLng, zoom)));
+  const minY = Math.max(0, Math.min(n - 1, latToTileY(bounds.maxLat, zoom)));
+  const maxY = Math.max(0, Math.min(n - 1, latToTileY(bounds.minLat, zoom)));
 
-  const overlapArea = (overlapMaxLat - overlapMinLat) * (overlapMaxLng - overlapMinLng);
-  return (overlapArea / innerArea) >= threshold;
+  const keys: string[] = [];
+  for (let x = minX; x <= maxX; x += 1) {
+    for (let y = minY; y <= maxY; y += 1) {
+      keys.push(`${zoom}/${x}/${y}`);
+    }
+  }
+  return keys;
 }
 
 /**
@@ -110,7 +117,6 @@ function padBounds(bounds: ViewportBounds, padding = FETCH_BOUNDS_PADDING): View
     minLng: Math.max(LNG_MIN, bounds.minLng - lngSpan * padding),
     maxLng: Math.min(LNG_MAX, bounds.maxLng + lngSpan * padding),
   };
-  // Clamp padded result to MAX_LAT/LNG_SPAN
   const paddedLatSpan = padded.maxLat - padded.minLat;
   const paddedLngSpan = padded.maxLng - padded.minLng;
   if (paddedLatSpan > MAX_LAT_SPAN) {
@@ -132,55 +138,6 @@ function getFilterKey(searchParams: URLSearchParams): string {
   filtered.sort();
   return filtered.toString();
 }
-
-// Legacy map-relevant key list kept as explicit documentation and fallback shape.
-// The active serialization path uses canonical parser output so map/list stay in sync.
-const MAP_RELEVANT_KEYS = [
-  "q",
-  "minLat",
-  "maxLat",
-  "minLng",
-  "maxLng",
-  "lat",
-  "lng",
-  "minPrice",
-  "maxPrice",
-  "amenities",
-  "moveInDate",
-  "leaseDuration",
-  "houseRules",
-  "languages",
-  "roomType",
-  "genderPreference",
-  "householdGender",
-  "nearMatches",
-] as const;
-
-const MAP_VIEWPORT_KEYS = MAP_RELEVANT_KEYS.filter(
-  (key) =>
-    key === "minLat" ||
-    key === "maxLat" ||
-    key === "minLng" ||
-    key === "maxLng" ||
-    key === "lat" ||
-    key === "lng",
-);
-
-function getMapRelevantParams(searchParams: URLSearchParams): string {
-  // Canonicalize filter params using shared parser so map and list receive identical filters.
-  const filtered = buildCanonicalFilterParamsFromSearchParams(searchParams);
-
-  // Preserve explicit viewport/location keys from current URL (including clamped bounds).
-  for (const key of MAP_VIEWPORT_KEYS) {
-    const values = searchParams.getAll(key);
-    values.forEach((v) => filtered.append(key, v));
-  }
-
-  // Sort for consistent comparison (URLSearchParams order isn't guaranteed)
-  filtered.sort();
-  return filtered.toString();
-}
-
 /**
  * Get user-friendly error message based on HTTP status
  */
@@ -390,36 +347,25 @@ export default function PersistentMapWrapper({
   const [listings, setListings] = useState<MapListingData[]>([]);
   const [isFetchingMapData, setIsFetchingMapData] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Stale-while-revalidate: keep last successful fetch visible during loading
-  const previousListingsRef = useRef<MapListingData[]>([]);
-  // Spatial cache: instant markers from previously-viewed areas on zoom-out/pan-back
-  const spatialCacheRef = useRef<Map<string, SpatialCacheEntry>>(new Map());
-  // Track last-fetched padded bounds for hysteresis (skip fetch when viewport mostly contained)
-  const lastFetchedBoundsRef = useRef<ViewportBounds | null>(null);
-  // Track filter key to invalidate spatial cache on filter change
-  const lastFilterKeyRef = useRef<string>("");
-  // P2-FIX (#151): Separate info messages from errors - info is non-blocking (no retry needed)
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
+  const previousListingsRef = useRef<MapListingData[]>([]);
+  const tileCacheRef = useRef<Map<string, TileCacheEntry>>(new Map());
+  const inFlightRef = useRef<Set<string>>(new Set());
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const retryCountRef = useRef<number>(0);
+  const lastSubscriptionKeyRef = useRef<string | null>(null);
+  const lastFilterKeyRef = useRef<string>("");
 
-  // Check for v2 data from context (injected by page.tsx via V2MapDataSetter)
   const { v2MapData, isV2Enabled, setIsV2Enabled } = useSearchV2Data();
-  // P2-FIX (#124): Use state instead of ref for last V2 data to ensure memo dependencies are correct
-  // Using a ref in useMemo causes stale data because refs aren't tracked by React
   const [lastV2Data, setLastV2Data] = useState<V2MapData | null>(null);
-  // P2-FIX (#115): Track if data path has been determined to prevent brief empty map.
-  // On initial mount, we don't know if v2 or v1 will provide data. Show loading until determined.
   const [dataPathDetermined, setDataPathDetermined] = useState(false);
 
-  // Coordinate with list transitions - show overlay when list is loading
   const transitionContext = useSearchTransitionSafe();
   const isListTransitioning = transitionContext?.isPending ?? false;
-  // Only trust V2 data when V2 mode is explicitly enabled.
-  // This prevents stale context data from masking fresh V1 filtered results.
   const hasV2Data = isV2Enabled && v2MapData !== null;
   const hasAnyV2Data = isV2Enabled && (hasV2Data || lastV2Data !== null);
-
-  // P2-FIX (#115): Mark data path as determined when we receive any signal
-  // Check if URL has bounds (indicates V1 path with known location)
   const hasBoundsInUrl =
     searchParams.has("minLng") &&
     searchParams.has("maxLng") &&
@@ -427,8 +373,6 @@ export default function PersistentMapWrapper({
     searchParams.has("maxLat");
 
   useEffect(() => {
-    // V2 mode signaled (either enabled or explicitly disabled after being enabled)
-    // OR we have v2 data OR we have v1 listings OR we have bounds in URL (V1 path)
     if (isV2Enabled || hasAnyV2Data || listings.length > 0 || hasBoundsInUrl) {
       setDataPathDetermined(true);
     }
@@ -438,293 +382,130 @@ export default function PersistentMapWrapper({
     if (v2MapData) {
       setLastV2Data(v2MapData);
     } else if (!isV2Enabled) {
-      // Clear stale V2 cache when v1 path is active to prevent map/list desync.
       setLastV2Data(null);
     }
   }, [v2MapData, isV2Enabled]);
 
-  // Compute effective listings based on data source (v2 context or v1 fetch)
-  // Memoized for stable reference to prevent unnecessary Map re-renders
-  // During V1 fetch: merge cached listings from overlapping areas for instant display
   const effectiveListings = useMemo(() => {
-    // P2-FIX (#124): Use lastV2Data state (not ref) so memo properly recalculates
     const activeV2Data = isV2Enabled ? (v2MapData ?? lastV2Data) : null;
     if (activeV2Data) {
       return v2MapDataToListings(activeV2Data);
     }
-    // During V1 fetch, merge previous data + cached spatial data so markers never disappear
+
     if (isFetchingMapData && previousListingsRef.current.length > 0) {
-      // Deduplicate by listing ID, cap at MAX_MAP_MARKERS
-      const seenIds = new Set<string>();
+      const seen = new Set<string>();
       const merged: MapListingData[] = [];
-      // Start with current listings (highest priority)
-      for (const l of listings) {
-        if (!seenIds.has(l.id) && merged.length < MAX_MAP_MARKERS) {
-          seenIds.add(l.id);
-          merged.push(l);
-        }
-      }
-      // Add previous listings
-      for (const l of previousListingsRef.current) {
-        if (!seenIds.has(l.id) && merged.length < MAX_MAP_MARKERS) {
-          seenIds.add(l.id);
-          merged.push(l);
-        }
-      }
-      // Add from spatial cache entries that overlap current viewport
-      const currentFilterKey = lastFilterKeyRef.current;
-      for (const entry of spatialCacheRef.current.values()) {
-        if (entry.filterKey !== currentFilterKey) continue;
-        for (const l of entry.listings) {
-          if (!seenIds.has(l.id) && merged.length < MAX_MAP_MARKERS) {
-            seenIds.add(l.id);
-            merged.push(l);
+      for (const entry of [listings, previousListingsRef.current]) {
+        for (const item of entry) {
+          if (!seen.has(item.id) && merged.length < MAX_MAP_MARKERS) {
+            seen.add(item.id);
+            merged.push(item);
           }
         }
       }
       return merged;
     }
+
     return listings;
   }, [isV2Enabled, v2MapData, lastV2Data, listings, isFetchingMapData]);
 
-  // Track current params to detect changes for debouncing
-  const lastFetchedParamsRef = useRef<string | null>(null);
-  const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const retryCountRef = useRef<number>(0);
-  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const fetchListings = useCallback(
-    async (paramsString: string, signal?: AbortSignal, fetchBounds?: ViewportBounds) => {
-      setIsFetchingMapData(true);
-      setError(null);
-
-      try {
-        const response = await fetch(`/api/map-listings?${paramsString}`, {
-          signal,
-        });
-
-        if (!response.ok) {
-          // Extract detailed error from response body
-          let serverMessage: string | undefined;
-          let requestId: string | undefined;
-
-          try {
-            const errorData = await response.json();
-            serverMessage = errorData.error;
-            requestId = response.headers.get("x-request-id") || undefined;
-          } catch {
-            // JSON parsing failed, use status-based message
-          }
-
-          // Handle 429 with automatic retry (max 1 retry)
-          if (response.status === 429 && retryCountRef.current < 1) {
-            retryCountRef.current += 1;
-
-            // Check for Retry-After header (in seconds)
-            const retryAfterHeader = response.headers.get("Retry-After");
-            const retryDelayMs = retryAfterHeader
-              ? parseInt(retryAfterHeader, 10) * 1000
-              : 2000; // Default 2s exponential backoff
-
-            // P2-7 FIX: Guard dev logging to avoid production console pollution
-            if (process.env.NODE_ENV === 'development') {
-              console.debug('[PersistentMapWrapper] Rate limited (429), retrying after', retryDelayMs, 'ms');
-            }
-
-            // Schedule automatic retry
-            retryTimeoutRef.current = setTimeout(() => {
-              fetchListings(paramsString, signal, fetchBounds);
-            }, retryDelayMs);
-
-            return; // Exit without throwing - retry will happen automatically
-          }
-
-          // Log error for debugging (PII-safe - no raw params)
-          // Use warn for 400 (expected validation failures) to avoid polluting error overlay
-          if (response.status === 400) {
-            // P2-7 FIX: Guard dev logging
-            if (process.env.NODE_ENV === 'development') {
-              console.debug('[PersistentMapWrapper] Map viewport validation failed:', {
-                status: response.status,
-                error: serverMessage,
-              });
-            }
-          } else {
-            console.error("Map listings fetch failed:", {
-              status: response.status,
-              statusText: response.statusText,
-              error: serverMessage,
-              requestId,
-            });
-          }
-
-          const errorMessage = getStatusErrorMessage(
-            response.status,
-            serverMessage,
-          );
-          throw new Error(errorMessage);
+  const fetchTile = useCallback(async (
+    tileKey: string,
+    tilePath: string,
+    filterParams: string,
+    zoom: number,
+    signal: AbortSignal,
+  ) => {
+    try {
+      const response = await fetch(`/api/map-tiles/${tilePath}?${filterParams}&zoom=${zoom}&includeDensity=true`, { signal });
+      if (!response.ok) {
+        if (response.status === 429 && retryCountRef.current < 1) {
+          retryCountRef.current += 1;
+          const retryAfterHeader = response.headers.get("Retry-After");
+          const retryDelayMs = retryAfterHeader ? parseInt(retryAfterHeader, 10) * 1000 : 2000;
+          retryTimeoutRef.current = setTimeout(() => {
+            fetchTile(tileKey, tilePath, filterParams, zoom, signal);
+          }, retryDelayMs);
+          return;
         }
-
-        const data = await response.json();
-        const fetched = data.listings || [];
-        previousListingsRef.current = fetched;
-        setListings(fetched);
-
-        // Store in spatial cache for instant zoom-out/pan-back display
-        if (fetchBounds) {
-          const cacheKey = quantizeBounds(fetchBounds);
-          const filterKey = lastFilterKeyRef.current;
-          spatialCacheRef.current.set(cacheKey, {
-            listings: fetched,
-            bounds: fetchBounds,
-            filterKey,
-            timestamp: Date.now(),
-          });
-          // LRU eviction: remove oldest entries beyond limit
-          if (spatialCacheRef.current.size > SPATIAL_CACHE_MAX_ENTRIES) {
-            let oldestKey: string | null = null;
-            let oldestTime = Infinity;
-            for (const [key, entry] of spatialCacheRef.current) {
-              if (entry.timestamp < oldestTime) {
-                oldestTime = entry.timestamp;
-                oldestKey = key;
-              }
-            }
-            if (oldestKey) spatialCacheRef.current.delete(oldestKey);
-          }
-          // Update last-fetched bounds for hysteresis checks
-          lastFetchedBoundsRef.current = fetchBounds;
-        }
-
-        // Reset retry counter on successful fetch
-        retryCountRef.current = 0;
-      } catch (err) {
-        if ((err as Error).name !== "AbortError") {
-          console.error("Failed to fetch map listings:", err);
-          setError((err as Error).message || "Failed to load map data");
-        }
-      } finally {
-        setIsFetchingMapData(false);
+        const body = await response.json().catch(() => ({}));
+        throw new Error(getStatusErrorMessage(response.status, body?.error));
       }
-    },
-    [],
-  );
 
-  // Single effect that handles both initial fetch and param changes
-  // Only fetches when map is rendered to avoid unnecessary API calls
-  // V2 mode: Skip fetch entirely when v2MapData is provided via context
-  useEffect(() => {
-    // Don't fetch if map isn't being rendered
-    if (!shouldRenderMap) {
-      return;
+      const payload = await response.json();
+      tileCacheRef.current.set(tileKey, {
+        listings: payload.listings || [],
+        filterKey: lastFilterKeyRef.current,
+        mode: payload.mode,
+        density: payload.density
+          ? {
+              listingCount: payload.density.listingCount ?? 0,
+              returnedCount: payload.density.returnedCount ?? 0,
+            }
+          : undefined,
+        timestamp: Date.now(),
+      });
+
+      if (tileCacheRef.current.size > TILE_CACHE_MAX_ENTRIES) {
+        let oldestKey: string | null = null;
+        let oldestTs = Infinity;
+        for (const [key, entry] of tileCacheRef.current) {
+          if (entry.timestamp < oldestTs) {
+            oldestTs = entry.timestamp;
+            oldestKey = key;
+          }
+        }
+        if (oldestKey) tileCacheRef.current.delete(oldestKey);
+      }
+    } finally {
+      inFlightRef.current.delete(tileKey);
     }
+  }, []);
 
-    // P1-2 FIX: Reset retry counter when effect re-runs with new params
-    // This ensures fresh retry attempts for each new search
+  useEffect(() => {
+    if (!shouldRenderMap) return;
+
     retryCountRef.current = 0;
-
-    // VIEWPORT VALIDATION: Check bounds validity FIRST, before any v2 checks.
-    // This ensures "Zoom in further" error shows regardless of data source (v1 or v2).
-    const hasBounds =
-      searchParams.has("minLng") &&
-      searchParams.has("maxLng") &&
-      searchParams.has("minLat") &&
-      searchParams.has("maxLat");
-
-    // Track whether we need to clamp bounds for the fetch
-    // Use URLSearchParams (writable) so we can modify if clamping is needed
-    let clampedSearchParams: URLSearchParams = new URLSearchParams(searchParams.toString());
+    const hasBounds = hasBoundsInUrl;
+    const clampedSearchParams = new URLSearchParams(searchParams.toString());
 
     if (hasBounds) {
-      // Client-side bounds validation - applies to both v1 and v2 paths
       const validation = isValidViewport(searchParams);
       if (!validation.valid) {
-        // For NaN/Infinity, reject entirely
         const minLat = parseFloat(searchParams.get("minLat") || "");
         if (!Number.isFinite(minLat)) {
           setError(validation.error || "Invalid viewport");
           setIsFetchingMapData(false);
           return;
         }
-        // For "too wide" viewports, clamp to max span centered on viewport center
-        // instead of rejecting — keeps listings visible when zoomed out
+
         const parsedMinLat = parseFloat(searchParams.get("minLat")!);
         const parsedMaxLat = parseFloat(searchParams.get("maxLat")!);
         const parsedMinLng = parseFloat(searchParams.get("minLng")!);
         const parsedMaxLng = parseFloat(searchParams.get("maxLng")!);
         const centerLat = (parsedMinLat + parsedMaxLat) / 2;
         const centerLng = (parsedMinLng + parsedMaxLng) / 2;
-        const clamped = new URLSearchParams(searchParams.toString());
-        clamped.set("minLat", (centerLat - MAX_LAT_SPAN / 2).toString());
-        clamped.set("maxLat", (centerLat + MAX_LAT_SPAN / 2).toString());
-        clamped.set("minLng", (centerLng - MAX_LNG_SPAN / 2).toString());
-        clamped.set("maxLng", (centerLng + MAX_LNG_SPAN / 2).toString());
-        clampedSearchParams = clamped;
-
-        // P2-7 FIX: Guard dev logging
-        if (process.env.NODE_ENV === 'development') {
-          console.debug('[PersistentMapWrapper] Map viewport clamped to max span:', {
-            original: {
-              lat: [parsedMinLat, parsedMaxLat],
-              lng: [parsedMinLng, parsedMaxLng],
-            },
-            clamped: {
-              lat: [centerLat - MAX_LAT_SPAN / 2, centerLat + MAX_LAT_SPAN / 2],
-              lng: [centerLng - MAX_LNG_SPAN / 2, centerLng + MAX_LNG_SPAN / 2],
-            },
-            maxSpan: { lat: MAX_LAT_SPAN, lng: MAX_LNG_SPAN },
-          });
-        }
-
-        // P2-FIX (#151): Use info message instead of error - map is functional, just clamped
+        clampedSearchParams.set("minLat", (centerLat - MAX_LAT_SPAN / 2).toString());
+        clampedSearchParams.set("maxLat", (centerLat + MAX_LAT_SPAN / 2).toString());
+        clampedSearchParams.set("minLng", (centerLng - MAX_LNG_SPAN / 2).toString());
+        clampedSearchParams.set("maxLng", (centerLng + MAX_LNG_SPAN / 2).toString());
         setInfoMessage("Zoomed in to show results");
       } else {
-        // Clear info message when viewport is valid (no clamping occurred)
         setInfoMessage(null);
       }
     }
 
-    // RACE GUARD: If v2 mode is signaled but data hasn't arrived yet,
-    // delay the v1 fetch to give the setter time to run.
-    // This prevents double-fetch and flicker.
-    // P1-3 NOTE: Error state set during viewport validation above is preserved
-    // through this early return - the cleanup doesn't clear error state.
     if (isV2Enabled && !hasV2Data) {
-      const raceGuardTimeout = setTimeout(() => {
-        // V2 data didn't arrive in time — disable v2 to fall back to v1 fetch.
-        // This triggers a re-render, the effect re-runs, skips this guard,
-        // and proceeds to the v1 fetch below.
-        setIsV2Enabled(false);
-      }, 200); // 200ms — enough for React flush, with margin
+      const raceGuardTimeout = setTimeout(() => setIsV2Enabled(false), 200);
       return () => clearTimeout(raceGuardTimeout);
     }
+    if (hasV2Data) return;
 
-    // Skip v1 fetch entirely if v2 data is provided via context
-    if (hasV2Data) {
-      return;
-    }
-
-    // P3a Fix: Use only map-relevant params for deduplication
-    // This prevents re-fetching when page/sort changes (which don't affect markers)
-    // VERIFIED: URLSearchParams.sort() ensures consistent ordering and toString()
-    // produces consistent URL-encoded strings, making string comparison reliable
-    const paramsString = getMapRelevantParams(clampedSearchParams);
-
-    // Skip if we've already fetched for these exact params
-    if (paramsString === lastFetchedParamsRef.current) {
-      return;
-    }
-
-    // Skip if bounds are missing - wait for map to set them
     if (!hasBounds) {
-      // Don't fetch without bounds - map will set them after load
-      // Clear loading state so map is interactive
       setIsFetchingMapData(false);
       return;
     }
 
-    // Parse current viewport bounds for spatial cache + hysteresis
     const currentBounds: ViewportBounds = {
       minLat: parseFloat(clampedSearchParams.get("minLat") || "0"),
       maxLat: parseFloat(clampedSearchParams.get("maxLat") || "0"),
@@ -732,104 +513,92 @@ export default function PersistentMapWrapper({
       maxLng: parseFloat(clampedSearchParams.get("maxLng") || "0"),
     };
 
-    // Invalidate spatial cache when filters change
-    const currentFilterKey = getFilterKey(clampedSearchParams);
-    if (currentFilterKey !== lastFilterKeyRef.current) {
-      spatialCacheRef.current.clear();
-      lastFetchedBoundsRef.current = null;
-      lastFilterKeyRef.current = currentFilterKey;
+    const filterKey = getFilterKey(clampedSearchParams);
+    if (filterKey !== lastFilterKeyRef.current) {
+      tileCacheRef.current.clear();
+      lastFilterKeyRef.current = filterKey;
     }
 
-    // Viewport hysteresis: skip fetch if new viewport is mostly within last-fetched padded area
-    if (lastFetchedBoundsRef.current && isViewportContained(currentBounds, lastFetchedBoundsRef.current)) {
-      return;
-    }
+    const paddedBounds = padBounds(currentBounds);
+    const zoomFromUrl = parseInt(clampedSearchParams.get("zoom") || "", 10);
+    const zoom = Number.isFinite(zoomFromUrl) ? zoomFromUrl : getZoomForBounds(paddedBounds);
+    const visibleTileKeys = getVisibleTileKeys(paddedBounds, zoom);
+    const subscriptionKey = `${filterKey}|z${zoom}|${visibleTileKeys.join(",")}`;
+    if (subscriptionKey === lastSubscriptionKeyRef.current) return;
+    lastSubscriptionKeyRef.current = subscriptionKey;
 
-    // Clear any pending fetch timeout
-    if (fetchTimeoutRef.current) {
-      clearTimeout(fetchTimeoutRef.current);
-    }
-
-    // M6-MAP: Client AbortController cancels the fetch but cannot cancel the
-    // in-progress DB query on the server. Server-side statement_timeout provides
-    // the safety net for runaway queries.
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    // Create abort controller for this fetch
+    if (fetchTimeoutRef.current) clearTimeout(fetchTimeoutRef.current);
+    if (abortControllerRef.current) abortControllerRef.current.abort();
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
 
-    // Pad fetch bounds by 20% to pre-fetch nearby listings (reduces fetches on small pans)
-    // Only the map's /api/map-listings fetch uses padded bounds.
-    // URL params (for list/page sync) continue using actual visible viewport — no conflict.
-    const paddedBounds = padBounds(currentBounds);
-    const paddedParams = new URLSearchParams(clampedSearchParams.toString());
-    paddedParams.set("minLat", paddedBounds.minLat.toString());
-    paddedParams.set("maxLat", paddedBounds.maxLat.toString());
-    paddedParams.set("minLng", paddedBounds.minLng.toString());
-    paddedParams.set("maxLng", paddedBounds.maxLng.toString());
-    const paddedParamsString = getMapRelevantParams(paddedParams);
+    const filterParams = buildCanonicalFilterParamsFromSearchParams(clampedSearchParams);
+    filterParams.sort();
+    const filterParamsString = filterParams.toString();
 
-    // Small debounce to coalesce rapid URL updates without adding noticeable lag.
-    fetchTimeoutRef.current = setTimeout(() => {
-      lastFetchedParamsRef.current = paramsString;
-      fetchListings(paddedParamsString, abortController.signal, paddedBounds);
+    fetchTimeoutRef.current = setTimeout(async () => {
+      setIsFetchingMapData(true);
+      setError(null);
+
+      const fetches: Promise<void>[] = [];
+      for (const tileKey of visibleTileKeys) {
+        if (tileCacheRef.current.has(tileKey) || inFlightRef.current.has(tileKey)) continue;
+        inFlightRef.current.add(tileKey);
+        fetches.push(fetchTile(tileKey, tileKey, filterParamsString, zoom, abortController.signal));
+      }
+
+      try {
+        await Promise.all(fetches);
+
+        const seen = new Set<string>();
+        const merged: MapListingData[] = [];
+        for (const tileKey of visibleTileKeys) {
+          const entry = tileCacheRef.current.get(tileKey);
+          if (!entry || entry.filterKey !== filterKey) continue;
+          for (const item of entry.listings) {
+            if (!seen.has(item.id) && merged.length < MAX_MAP_MARKERS) {
+              seen.add(item.id);
+              merged.push(item);
+            }
+          }
+        }
+
+        previousListingsRef.current = merged.length > 0 ? merged : previousListingsRef.current;
+        setListings(merged);
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") {
+          setError((err as Error).message || "Failed to load map data");
+        }
+      } finally {
+        setIsFetchingMapData(false);
+      }
     }, MAP_FETCH_DEBOUNCE_MS);
 
     return () => {
-      if (fetchTimeoutRef.current) {
-        clearTimeout(fetchTimeoutRef.current);
-      }
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current);
-      }
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
+      if (fetchTimeoutRef.current) clearTimeout(fetchTimeoutRef.current);
+      if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+      abortController.abort();
     };
-  }, [searchParams, fetchListings, shouldRenderMap, isV2Enabled, hasV2Data]);
+  }, [searchParams, shouldRenderMap, isV2Enabled, hasV2Data, setIsV2Enabled, fetchTile, hasBoundsInUrl]);
 
   const handleRetry = useCallback(() => {
-    // Validate viewport before retrying - prevents API call for known-invalid viewports
     const validation = isValidViewport(searchParams);
     if (!validation.valid) {
       setError(validation.error || "Invalid viewport");
       return;
     }
-
-    // P1-1 FIX: Abort any existing request before starting retry
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    // Create new AbortController for retry request
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    // Force a refetch by clearing the last fetched ref
-    lastFetchedParamsRef.current = null;
+    lastSubscriptionKeyRef.current = null;
     setError(null);
-    fetchListings(getMapRelevantParams(searchParams), abortController.signal);
-  }, [searchParams, fetchListings]);
+    setIsFetchingMapData(false);
+  }, [searchParams]);
 
-  // P2-FIX (#115): Also show placeholder when data path hasn't been determined yet.
-  // This prevents the brief empty map flash between mount and v2 signal.
   const showInitialPlaceholder = !dataPathDetermined || (isV2Enabled && !hasAnyV2Data);
   const showV2LoadingOverlay = isV2Enabled && !hasV2Data && hasAnyV2Data;
 
-  // CRITICAL: Don't render map component if shouldRenderMap is false
-  // This prevents MapLibre GL JS from loading until needed
   if (!shouldRenderMap) {
     return null;
   }
 
-  // Show loading placeholder while waiting for data (race guard)
-  // P2-FIX (#115): Also show when data path hasn't been determined to prevent brief empty map.
-  // IMPORTANT: If there's an error (e.g., viewport too large), show error banner instead
-  // NOTE: min-h-[300px] ensures error banner is visible even when parent chain has
-  // zero height (h-full chain issue) combined with overflow-hidden clipping
   if (showInitialPlaceholder) {
     return (
       <div className="relative w-full h-full min-h-[300px]">
@@ -844,15 +613,11 @@ export default function PersistentMapWrapper({
 
   return (
     <div className="relative w-full h-full min-h-[300px]">
-      {/* P2-FIX (#151): Show error banner for errors, info banner for non-error messages */}
       {error && <MapErrorBanner message={error} onRetry={handleRetry} />}
       {!error && infoMessage && <MapInfoBanner message={infoMessage} />}
-      {/* Data loading bar - shows when fetching map markers after pan/zoom/filter */}
       {(isFetchingMapData || isListTransitioning || showV2LoadingOverlay) && (
         <MapDataLoadingBar />
       )}
-      {/* Marker loading shimmer removed - stale-while-revalidate keeps old markers visible */}
-      {/* Coordinated loading overlay - shows when list is transitioning (filter change) */}
       {isListTransitioning && <MapTransitionOverlay />}
       <MapErrorBoundary>
         <Suspense fallback={<MapLoadingPlaceholder />}>

--- a/src/lib/search-types.ts
+++ b/src/lib/search-types.ts
@@ -66,6 +66,7 @@ export interface FilterParams {
   languages?: string[];
   genderPreference?: string;
   householdGender?: string;
+  zoom?: number;
   bounds?: {
     minLat: number;
     maxLat: number;


### PR DESCRIPTION
### Motivation

- Reduce heavy viewport-wide map queries and improve UX by fetching per-tile data keyed to visible tiles and zoom. 
- Support aggregated clusters at low zoom and expanded pin sets at high zoom with optional density metadata for progressive disclosure. 
- Move map query planning server-side to be zoom-aware and stop relying on a single global `LIMIT 200` as the primary control mechanism.

### Description

- Added a new tile API endpoint `GET /api/map-tiles/[z]/[x]/[y]` that validates tile coords, parses canonical filters and returns a per-tile payload with optional density metadata (file: `src/app/api/map-tiles/[z]/[x]/[y]/route.ts`).
- Refactored backend map queries in `src/lib/data.ts` by extracting `buildMapBaseFilters`, adding `getMapTileListings` and helpers (`tileToBounds`, tile/grid clustering constants and types), and introducing zoom-aware plans that return either cluster buckets (low zoom) or expanded pins (high zoom); new types: `MapTileRequestParams`, `MapTileResult`, `MapTileDensityMetadata`.
- Reworked the client map fetcher in `src/components/PersistentMapWrapper.tsx` to subscribe to visible tile keys + zoom instead of issuing a single viewport-wide fetch; implemented tile-keyed caching, in-flight tracking, abort/retry handling, stale-while-revalidate merge behavior and an LRU eviction for tile cache while preserving the previous UX and error/info banners.
- Added optional `zoom?: number` to `FilterParams` in `src/lib/search-types.ts` to support zoom-aware planning and propagation of zoom into tile requests.

### Testing

- Ran linting with `npx eslint src/components/PersistentMapWrapper.tsx src/lib/data.ts src/app/api/map-tiles/[z]/[x]/[y]/route.ts src/lib/search-types.ts`; result: no new errors, existing `no-explicit-any` warnings in `src/lib/data.ts` remain.
- Type checking with `npm run -s typecheck` succeeded (route types generated).
- Started dev server (`npm run dev`) to validate runtime wiring; server start revealed missing `DATABASE_URL` in the environment which prevented full DB-backed rendering in this environment (expected in CI/dev without DB credentials).
- Exercised frontend route with a Playwright script to verify map rendering flow and captured a screenshot artifact demonstrating the change (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f73ed7ca48331a3a3e1fc5f3934cc)