### PR TITLE
fix(tests): add missing getContainer to MapLibre mock — 67 failures → 0

### DIFF
--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -156,6 +156,11 @@ function createMockMapInstance() {
     loaded: jest.fn(() => true),
     isSourceLoaded: jest.fn(() => true),
     getCanvas: jest.fn(() => mockCanvas),
+    getContainer: jest.fn(() => {
+      const container = document.createElement("div");
+      container.setAttribute("data-testid", "map-container-mock");
+      return container;
+    }),
   };
 }
 

--- a/src/__tests__/components/map/touch-gestures.test.tsx
+++ b/src/__tests__/components/map/touch-gestures.test.tsx
@@ -127,6 +127,11 @@ function createMockMapInstance() {
     resize: jest.fn(),
     loaded: jest.fn(() => true),
     getCanvas: jest.fn(() => ({ tabIndex: 0 })),
+    getContainer: jest.fn(() => {
+      const container = document.createElement("div");
+      container.setAttribute("data-testid", "map-container-mock");
+      return container;
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary

Adds `getContainer()` to the MapLibre mock in both map test files, resolving all 67 component test failures.

### Root Cause
P1 FLAKE-003 fix added `getContainer()` calls to `Map.tsx` for the `data-map-ready` DOM attribute. The test mock was never updated to include this method, causing `TypeError: mapRef.current.getMap(...).getContainer is not a function` in every map-related test.

### Fix
Added `getContainer: jest.fn(() => document.createElement('div'))` to `createMockMapInstance()` in:
- `src/__tests__/components/Map.test.tsx` (44 tests fixed)
- `src/__tests__/components/map/touch-gestures.test.tsx` (23 tests fixed)

### Results
- **Before**: 67 failed, 1 passed
- **After**: 0 failed, 68 passed
- **Full suite**: 321 suites, 7,039 tests, 0 failures

## Test plan
- [x] `pnpm test --no-coverage` — 7,039 passed, 0 failures, 321/321 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)