### PR TITLE
fix(ui): normalize price formatting to canonical $X,XXX/mo

### DIFF
--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -1785,7 +1785,7 @@ describe("Map Component", () => {
       markerWrappers.forEach((wrapper) => {
         const ariaLabel = wrapper.getAttribute("aria-label");
         expect(ariaLabel).toBeTruthy();
-        expect(ariaLabel).toMatch(/\$\d+\/month/);
+        expect(ariaLabel).toMatch(/\$[\d,]+ per month/);
       });
     });
 

--- a/src/app/admin/listings/ListingList.tsx
+++ b/src/app/admin/listings/ListingList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { updateListingStatus, deleteListing } from "@/app/actions/admin";
+import { formatPrice } from "@/lib/format";
 import {
   Search,
   Loader2,
@@ -241,8 +242,7 @@ export default function ListingList({
                             </span>
                           )}
                           <span className="flex items-center gap-1">
-                            <DollarSign className="w-3 h-3" />${listing.price}
-                            /mo
+                            <DollarSign className="w-3 h-3" />{formatPrice(Number(listing.price))}/mo
                           </span>
                           <span className="flex items-center gap-1">
                             <Eye className="w-3 h-3" />

--- a/src/app/recently-viewed/RecentlyViewedClient.tsx
+++ b/src/app/recently-viewed/RecentlyViewedClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Clock, Search, MapPin, Home } from "lucide-react";
+import { formatPrice } from "@/lib/format";
 
 // Placeholder images for when listing has no images
 const PLACEHOLDER_IMAGES = [
@@ -173,7 +174,7 @@ export default function RecentlyViewedClient({
                     </p>
                   )}
                   <p className="font-semibold text-on-surface mt-2">
-                    ${(listing.price ?? 0).toLocaleString()}
+                    {formatPrice(listing.price ?? 0)}
                     <span className="text-on-surface-variant font-normal text-sm">
                       /mo
                     </span>

--- a/src/app/recently-viewed/page.tsx
+++ b/src/app/recently-viewed/page.tsx
@@ -4,7 +4,7 @@ import { getRecentlyViewed } from "@/app/actions/listing-status";
 import RecentlyViewedClient from "./RecentlyViewedClient";
 
 export const metadata = {
-  title: "Recently Viewed | RoomShare",
+  title: "Recently Viewed | Roomshare",
   description: "Listings you have recently viewed",
 };
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -34,6 +34,7 @@ import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Home, Loader2, MapPin, Maximize2, X } from "lucide-react";
 import { triggerHaptic } from "@/lib/haptics";
+import { formatPrice } from "@/lib/format";
 import { Button } from "./ui/button";
 import { MAP_FLY_TO_EVENT, MapFlyToEventDetail } from "./SearchForm";
 import { useListingFocus } from "@/contexts/ListingFocusContext";
@@ -571,7 +572,7 @@ const MapMarkerItem = React.memo(function MapMarkerItem({
     [listingId, onClickById, onKeyboardNav]
   );
 
-  const ariaLabel = `$${price}/month${title ? `, ${title}` : ""}${availableSlots > 0 ? `, ${availableSlots} spots available` : ", currently filled"}. Use arrow keys to navigate between markers.`;
+  const ariaLabel = `${formatPrice(price)} per month${title ? `, ${title}` : ""}${availableSlots > 0 ? `, ${availableSlots} spots available` : ", currently filled"}. Use arrow keys to navigate between markers.`;
 
   return (
     <Marker
@@ -2670,7 +2671,7 @@ export default function MapComponent({
         aria-atomic="true"
       >
         {selectedListing
-          ? `Selected listing: ${selectedListing.title}, $${selectedListing.price} per month, ${selectedListing.availableSlots > 0 ? `${selectedListing.availableSlots} spots available` : "currently filled"}`
+          ? `Selected listing: ${selectedListing.title}, ${formatPrice(selectedListing.price)} per month, ${selectedListing.availableSlots > 0 ? `${selectedListing.availableSlots} spots available` : "currently filled"}`
           : ""}
       </div>
 
@@ -2699,7 +2700,7 @@ export default function MapComponent({
             const index = sortedMarkerPositions.findIndex(
               (p) => p.listing.id === keyboardFocusedId
             );
-            return `Marker ${index + 1} of ${sortedMarkerPositions.length}: ${focused.listing.title || "Listing"}, $${focused.listing.price} per month`;
+            return `Marker ${index + 1} of ${sortedMarkerPositions.length}: ${focused.listing.title || "Listing"}, ${formatPrice(focused.listing.price)} per month`;
           })()}
       </div>
 

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -390,8 +390,8 @@ function ListingCardInner({
                     {formatPrice(listing.price)}
                   </span>
                   {listing.price > 0 && (
-                    <span className="text-on-surface-variant text-xs ml-1 uppercase tracking-wider font-medium">
-                      / mo
+                    <span className="text-on-surface-variant text-xs ml-1 tracking-wider font-medium">
+                      /mo
                     </span>
                   )}
                 </>

--- a/src/components/search/DatePills.tsx
+++ b/src/components/search/DatePills.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { formatPrice } from "@/lib/format";
 
 export interface DateSuggestion {
   /** Display label, e.g. "Feb 15 – Mar 15" */
@@ -55,11 +56,7 @@ export function DatePills({ suggestions }: DatePillsProps) {
               {suggestion.label}
             </span>
             <span className="text-xs text-green-600 font-medium whitespace-nowrap">
-              ~$
-              {suggestion.avgPrice.toLocaleString("en-US", {
-                maximumFractionDigits: 0,
-              })}
-              /mo
+              ~{formatPrice(suggestion.avgPrice)}/mo
             </span>
           </button>
         ))}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -7,6 +7,11 @@ export function formatPrice(price: number): string {
   return `$${priceFormatter.format(price)}`;
 }
 
+/** Canonical monthly price: "$1,500/mo" */
+export function formatPricePerMonth(price: number): string {
+  return `${formatPrice(price)}/mo`;
+}
+
 export function formatPriceCompact(price: number): string {
   const num = typeof price === "number" ? price : parseInt(String(price), 10);
   if (isNaN(num)) return "$0";


### PR DESCRIPTION
## Summary
- Standardize all price display across the app to use the shared `formatPrice()` utility from `src/lib/format.ts`
- Add `formatPricePerMonth()` helper for the canonical `$X,XXX/mo` pattern
- Fix brand name inconsistency in recently-viewed metadata

## Changes (8 files)
| File | Before | After |
|------|--------|-------|
| `ListingCard.tsx` | `/ MO` (uppercase, spaced) | `/mo` |
| `DatePills.tsx` | inline `toLocaleString()` | `formatPrice()` |
| `ListingList.tsx` (admin) | raw `${listing.price}` | `formatPrice()` |
| `RecentlyViewedClient.tsx` | inline `toLocaleString()` | `formatPrice()` |
| `Map.tsx` (3 aria labels) | raw `$${price}/month` | `formatPrice(price) per month` |
| `format.ts` | - | Added `formatPricePerMonth()` |
| `Map.test.tsx` | `/\$\d+\/month/` | `/\$[\d,]+ per month/` |

## Test plan
- [x] Typecheck passes
- [x] Lint passes (0 errors)
- [x] 69 related tests pass (ListingCard + Map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)