### PR TITLE
[codex] Clarify desktop map hover card highlight

### DIFF
--- a/src/__tests__/components/ListingCard.test.tsx
+++ b/src/__tests__/components/ListingCard.test.tsx
@@ -1,5 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import ListingCard from "@/components/listings/ListingCard";
+import {
+  useListingFocusActions,
+  useIsListingFocused,
+} from "@/contexts/ListingFocusContext";
+
+jest.mock("@/contexts/ListingFocusContext", () => ({
+  useListingFocusActions: jest.fn(),
+  useIsListingFocused: jest.fn(),
+}));
 
 // Mock FavoriteButton
 jest.mock("@/components/FavoriteButton", () => {
@@ -46,6 +55,23 @@ jest.mock("@/components/listings/ImageCarousel", () => ({
   },
 }));
 
+const mockUseListingFocusActions = jest.mocked(useListingFocusActions);
+const mockUseIsListingFocused = jest.mocked(useIsListingFocused);
+
+function mockFocusState({
+  isHovered = false,
+  isActive = false,
+}: {
+  isHovered?: boolean;
+  isActive?: boolean;
+} = {}) {
+  mockUseIsListingFocused.mockReturnValue({
+    isHovered,
+    isActive,
+    isFocused: isHovered || isActive,
+  });
+}
+
 const mockListing = {
   id: "listing-123",
   title: "Cozy Room in Downtown",
@@ -62,6 +88,19 @@ const mockListing = {
   avgRating: 4.9,
   reviewCount: 5,
 };
+
+beforeEach(() => {
+  mockUseListingFocusActions.mockReturnValue({
+    setHovered: jest.fn(),
+    setActive: jest.fn(),
+    requestScrollTo: jest.fn(),
+    ackScrollTo: jest.fn(),
+    clearFocus: jest.fn(),
+    hasProvider: false,
+    focusSourceRef: { current: null },
+  });
+  mockFocusState();
+});
 
 describe("ListingCard", () => {
   describe("rendering", () => {
@@ -256,6 +295,43 @@ describe("ListingCard", () => {
       const listing = { ...mockListing, images: undefined };
       render(<ListingCard listing={listing} />);
       expect(screen.getByText("No Photos")).toBeInTheDocument();
+    });
+  });
+
+  describe("focus state styling", () => {
+    it("renders a stronger hovered state without promoting the card to active", () => {
+      mockFocusState({ isHovered: true });
+
+      render(<ListingCard listing={mockListing} />);
+
+      const article = screen.getByTestId("listing-card");
+      expect(article).toHaveAttribute("data-focus-state", "hovered");
+      expect(article).toHaveClass("ring-2", "ring-primary/50", "shadow-lg");
+      expect(article).not.toHaveClass("ring-offset-2");
+    });
+
+    it("keeps the active state styling distinct from hover", () => {
+      mockFocusState({ isActive: true });
+
+      render(<ListingCard listing={mockListing} />);
+
+      const article = screen.getByTestId("listing-card");
+      expect(article).toHaveAttribute("data-focus-state", "active");
+      expect(article).toHaveClass(
+        "ring-2",
+        "ring-primary",
+        "ring-offset-2",
+        "shadow-xl"
+      );
+      expect(article).not.toHaveClass("ring-primary/50");
+    });
+
+    it("defaults to no focus styling when neither hovered nor active", () => {
+      render(<ListingCard listing={mockListing} />);
+
+      const article = screen.getByTestId("listing-card");
+      expect(article).toHaveAttribute("data-focus-state", "none");
+      expect(article).not.toHaveClass("ring-primary/50", "ring-offset-2");
     });
   });
 

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -308,7 +308,7 @@ function ListingCardInner({
         "group relative flex flex-col rounded-2xl bg-surface-container-lowest mb-4 shadow-sm transition-all duration-500 overflow-hidden cursor-pointer",
         !isActive && "hover:shadow-xl hover:-translate-y-1",
         isActive && "ring-2 ring-primary ring-offset-2 -translate-y-0.5 shadow-xl",
-        isHovered && !isActive && "ring-1 ring-primary/20",
+        isHovered && !isActive && "ring-2 ring-primary/50 shadow-lg",
         className
       )}
     >


### PR DESCRIPTION
## Summary
- strengthen the desktop-only hovered listing-card outline so marker hover is clearly visible in the results rail
- keep the existing focus-state model unchanged so hover remains transient and click-based selection remains persistent
- add focused ListingCard tests for neutral, hovered, and active focus styling states

## Root Cause
Desktop map marker hover only sets `hoveredId`, while the brighter listing-card treatment was reserved for `activeId`. That made marker-hovered cards look visually inconsistent compared with selected cards even though the state wiring was behaving as designed.

## Validation
- `pnpm jest src/__tests__/components/ListingCard.test.tsx --runInBand`
- `pnpm jest src/__tests__/components/Map.test.tsx --runInBand -t 'treats hidden clone IDs as aliases for the visible marker state|suppresses the popup in sheet selection mode while syncing the active listing'`

## Impact
Users hovering map markers on desktop should now see a clearer corresponding card highlight in the listing column without changing selection behavior.