### PR TITLE
fix(booking): handle concurrent booking race condition gracefully (BUG-001)

### DIFF
--- a/BUGS_FOUND.md
+++ b/BUGS_FOUND.md
@@ -12,5 +12,6 @@
   3. One request succeeds, the other returns 500 instead of a conflict response
 - **CI evidence**: Shard 4 of run #23572376788 — `error500B` assertion failed at line 484
 - **Root cause (likely)**: The booking server action lacks proper optimistic locking or conflict handling. When two concurrent transactions compete for the same slot, the losing transaction hits an unhandled database constraint violation instead of catching it gracefully.
-- **Test status**: Marked as `test.fixme()` until the app-level race condition handler returns a proper conflict response instead of 500.
+- **Test status**: ~~Marked as `test.fixme()`~~ **FIXED** — unskipped TEST-201.
+- **Fix**: Wrapped `withIdempotency()` calls in `createBooking()` and `createHold()` with try/catch. When serialization retries are exhausted or non-retryable DB errors occur, the function now returns `{ success: false, code: "CONFLICT" }` instead of throwing an unhandled exception that propagates as a 500.
 - **CLAUDE.md reference**: "two users competing cannot create impossible states" — the 500 error is technically not an impossible state (no double-booking occurred), but the error response violates the reliability invariant.

--- a/src/app/actions/booking.ts
+++ b/src/app/actions/booking.ts
@@ -454,22 +454,40 @@ export async function createBooking(
   // P0-04 FIX: Use withIdempotency wrapper for atomic idempotency handling
   // This ensures idempotency key is claimed BEFORE transaction runs, not after
   if (idempotencyKey) {
-    const idempotencyResult = await withIdempotency<InternalBookingResult>(
-      idempotencyKey,
-      userId,
-      "createBooking",
-      requestBody,
-      async (tx) =>
-        executeBookingTransaction(
-          tx,
-          userId,
-          listingId,
-          startDate,
-          endDate,
-          pricePerMonth,
-          slotsRequested
-        )
-    );
+    let idempotencyResult: Awaited<ReturnType<typeof withIdempotency<InternalBookingResult>>>;
+    try {
+      idempotencyResult = await withIdempotency<InternalBookingResult>(
+        idempotencyKey,
+        userId,
+        "createBooking",
+        requestBody,
+        async (tx) =>
+          executeBookingTransaction(
+            tx,
+            userId,
+            listingId,
+            startDate,
+            endDate,
+            pricePerMonth,
+            slotsRequested
+          )
+      );
+    } catch (error) {
+      // BUG-001 FIX: withIdempotency throws on serialization exhaustion or
+      // non-retryable DB errors. Catch and return gracefully instead of
+      // letting it propagate as a 500 Internal Server Error.
+      logger.sync.error("Booking idempotency transaction failed", {
+        action: "createBooking",
+        error: error instanceof Error ? error.message : "Unknown error",
+        listingId,
+        userId,
+      });
+      return {
+        success: false,
+        error: "Booking could not be completed due to high demand. Please try again.",
+        code: "CONFLICT",
+      };
+    }
 
     // Handle idempotency wrapper errors (400 for hash mismatch, 500 for lock failure)
     if (!idempotencyResult.success) {
@@ -1024,22 +1042,40 @@ export async function createHold(
 
   // Idempotency path
   if (idempotencyKey) {
-    const idempotencyResult = await withIdempotency<InternalHoldResult>(
-      idempotencyKey,
-      userId,
-      "createHold",
-      requestBody,
-      async (tx) =>
-        executeHoldTransaction(
-          tx,
-          userId,
-          listingId,
-          startDate,
-          endDate,
-          pricePerMonth,
-          slotsRequested
-        )
-    );
+    let idempotencyResult: Awaited<ReturnType<typeof withIdempotency<InternalHoldResult>>>;
+    try {
+      idempotencyResult = await withIdempotency<InternalHoldResult>(
+        idempotencyKey,
+        userId,
+        "createHold",
+        requestBody,
+        async (tx) =>
+          executeHoldTransaction(
+            tx,
+            userId,
+            listingId,
+            startDate,
+            endDate,
+            pricePerMonth,
+            slotsRequested
+          )
+      );
+    } catch (error) {
+      // BUG-001 FIX: withIdempotency throws on serialization exhaustion or
+      // non-retryable DB errors. Catch and return gracefully instead of
+      // letting it propagate as a 500 Internal Server Error.
+      logger.sync.error("Hold idempotency transaction failed", {
+        action: "createHold",
+        error: error instanceof Error ? error.message : "Unknown error",
+        listingId,
+        userId,
+      });
+      return {
+        success: false,
+        error: "Hold could not be placed due to high demand. Please try again.",
+        code: "CONFLICT",
+      };
+    }
 
     if (!idempotencyResult.success) {
       logger.sync.warn("Idempotency check failed", {

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -232,6 +232,7 @@ export default function BookingForm({
   const categorizeError = (result: BookingResult): ErrorType => {
     if (result.code === "SESSION_EXPIRED") return "auth";
     if (result.code === "PRICE_CHANGED") return "validation";
+    if (result.code === "CONFLICT") return "server";
     if (result.fieldErrors && Object.keys(result.fieldErrors).length > 0)
       return "validation";
 
@@ -419,6 +420,11 @@ export default function BookingForm({
         if (result.code === "PRICE_CHANGED" && result.currentPrice != null) {
           setMessage(
             `The listing price has changed to $${result.currentPrice}/month. Please review and try again.`
+          );
+        } else if (result.code === "CONFLICT") {
+          setMessage(
+            result.error ||
+              "Could not be completed due to high demand. Please try again."
           );
         } else if (errType === "rate_limit") {
           setMessage(

--- a/tests/e2e/stability/stability-phase2.spec.ts
+++ b/tests/e2e/stability/stability-phase2.spec.ts
@@ -381,11 +381,9 @@ test.describe("Stability Phase 2: Concurrency @stability @concurrency", () => {
    * TEST-201: Two Users Simultaneous Booking — No Crash
    * Invariant: SI-09 — serializable isolation handles concurrent writes
    */
-  // FINDING-004: Unskipped, but concurrent booking triggers 500 error on one request
-  // APP BUG: When two users book simultaneously, one gets a 500 Internal Server Error
-  // instead of a graceful "slot taken" message. Logged in BUGS_FOUND.md.
-  // Using test.fixme until the app-level race condition is fixed.
-  test.fixme("TEST-201: Two users booking simultaneously — both complete without crash", async ({
+  // BUG-001 FIXED: withIdempotency now catches serialization exhaustion and returns
+  // { success: false, code: "CONFLICT" } instead of throwing a 500.
+  test("TEST-201: Two users booking simultaneously — both complete without crash", async ({
     browser,
   }, testInfo) => {
     test.slow();

--- a/tests/e2e/stability/stability-phase2.spec.ts
+++ b/tests/e2e/stability/stability-phase2.spec.ts
@@ -463,7 +463,7 @@ test.describe("Stability Phase 2: Concurrency @stability @concurrency", () => {
         await p
           .waitForFunction(
             () =>
-              /request sent|booking confirmed|submitted|already have|error|failed|slots/i.test(
+              /request sent|booking confirmed|submitted|already have|error|failed|slots|could not be completed|high demand/i.test(
                 document.body.innerText
               ),
             { timeout: 60_000 }


### PR DESCRIPTION
## Summary

Fixes the concurrent booking race condition that caused a 500 Internal Server Error when two users booked the same listing simultaneously.

**Root cause:** `withIdempotency()` in `src/lib/idempotency.ts` throws on serialization retry exhaustion (line 256) or non-retryable DB errors (line 264). Both `createBooking()` and `createHold()` called it without try/catch, so the exception propagated through Next.js as an unhandled 500 visible to the user.

**Fix:** Wrap both `withIdempotency()` calls in try/catch blocks that return `{ success: false, code: "CONFLICT" }` with user-friendly messages instead of unhandled exceptions.

- `createBooking()`: "Booking could not be completed due to high demand. Please try again."
- `createHold()`: "Hold could not be placed due to high demand. Please try again."

**Also:** Unskips TEST-201 (concurrent booking E2E test) which was marked `test.fixme` pending this fix.

## Test plan
- [x] TypeScript compiles clean
- [ ] CI E2E tests pass (TEST-201 now unskipped and should pass)
- [ ] Manual: open same listing in 2 browsers, book simultaneously — both should get a response (one success, one "high demand" message), neither should see 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)