### PR TITLE
fix(map,e2e): suppress map empty-state flash and stabilize 3 flaky tests

### DIFF
--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -1498,7 +1498,8 @@ describe("Map Component", () => {
       render(<MapComponent listings={[]} />);
 
       await act(async () => {
-        jest.advanceTimersByTime(100);
+        // Advance past the 1.5s map initialization gate + render cycle
+        jest.advanceTimersByTime(2000);
       });
 
       expect(screen.getByText(/no listings in this area/i)).toBeInTheDocument();
@@ -1511,7 +1512,7 @@ describe("Map Component", () => {
       render(<MapComponent listings={[]} />);
 
       await act(async () => {
-        jest.advanceTimersByTime(100);
+        jest.advanceTimersByTime(2000);
       });
 
       expect(

--- a/src/app/listings/create/CreateListingForm.tsx
+++ b/src/app/listings/create/CreateListingForm.tsx
@@ -617,6 +617,7 @@ export default function CreateListingForm({
                 key={section.id}
                 className="flex items-center flex-1"
                 aria-label={`Step ${index + 1} of ${FORM_SECTIONS.length}: ${section.label}, ${isComplete ? "complete" : "incomplete"}`}
+                data-step-complete={isComplete}
               >
                 {/* Step Circle */}
                 <div className="flex flex-col items-center">

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -864,6 +864,8 @@ export default function MapComponent({
   // Scale map label text with OS/browser font-size (Dynamic Type support)
   const [textScale, setTextScale] = useState(1);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
+  // Suppress MapEmptyState during initialization — map data fetch lags behind list SSR
+  const [isMapInitialized, setIsMapInitialized] = useState(false);
   const [isWebglContextLost, setIsWebglContextLost] = useState(false);
   const [mapRemountKey, setMapRemountKey] = useState(0);
   const [currentZoom, setCurrentZoom] = useState(12);
@@ -1003,6 +1005,17 @@ export default function MapComponent({
       roomshare.mapInitCount = ((roomshare.mapInitCount as number) || 0) + 1;
     }
   }, []); // Empty deps = only on mount
+
+  // Mark map as initialized after data has had time to arrive.
+  // Prevents "No listings" flash while map fetch catches up to list SSR.
+  useEffect(() => {
+    if (listings.length > 0) {
+      setIsMapInitialized(true);
+      return;
+    }
+    const timer = setTimeout(() => setIsMapInitialized(true), 1500);
+    return () => clearTimeout(timer);
+  }, [listings.length]);
 
   // Detect dark mode
   useEffect(() => {
@@ -3294,6 +3307,7 @@ export default function MapComponent({
 
       {/* Empty state overlay - when map is loaded but no listings in viewport */}
       {isMapLoaded &&
+        isMapInitialized &&
         !areTilesLoading &&
         !isSearching &&
         !suppressEmptyState &&

--- a/tests/e2e/booking/booking-state-guards.spec.ts
+++ b/tests/e2e/booking/booking-state-guards.spec.ts
@@ -610,10 +610,11 @@ test.describe("Booking State Guards: Terminal States @critical @booking @securit
       });
       await navigateToBookingsTab(page, "received");
 
-      // Look for expired badge
+      // Look for expired badge — allow time for booking list to hydrate
       const expiredBadge = page.getByText("Expired").first();
       const badgeVisible = await expiredBadge
-        .isVisible({ timeout: 10_000 })
+        .waitFor({ state: "visible", timeout: 30_000 })
+        .then(() => true)
         .catch(() => false);
 
       if (badgeVisible) {

--- a/tests/e2e/journeys/02-auth.spec.ts
+++ b/tests/e2e/journeys/02-auth.spec.ts
@@ -243,12 +243,11 @@ test.describe("Authentication Journeys", () => {
         .click();
 
       // Should show error without revealing which field is wrong
+      // Scope to the form error container to avoid matching unrelated alerts
       await expect(
-        page
-          .getByText(/invalid|incorrect|wrong|failed/i)
-          .first()
-          .or(page.locator('[role="alert"]').first())
-      ).toBeVisible({ timeout: 30000 });
+        page.locator('#form-error[role="alert"]:not(:empty)')
+          .or(page.locator('form').getByText(/invalid|incorrect|wrong|failed|check your/i).first())
+      ).toBeVisible({ timeout: 30_000 });
 
       // Should stay on login page
       await expect(page).toHaveURL(/\/login/);

--- a/tests/e2e/page-objects/create-listing.page.ts
+++ b/tests/e2e/page-objects/create-listing.page.ts
@@ -368,12 +368,11 @@ export class CreateListingPage {
   // ── Progress Indicator ──
 
   async getCompletedStepCount(): Promise<number> {
-    // TODO: add data-step-complete attribute to step circles in CreateListingForm
-    // Completed step circles show a Check icon (green background with checkmark)
-    const greenSteps = this.page.locator(
-      '[data-testid="progress-steps"] .w-10.h-10.rounded-full.bg-green-50, [data-testid="progress-steps"] .w-10.h-10.rounded-full[class*="bg-green-900"]'
+    // Use data-step-complete attribute for reliable detection across themes
+    const completedSteps = this.page.locator(
+      '[data-testid="progress-steps"] [data-step-complete="true"]'
     );
-    return greenSteps.count();
+    return completedSteps.count();
   }
 
   async expectProgressText(text: string | RegExp) {


### PR DESCRIPTION
## Summary

### Map desync fix
The map showed "No listings in this area" while the list displayed 100+ results. Root cause: map data fetch lags behind list SSR by ~500-1500ms during hydration. The MapEmptyState was rendering during this gap.

**Fix:** Add `isMapInitialized` gate — suppresses empty state for 1.5s after mount (or immediately when listings arrive).

### Flaky E2E stabilization
Three tests that fail on nearly every CI run, all with `toBeVisible` failures:

| Test | Root Cause | Fix |
|------|-----------|-----|
| `booking-state-guards:603` | `isVisible()` used with timeout param (not supported) | Switch to `waitFor({ state: "visible", timeout: 30s })` |
| `create-listing:329` | CSS class selector breaks during hydration | Add `data-step-complete` attr, use data attribute selector |
| `02-auth:251` | Ambiguous `.or()` matches wrong `role="alert"` | Scope to `#form-error[role="alert"]` |

## Changes (5 files)
- `src/components/Map.tsx` — `isMapInitialized` state + gate on MapEmptyState
- `src/app/listings/create/CreateListingForm.tsx` — `data-step-complete` attribute
- `tests/e2e/booking/booking-state-guards.spec.ts` — `waitFor` instead of `isVisible`
- `tests/e2e/page-objects/create-listing.page.ts` — data attribute selector
- `tests/e2e/journeys/02-auth.spec.ts` — scoped error alert selector

## Test plan
- [x] Typecheck passes
- [x] 40 unit tests pass (Map + CreateListing)
- [ ] E2E shards should show fewer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)