### PR TITLE
[codex] Remove desktop search shortcut hint

### DIFF
--- a/src/__tests__/components/search/DesktopHeaderSearch.test.tsx
+++ b/src/__tests__/components/search/DesktopHeaderSearch.test.tsx
@@ -128,6 +128,8 @@ describe("DesktopHeaderSearch", () => {
   it("blocks typed locations that were not selected from autocomplete", () => {
     render(<DesktopHeaderSearch collapsed={false} />);
 
+    expect(screen.queryByText("⌘")).not.toBeInTheDocument();
+
     fireEvent.change(screen.getByTestId("desktop-location-input"), {
       target: { value: "Chicago" },
     });

--- a/src/components/search/DesktopHeaderSearch.tsx
+++ b/src/components/search/DesktopHeaderSearch.tsx
@@ -504,16 +504,6 @@ export const DesktopHeaderSearch = forwardRef<
           <Search className={cn(collapsed ? "h-4 w-4" : "h-5 w-5")} />
         </Button>
 
-        {!collapsed && (
-          <div className="ml-4 mr-2 hidden items-center gap-1 text-xs font-medium text-on-surface-variant lg:flex">
-            <kbd className="rounded-md border border-outline-variant/20 bg-surface-container-highest px-1.5 py-0.5 font-sans shadow-sm">
-              ⌘
-            </kbd>
-            <kbd className="rounded-md border border-outline-variant/20 bg-surface-container-highest px-1.5 py-0.5 font-sans shadow-sm">
-              K
-            </kbd>
-          </div>
-        )}
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the visible `⌘ K` shortcut hint from the expanded desktop header search UI
- keep the existing `Cmd/Ctrl + K` keyboard shortcut behavior unchanged
- add a component assertion that the expanded desktop form no longer renders the hint

## Why
The badge adds visual clutter and is Mac-specific, while the underlying shortcut logic already supports `Ctrl+K` on non-Mac platforms.

## Validation
- `pnpm exec jest src/__tests__/components/search/DesktopHeaderSearch.test.tsx src/__tests__/hooks/useKeyboardShortcuts.test.ts --runInBand`