### PR TITLE
fix(build): allow Prisma fallback URL during Next.js build phase

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -19,7 +19,9 @@ const FALLBACK_DATABASE_URL =
 const getDatasourceUrl = () => {
   const baseUrl = process.env.DATABASE_URL;
   if (!baseUrl) {
-    if (process.env.NODE_ENV === "test") {
+    // Allow build-time static generation (no DB needed for prerendering)
+    // NEXT_PHASE is set by Next.js during `next build`
+    if (process.env.NODE_ENV === "test" || process.env.NEXT_PHASE) {
       return FALLBACK_DATABASE_URL;
     }
 


### PR DESCRIPTION
## Summary
- Vercel preview/production deploys fail because `DATABASE_URL` isn't set at build time
- During `next build`, Next.js prerenders `/_not-found` which evaluates the layout tree, loading the Prisma client — which throws if no `DATABASE_URL` is configured
- Fix: allow the placeholder fallback URL when `NEXT_PHASE` is set (same pattern already used in `env.ts`)

## What changed
**`src/lib/prisma.ts`** — 1-line condition change in `getDatasourceUrl()`:
```diff
- if (process.env.NODE_ENV === "test") {
+ if (process.env.NODE_ENV === "test" || process.env.NEXT_PHASE) {
```

## Why this is safe
- `NEXT_PHASE` is only set by Next.js during `next build` — never at runtime
- No actual DB queries execute during static page prerendering
- The fallback URL is a non-routable placeholder that would fail if any query actually ran
- Same guard pattern already used in `src/lib/env.ts` for env validation

## Test plan
- [x] Typecheck passes
- [x] Logic verified: `NEXT_PHASE=phase-production-build` with no `DATABASE_URL` returns fallback
- [ ] Vercel preview deploy should succeed on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)