### PR TITLE
[codex] Collapse exact cloned map markers

### DIFF
--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -349,6 +349,8 @@ jest.mock("@/lib/haptics", () => ({
 const mockSetHovered = jest.fn();
 const mockSetActive = jest.fn();
 const mockRequestScrollTo = jest.fn();
+let mockHoveredId: string | null = null;
+let mockActiveId: string | null = null;
 const mockSetSearchAsMove = jest.fn();
 const mockSetHasUserMoved = jest.fn();
 const mockSetBoundsDirty = jest.fn();
@@ -370,8 +372,8 @@ const mockPrivacyCircle = jest.fn((props: PrivacyCircleProps) => null);
 
 jest.mock("@/contexts/ListingFocusContext", () => ({
   useListingFocus: () => ({
-    hoveredId: null,
-    activeId: null,
+    hoveredId: mockHoveredId,
+    activeId: mockActiveId,
     setHovered: mockSetHovered,
     setActive: mockSetActive,
     requestScrollTo: mockRequestScrollTo,
@@ -551,6 +553,8 @@ describe("Map Component", () => {
     mockReplaceWithTransition.mockClear();
     mockPrivacyCircle.mockClear();
     mockSearchParams = new URLSearchParams();
+    mockHoveredId = null;
+    mockActiveId = null;
 
     // Reset mock map instance
     mockCanvas = createMockCanvas();
@@ -1458,6 +1462,7 @@ describe("Map Component", () => {
       expect(lastCall).toBeDefined();
       if (!lastCall) return;
       expect(lastCall.listings).toHaveLength(2);
+      expect(screen.getAllByTestId("map-marker")).toHaveLength(2);
 
       // For overlapping points, displayed marker positions should be offset
       // (not collapsed to the same center coordinate).
@@ -1467,6 +1472,98 @@ describe("Map Component", () => {
         )
       );
       expect(uniqueCoords.size).toBe(2);
+    });
+
+    it("collapses exact cloned listings into one displayed marker and privacy circle", async () => {
+      const clonedListings = [
+        {
+          id: "clone-1",
+          title: "Sunny Mission Room",
+          price: 1200,
+          availableSlots: 1,
+          ownerId: "owner-1",
+          images: [],
+          location: { lat: 37.7599, lng: -122.4148 },
+        },
+        {
+          id: "clone-2",
+          title: " sunny mission room ",
+          price: 1200,
+          availableSlots: 1,
+          ownerId: "owner-2",
+          images: [],
+          location: { lat: 37.7599, lng: -122.4148 },
+        },
+      ];
+
+      mockQuerySourceFeaturesData = listingsToFeatures(clonedListings);
+      render(<MapComponent listings={clonedListings} />);
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      const handlers = (
+        window as unknown as Record<string, { onIdle?: () => void }>
+      ).__mapHandlers;
+      await act(async () => {
+        handlers?.onIdle?.();
+      });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId("map-marker")).toHaveLength(1);
+      });
+
+      const calls = mockPrivacyCircle.mock.calls;
+      const lastCall = calls[calls.length - 1]?.[0];
+
+      expect(lastCall).toBeDefined();
+      if (!lastCall) return;
+      expect(lastCall.listings).toHaveLength(1);
+    });
+
+    it("treats hidden clone IDs as aliases for the visible marker state", async () => {
+      const clonedListings = [
+        {
+          id: "clone-1",
+          title: "Sunny Mission Room",
+          price: 1200,
+          availableSlots: 1,
+          ownerId: "owner-1",
+          images: [],
+          location: { lat: 37.7599, lng: -122.4148 },
+        },
+        {
+          id: "clone-2",
+          title: "Sunny Mission Room",
+          price: 1200,
+          availableSlots: 1,
+          ownerId: "owner-2",
+          images: [],
+          location: { lat: 37.7599, lng: -122.4148 },
+        },
+      ];
+
+      mockHoveredId = "clone-2";
+      mockQuerySourceFeaturesData = listingsToFeatures(clonedListings);
+      render(<MapComponent listings={clonedListings} />);
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      const handlers = (
+        window as unknown as Record<string, { onIdle?: () => void }>
+      ).__mapHandlers;
+      await act(async () => {
+        handlers?.onIdle?.();
+      });
+
+      expect(screen.getAllByTestId("map-marker")).toHaveLength(1);
+      expect(screen.getByTestId("map-pin-primary-clone-1")).toHaveAttribute(
+        "data-focus-state",
+        "hovered"
+      );
     });
   });
 

--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -1565,6 +1565,59 @@ describe("Map Component", () => {
         "hovered"
       );
     });
+
+    it("keeps visually different tiered markers separate even when other fields match", async () => {
+      const tieredListings = [
+        {
+          id: "primary-pin",
+          title: "Sunny Mission Room",
+          price: 1200,
+          availableSlots: 1,
+          ownerId: "owner-1",
+          images: [],
+          location: { lat: 37.7599, lng: -122.4148 },
+          tier: "primary" as const,
+        },
+        {
+          id: "mini-pin",
+          title: "Sunny Mission Room",
+          price: 1200,
+          availableSlots: 1,
+          ownerId: "owner-2",
+          images: [],
+          location: { lat: 37.7599, lng: -122.4148 },
+          tier: "mini" as const,
+        },
+      ];
+
+      mockQuerySourceFeaturesData = listingsToFeatures(tieredListings);
+      render(<MapComponent listings={tieredListings} />);
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      const handlers = (
+        window as unknown as Record<string, { onIdle?: () => void }>
+      ).__mapHandlers;
+      await act(async () => {
+        handlers?.onIdle?.();
+      });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId("map-marker")).toHaveLength(2);
+      });
+
+      const calls = mockPrivacyCircle.mock.calls;
+      const lastCall = calls[calls.length - 1]?.[0];
+
+      expect(lastCall).toBeDefined();
+      if (!lastCall) return;
+      expect(lastCall.listings).toHaveLength(2);
+      expect(lastCall.listings.map((entry: { id: string }) => entry.id)).toEqual(
+        expect.arrayContaining(["primary-pin", "mini-pin"])
+      );
+    });
   });
 
   describe("marker retry mechanism", () => {

--- a/src/__tests__/lib/maps/marker-utils.test.ts
+++ b/src/__tests__/lib/maps/marker-utils.test.ts
@@ -8,6 +8,7 @@
 import {
   COORD_PRECISION,
   groupListingsByCoord,
+  groupExactMapListingClones,
   formatStackPriceRange,
   type MapMarkerListing,
 } from "@/lib/maps/marker-utils";
@@ -202,6 +203,63 @@ describe("marker-utils", () => {
       const result = formatStackPriceRange(listings);
       expect(result).toContain("–"); // en-dash U+2013
       expect(result).not.toMatch(/\$\d+-\$\d+/); // not hyphen
+    });
+  });
+
+  describe("groupExactMapListingClones", () => {
+    const createCloneCandidate = (
+      id: string,
+      overrides: Partial<MapMarkerListing> = {}
+    ): MapMarkerListing => ({
+      id,
+      title: " Sunny Mission Room ",
+      price: 1200,
+      availableSlots: 1,
+      ownerId: `owner-${id}`,
+      location: { lat: 37.7599, lng: -122.4148 },
+      ...overrides,
+    });
+
+    it("collapses exact clones with different IDs into one canonical group", () => {
+      const groups = groupExactMapListingClones([
+        createCloneCandidate("clone-1"),
+        createCloneCandidate("clone-2", { title: "sunny mission room" }),
+      ]);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].listing.id).toBe("clone-1");
+      expect(groups[0].memberIds).toEqual(["clone-1", "clone-2"]);
+      expect(groups[0].listings.map((listing) => listing.id)).toEqual([
+        "clone-1",
+        "clone-2",
+      ]);
+    });
+
+    it("preserves first-listing priority when choosing the canonical marker", () => {
+      const groups = groupExactMapListingClones([
+        createCloneCandidate("first"),
+        createCloneCandidate("second"),
+        createCloneCandidate("third"),
+      ]);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].listing.id).toBe("first");
+      expect(groups[0].memberIds).toEqual(["first", "second", "third"]);
+    });
+
+    it("does not collapse distinct co-located listings", () => {
+      const groups = groupExactMapListingClones([
+        createCloneCandidate("clone-1"),
+        createCloneCandidate("different-title", { title: "Mission Room B" }),
+        createCloneCandidate("different-price", { price: 1300 }),
+      ]);
+
+      expect(groups).toHaveLength(3);
+      expect(groups.map((group) => group.listing.id)).toEqual([
+        "clone-1",
+        "different-title",
+        "different-price",
+      ]);
     });
   });
 

--- a/src/__tests__/lib/maps/marker-utils.test.ts
+++ b/src/__tests__/lib/maps/marker-utils.test.ts
@@ -261,6 +261,19 @@ describe("marker-utils", () => {
         "different-price",
       ]);
     });
+
+    it("does not collapse listings that differ by visible marker tier", () => {
+      const groups = groupExactMapListingClones([
+        createCloneCandidate("primary", { tier: "primary" }),
+        createCloneCandidate("mini", { tier: "mini" }),
+      ]);
+
+      expect(groups).toHaveLength(2);
+      expect(groups.map((group) => group.listing.id)).toEqual([
+        "primary",
+        "mini",
+      ]);
+    });
   });
 
   /**

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -68,6 +68,7 @@ import {
   MAP_FETCH_MAX_LAT_SPAN,
   MAP_FETCH_MAX_LNG_SPAN,
 } from "@/lib/constants";
+import { groupExactMapListingClones } from "@/lib/maps/marker-utils";
 import { SNAP_COLLAPSED } from "@/lib/mobile-layout";
 import { SEARCH_PHONE_MAX_QUERY } from "@/lib/search-layout";
 import { cn } from "@/lib/utils";
@@ -180,6 +181,7 @@ interface Listing {
 
 interface MarkerPosition {
   listing: Listing;
+  memberIds: string[];
   lat: number;
   lng: number;
 }
@@ -1438,33 +1440,47 @@ export default function MapComponent({
   // When clustering, use unclustered listings; otherwise use all listings
   const markersSource = useClustering ? unclusteredListings : listings;
 
-  // P2-FIX (#150): Create stable ID key to avoid recalculating markerPositions
-  // when array reference changes but listing IDs remain the same
-  const markersSourceKey = useMemo(() => {
+  // Build a stable marker signature so grouping recalculates only when the
+  // rendered marker payload changes, not when parent arrays are recreated.
+  const markersSourceSignature = useMemo(() => {
     return markersSource
-      .map((l) => l.id)
+      .map((listing) =>
+        [
+          listing.id,
+          listing.title.trim(),
+          listing.price,
+          listing.availableSlots,
+          listing.location.lat,
+          listing.location.lng,
+          listing.tier ?? "",
+        ].join(":")
+      )
       .sort()
       .join(",");
   }, [markersSource]);
 
-  // HIGH-1 FIX: Read markersSource via closure instead of ref.
-  // The ref-in-memo pattern was a React anti-pattern (stale data risk, React Compiler incompatible).
-  // markersSourceKey still controls when the memo recomputes (P2-FIX #150 preserved).
+  const groupedMarkers = useMemo(() => {
+    return groupExactMapListingClones(markersSource);
+    // markersSourceSignature controls recomputation while the closure reads the latest source.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [markersSourceSignature]);
+
   const markerPositions = useMemo(() => {
-    const source = markersSource;
+    const source = groupedMarkers;
     const positions: MarkerPosition[] = [];
     const coordsCounts: Record<string, number> = {};
 
     // First pass: count how many listings share each coordinate
-    source.forEach((listing) => {
-      const key = `${listing.location.lat},${listing.location.lng}`;
+    source.forEach((group) => {
+      const key = `${group.listing.location.lat},${group.listing.location.lng}`;
       coordsCounts[key] = (coordsCounts[key] || 0) + 1;
     });
 
     // Second pass: add offsets for overlapping markers
     const coordsIndices: Record<string, number> = {};
 
-    source.forEach((listing) => {
+    source.forEach((group) => {
+      const listing = group.listing;
       const key = `${listing.location.lat},${listing.location.lng}`;
       const count = coordsCounts[key] || 1;
 
@@ -1472,6 +1488,7 @@ export default function MapComponent({
         // No overlap, use original coordinates
         positions.push({
           listing,
+          memberIds: group.memberIds,
           lat: listing.location.lat,
           lng: listing.location.lng,
         });
@@ -1493,6 +1510,7 @@ export default function MapComponent({
 
         positions.push({
           listing,
+          memberIds: group.memberIds,
           lat: listing.location.lat + latOffset,
           lng: listing.location.lng + lngOffset,
         });
@@ -1500,18 +1518,28 @@ export default function MapComponent({
     });
 
     return positions;
-    // P2-FIX (#150): Depend on stable ID key instead of array reference
+    // Depend on the grouped marker signature instead of array reference churn.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [markersSourceKey]);
+  }, [markersSourceSignature]);
 
   // CRIT-2 FIX: Synchronous ref for stable callback access to latest positions.
   // Synchronous assignment (not useEffect) avoids timing issues between render and effect.
   const markerPositionsRef = useRef(markerPositions);
   markerPositionsRef.current = markerPositions;
 
-  // O(1) lookup Set for ClusterHighlightMarker — avoids O(n) .some() scan
+  const markerPositionById = useMemo(() => {
+    const map = new globalThis.Map<string, MarkerPosition>();
+    markerPositions.forEach((position) => {
+      position.memberIds.forEach((memberId) => {
+        map.set(memberId, position);
+      });
+    });
+    return map;
+  }, [markerPositions]);
+
+  // O(1) lookup Set for ClusterHighlightMarker — includes alias IDs for clone groups.
   const markerPositionIds = useMemo(
-    () => new Set(markerPositions.map((p) => p.listing.id)),
+    () => new Set(markerPositions.flatMap((position) => position.memberIds)),
     [markerPositions]
   );
 
@@ -1542,7 +1570,7 @@ export default function MapComponent({
   const findMarkerIndex = useCallback(
     (id: string | null): number => {
       if (!id) return -1;
-      return sortedMarkerPositions.findIndex((p) => p.listing.id === id);
+      return sortedMarkerPositions.findIndex((p) => p.memberIds.includes(id));
     },
     [sortedMarkerPositions]
   );
@@ -1688,13 +1716,10 @@ export default function MapComponent({
 
   // Clear keyboard focus when clicking elsewhere or when markers change
   useEffect(() => {
-    if (
-      keyboardFocusedId &&
-      !markerPositions.find((p) => p.listing.id === keyboardFocusedId)
-    ) {
+    if (keyboardFocusedId && !markerPositionById.has(keyboardFocusedId)) {
       setKeyboardFocusedId(null);
     }
-  }, [keyboardFocusedId, markerPositions]);
+  }, [keyboardFocusedId, markerPositionById]);
 
   // Stabilize initial view state so it's only computed once on mount.
   // Prevents SF default from being re-applied when listings temporarily become empty.
@@ -3143,8 +3168,8 @@ export default function MapComponent({
   // so they don't depend on markerPositions and never change when listings change.
   const handleMarkerClickById = useCallback(
     (listingId: string) => {
-      const position = markerPositionsRef.current.find(
-        (p) => p.listing.id === listingId
+      const position = markerPositionsRef.current.find((p) =>
+        p.memberIds.includes(listingId)
       );
       if (!position) return;
       setViewedIds((prev) => new Set(prev).add(listingId));
@@ -3293,14 +3318,12 @@ export default function MapComponent({
         aria-atomic="true"
       >
         {keyboardFocusedId &&
-          markerPositions.find((p) => p.listing.id === keyboardFocusedId) &&
+          markerPositionById.has(keyboardFocusedId) &&
           (() => {
-            const focused = markerPositions.find(
-              (p) => p.listing.id === keyboardFocusedId
-            );
+            const focused = markerPositionById.get(keyboardFocusedId);
             if (!focused) return "";
-            const index = sortedMarkerPositions.findIndex(
-              (p) => p.listing.id === keyboardFocusedId
+            const index = sortedMarkerPositions.findIndex((p) =>
+              p.memberIds.includes(keyboardFocusedId)
             );
             return `Marker ${index + 1} of ${sortedMarkerPositions.length}: ${focused.listing.title || "Listing"}, ${formatPrice(focused.listing.price)} per month`;
           })()}
@@ -3691,10 +3714,16 @@ export default function MapComponent({
             availableSlots={position.listing.availableSlots}
             tier={position.listing.tier}
             currentZoom={currentZoom}
-            isHovered={hoveredId === position.listing.id}
-            isActive={activeId === position.listing.id}
-            isDimmed={!!hoveredId && hoveredId !== position.listing.id}
-            isKeyboardFocused={keyboardFocusedId === position.listing.id}
+            isHovered={
+              hoveredId ? position.memberIds.includes(hoveredId) : false
+            }
+            isActive={activeId ? position.memberIds.includes(activeId) : false}
+            isDimmed={!!hoveredId && !position.memberIds.includes(hoveredId)}
+            isKeyboardFocused={
+              keyboardFocusedId
+                ? position.memberIds.includes(keyboardFocusedId)
+                : false
+            }
             isViewed={viewedIds.has(position.listing.id)}
             onClickById={handleMarkerClickById}
             onPointerEnter={handleMarkerPointerEnter}

--- a/src/lib/maps/marker-utils.ts
+++ b/src/lib/maps/marker-utils.ts
@@ -41,6 +41,76 @@ export interface ListingGroup {
 }
 
 /**
+ * Group of exact-clone listings for map marker rendering.
+ * Distinct IDs can still collapse when the visible marker payload is identical.
+ */
+export interface ExactCloneGroup<T extends MapMarkerListing = MapMarkerListing> {
+  /** Stable key derived from the clone signature */
+  key: string;
+  /** First listing in source order, used as the visible canonical marker */
+  listing: T;
+  /** All listings collapsed into the canonical marker */
+  listings: T[];
+  /** All member listing IDs, including the canonical listing ID */
+  memberIds: string[];
+}
+
+function normalizeCloneTitle(title: string): string {
+  return title.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function buildExactCloneKey(
+  listing: MapMarkerListing,
+  precision: number
+): string {
+  return [
+    normalizeCloneTitle(listing.title),
+    listing.price,
+    listing.availableSlots,
+    listing.location.lat.toFixed(precision),
+    listing.location.lng.toFixed(precision),
+  ].join("|");
+}
+
+/**
+ * Collapse exact-clone listings into a single canonical marker entry.
+ * This is intentionally narrower than coordinate grouping and is used only by the map UI.
+ *
+ * @param listings - Array of listings in source order
+ * @param precision - Decimal places for coordinate comparison (default: 5)
+ * @returns Canonical marker groups preserving first-listing priority
+ */
+export function groupExactMapListingClones<T extends MapMarkerListing>(
+  listings: T[],
+  precision = COORD_PRECISION
+): ExactCloneGroup<T>[] {
+  const groups = new Map<string, ExactCloneGroup<T>>();
+  const orderedGroups: ExactCloneGroup<T>[] = [];
+
+  listings.forEach((listing) => {
+    const key = buildExactCloneKey(listing, precision);
+    const existing = groups.get(key);
+
+    if (existing) {
+      existing.listings.push(listing);
+      existing.memberIds.push(listing.id);
+      return;
+    }
+
+    const group: ExactCloneGroup<T> = {
+      key,
+      listing,
+      listings: [listing],
+      memberIds: [listing.id],
+    };
+    groups.set(key, group);
+    orderedGroups.push(group);
+  });
+
+  return orderedGroups;
+}
+
+/**
  * Groups listings by coordinate, keeping true position.
  * Uses coordinate precision to group nearby points (~1.1m at 5 decimals).
  *

--- a/src/lib/maps/marker-utils.ts
+++ b/src/lib/maps/marker-utils.ts
@@ -18,6 +18,7 @@ export interface MapMarkerListing {
   title: string;
   price: number;
   availableSlots: number;
+  tier?: "primary" | "mini";
   ownerId?: string;
   images?: string[];
   location: {
@@ -67,6 +68,7 @@ function buildExactCloneKey(
     normalizeCloneTitle(listing.title),
     listing.price,
     listing.availableSlots,
+    listing.tier ?? "",
     listing.location.lat.toFixed(precision),
     listing.location.lng.toFixed(precision),
   ].join("|");


### PR DESCRIPTION
## Summary
- collapse exact cloned map listings into one visible map marker before overlap offsets are applied
- treat hidden clone IDs as aliases of the visible canonical marker for hover, active, dimming, keyboard focus, and marker click lookup
- add map and marker util coverage for clone collapsing, alias-aware highlighting, overlapping non-clones, and privacy-circle counts

## Root cause
`/api/map-listings` can return distinct listing IDs that share the same visible marker payload. `Map.tsx` previously offset every same-coordinate listing independently, so cloned listings rendered as duplicate price pills on the map.

## Impact
- duplicate-looking cloned listings now render as a single visible marker on the map
- genuinely different overlapping listings still render as separate offset markers
- map highlight state stays correct even when list/search state references a hidden clone ID

## Validation
- `pnpm jest src/__tests__/lib/maps/marker-utils.test.ts src/__tests__/components/Map.test.tsx --runInBand --testNamePattern "groupExactMapListingClones|passes displayed marker positions to PrivacyCircle for overlapping listings|collapses exact cloned listings into one displayed marker and privacy circle|treats hidden clone IDs as aliases for the visible marker state"`
- `pnpm exec tsc --noEmit --pretty false`
