### PR TITLE
[codex] Migrate semantic embeddings to Gemini GA

### DIFF
--- a/prisma/migrations/20260515000000_embedding_ga_version_isolation/migration.sql
+++ b/prisma/migrations/20260515000000_embedding_ga_version_isolation/migration.sql
@@ -1,0 +1,266 @@
+-- =============================================================================
+-- Migration: Isolate semantic search by embedding profile version
+-- PURPOSE:
+--   Add GA embedding-version-aware overloads for semantic search functions so
+--   preview and GA vectors are never compared during ranking.
+--
+-- ROLLBACK:
+--   DROP FUNCTION IF EXISTS search_listings_semantic(
+--     vector, text, text, float, float, float, float, numeric, numeric,
+--     text[], text[], text, text, text, text, int, text, timestamptz,
+--     text[], float, int, int, int
+--   );
+--   DROP FUNCTION IF EXISTS get_similar_listings(text, text, int, float);
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_search_docs_embedding_ga_hnsw;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_search_docs_embedding_model_status;
+-- DATA-SAFETY:
+--   Additive function overloads and indexes only. Existing overloads are kept
+--   for rolling deploy safety and can be removed after old code is retired.
+-- =============================================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_docs_embedding_model_status
+  ON listing_search_docs (embedding_model, embedding_status)
+  WHERE embedding IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_docs_embedding_ga_hnsw
+  ON listing_search_docs
+  USING hnsw (embedding vector_cosine_ops)
+  WHERE embedding IS NOT NULL
+    AND embedding_model = 'gemini-embedding-2.search-result.nosensitive-v1.d768'
+    AND embedding_status IN ('COMPLETED', 'PARTIAL');
+
+CREATE OR REPLACE FUNCTION search_listings_semantic(
+  query_embedding vector(768),
+  query_text text DEFAULT '',
+  required_embedding_version text DEFAULT 'gemini-embedding-2.search-result.nosensitive-v1.d768',
+  bound_min_lat float DEFAULT NULL,
+  bound_min_lng float DEFAULT NULL,
+  bound_max_lat float DEFAULT NULL,
+  bound_max_lng float DEFAULT NULL,
+  min_price numeric DEFAULT 0,
+  max_price numeric DEFAULT 99999,
+  filter_amenities text[] DEFAULT NULL,
+  filter_house_rules text[] DEFAULT NULL,
+  filter_room_type text DEFAULT NULL,
+  filter_lease_duration text DEFAULT NULL,
+  filter_gender_preference text DEFAULT NULL,
+  filter_household_gender text DEFAULT NULL,
+  filter_min_available_slots int DEFAULT 1,
+  filter_booking_mode text DEFAULT NULL,
+  filter_move_in_date timestamptz DEFAULT NULL,
+  filter_languages text[] DEFAULT NULL,
+  semantic_weight float DEFAULT 0.6,
+  match_count int DEFAULT 20,
+  result_offset int DEFAULT 0,
+  rrf_k int DEFAULT 60
+)
+RETURNS TABLE (
+  id text,
+  title text,
+  description text,
+  price double precision,
+  images text[],
+  room_type text,
+  lease_duration text,
+  available_slots int,
+  total_slots int,
+  amenities text[],
+  house_rules text[],
+  household_languages text[],
+  primary_home_language text,
+  gender_preference text,
+  household_gender text,
+  booking_mode text,
+  move_in_date timestamptz,
+  address text,
+  city text,
+  state text,
+  zip text,
+  lat double precision,
+  lng double precision,
+  owner_id text,
+  avg_rating double precision,
+  review_count int,
+  view_count int,
+  listing_created_at timestamptz,
+  recommended_score double precision,
+  semantic_similarity float,
+  keyword_rank float,
+  combined_score float
+)
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH
+  filtered AS (
+    SELECT
+      sd.id,
+      sd.embedding,
+      sd.search_tsv
+    FROM listing_search_docs sd
+    WHERE sd.status = 'ACTIVE'
+      AND sd.embedding IS NOT NULL
+      AND sd.embedding_model = required_embedding_version
+      AND sd.embedding_status IN ('COMPLETED', 'PARTIAL')
+      AND sd.price BETWEEN min_price AND max_price
+      AND (
+        bound_min_lat IS NULL
+        OR sd.location_geog && ST_MakeEnvelope(
+          bound_min_lng, bound_min_lat, bound_max_lng, bound_max_lat, 4326
+        )::geography
+      )
+      AND (filter_amenities IS NULL OR sd.amenities_lower @> filter_amenities)
+      AND (filter_house_rules IS NULL OR sd.house_rules_lower @> filter_house_rules)
+      AND (filter_languages IS NULL OR sd.household_languages_lower && filter_languages)
+      AND (filter_room_type IS NULL OR sd.room_type = filter_room_type)
+      AND (filter_lease_duration IS NULL OR sd.lease_duration = filter_lease_duration)
+      AND (filter_gender_preference IS NULL OR filter_gender_preference = 'any' OR sd.gender_preference = filter_gender_preference)
+      AND (filter_household_gender IS NULL OR filter_household_gender = 'any' OR sd.household_gender = filter_household_gender)
+      AND (filter_booking_mode IS NULL OR filter_booking_mode = 'any' OR sd.booking_mode = filter_booking_mode)
+      AND sd.available_slots >= COALESCE(filter_min_available_slots, 1)
+      AND (filter_move_in_date IS NULL OR sd.move_in_date IS NULL OR sd.move_in_date <= filter_move_in_date)
+  ),
+  semantic_results AS (
+    SELECT
+      f.id,
+      ROW_NUMBER() OVER (ORDER BY f.embedding <=> query_embedding) AS rank,
+      1 - (f.embedding <=> query_embedding) AS similarity
+    FROM filtered f
+    ORDER BY f.embedding <=> query_embedding
+    LIMIT (match_count + result_offset) * 3
+  ),
+  keyword_results AS (
+    SELECT
+      f.id,
+      ROW_NUMBER() OVER (
+        ORDER BY ts_rank_cd(f.search_tsv, plainto_tsquery('english', query_text)) DESC
+      ) AS rank,
+      ts_rank_cd(f.search_tsv, plainto_tsquery('english', query_text)) AS kw_score
+    FROM filtered f
+    WHERE query_text IS NOT NULL
+      AND query_text != ''
+      AND f.search_tsv @@ plainto_tsquery('english', query_text)
+    ORDER BY ts_rank_cd(f.search_tsv, plainto_tsquery('english', query_text)) DESC
+    LIMIT (match_count + result_offset) * 3
+  ),
+  fused AS (
+    SELECT
+      COALESCE(s.id, k.id) AS id,
+      (
+        COALESCE(semantic_weight * (1.0 / (rrf_k + s.rank)), 0) +
+        COALESCE((1 - semantic_weight) * (1.0 / (rrf_k + k.rank)), 0)
+      ) AS combined_score,
+      s.similarity AS semantic_similarity,
+      k.kw_score AS keyword_rank
+    FROM semantic_results s
+    FULL OUTER JOIN keyword_results k ON s.id = k.id
+  )
+  SELECT
+    sd.id,
+    sd.title,
+    sd.description,
+    sd.price::float8,
+    sd.images,
+    sd.room_type,
+    sd.lease_duration,
+    sd.available_slots,
+    sd.total_slots,
+    sd.amenities,
+    sd.house_rules,
+    sd.household_languages,
+    sd.primary_home_language,
+    sd.gender_preference,
+    sd.household_gender,
+    sd.booking_mode,
+    sd.move_in_date,
+    sd.address,
+    sd.city,
+    sd.state,
+    sd.zip,
+    sd.lat,
+    sd.lng,
+    sd.owner_id,
+    sd.avg_rating,
+    sd.review_count::int,
+    sd.view_count::int,
+    sd.listing_created_at,
+    sd.recommended_score,
+    f.semantic_similarity,
+    f.keyword_rank,
+    f.combined_score
+  FROM fused f
+  JOIN listing_search_docs sd ON sd.id = f.id
+  ORDER BY f.combined_score DESC NULLS LAST, sd.recommended_score DESC
+  LIMIT match_count
+  OFFSET result_offset;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_similar_listings(
+  target_listing_id text,
+  required_embedding_version text DEFAULT 'gemini-embedding-2.search-result.nosensitive-v1.d768',
+  match_count int DEFAULT 6,
+  similarity_threshold float DEFAULT 0.3
+)
+RETURNS TABLE (
+  id text,
+  title text,
+  description text,
+  price double precision,
+  images text[],
+  city text,
+  state text,
+  room_type text,
+  available_slots int,
+  total_slots int,
+  amenities text[],
+  household_languages text[],
+  avg_rating double precision,
+  review_count int,
+  similarity float
+)
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  target_embedding vector(768);
+BEGIN
+  SELECT sd.embedding INTO target_embedding
+  FROM listing_search_docs sd
+  WHERE sd.id = target_listing_id
+    AND sd.embedding IS NOT NULL
+    AND sd.embedding_model = required_embedding_version
+    AND sd.embedding_status IN ('COMPLETED', 'PARTIAL');
+
+  IF target_embedding IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    sd.id,
+    sd.title,
+    sd.description,
+    sd.price::float8,
+    sd.images,
+    sd.city,
+    sd.state,
+    sd.room_type,
+    sd.available_slots,
+    sd.total_slots,
+    sd.amenities,
+    sd.household_languages,
+    sd.avg_rating,
+    sd.review_count::int,
+    (1 - (sd.embedding <=> target_embedding))::float AS similarity
+  FROM listing_search_docs sd
+  WHERE sd.id != target_listing_id
+    AND sd.status = 'ACTIVE'
+    AND sd.embedding IS NOT NULL
+    AND sd.embedding_model = required_embedding_version
+    AND sd.embedding_status IN ('COMPLETED', 'PARTIAL')
+    AND (1 - (sd.embedding <=> target_embedding)) > similarity_threshold
+  ORDER BY sd.embedding <=> target_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/prisma/migrations/20260515000000_embedding_ga_version_isolation/migration.sql
+++ b/prisma/migrations/20260515000000_embedding_ga_version_isolation/migration.sql
@@ -14,20 +14,11 @@
 --   DROP INDEX CONCURRENTLY IF EXISTS idx_search_docs_embedding_ga_hnsw;
 --   DROP INDEX CONCURRENTLY IF EXISTS idx_search_docs_embedding_model_status;
 -- DATA-SAFETY:
---   Additive function overloads and indexes only. Existing overloads are kept
---   for rolling deploy safety and can be removed after old code is retired.
+--   Additive function overloads only. Existing overloads are kept for rolling
+--   deploy safety and can be removed after old code is retired.
+--   Concurrent indexes are split into one-statement follow-up migrations so
+--   Prisma can deploy this migration transactionally.
 -- =============================================================================
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_docs_embedding_model_status
-  ON listing_search_docs (embedding_model, embedding_status)
-  WHERE embedding IS NOT NULL;
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_docs_embedding_ga_hnsw
-  ON listing_search_docs
-  USING hnsw (embedding vector_cosine_ops)
-  WHERE embedding IS NOT NULL
-    AND embedding_model = 'gemini-embedding-2.search-result.nosensitive-v1.d768'
-    AND embedding_status IN ('COMPLETED', 'PARTIAL');
 
 CREATE OR REPLACE FUNCTION search_listings_semantic(
   query_embedding vector(768),

--- a/prisma/migrations/20260515010000_embedding_ga_model_status_index/migration.sql
+++ b/prisma/migrations/20260515010000_embedding_ga_model_status_index/migration.sql
@@ -1,0 +1,14 @@
+-- =============================================================================
+-- Migration: GA embedding model/status lookup index
+-- PURPOSE:
+--   Support embedding-version and status filters used before semantic ranking.
+--
+-- ROLLBACK:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_search_docs_embedding_model_status;
+-- DATA-SAFETY:
+--   Additive index only. CONCURRENTLY avoids blocking writes on live tables.
+-- =============================================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_docs_embedding_model_status
+  ON listing_search_docs (embedding_model, embedding_status)
+  WHERE embedding IS NOT NULL;

--- a/prisma/migrations/20260515020000_embedding_ga_hnsw_index/migration.sql
+++ b/prisma/migrations/20260515020000_embedding_ga_hnsw_index/migration.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- Migration: GA embedding HNSW index
+-- PURPOSE:
+--   Keep ANN search scoped to the GA embedding profile so preview and GA
+--   vectors are never compared by the index.
+--
+-- ROLLBACK:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_search_docs_embedding_ga_hnsw;
+-- DATA-SAFETY:
+--   Additive index only. CONCURRENTLY avoids blocking writes on live tables.
+-- =============================================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_docs_embedding_ga_hnsw
+  ON listing_search_docs
+  USING hnsw (embedding vector_cosine_ops)
+  WHERE embedding IS NOT NULL
+    AND embedding_model = 'gemini-embedding-2.search-result.nosensitive-v1.d768'
+    AND embedding_status IN ('COMPLETED', 'PARTIAL');

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -9,12 +9,21 @@
  */
 import { prisma } from "../src/lib/prisma";
 import pgvector from "pgvector";
-import { generateEmbedding, generateMultimodalEmbedding, EMBEDDING_MODEL } from "../src/lib/embeddings/gemini";
+import {
+  generateEmbedding,
+  generateMultimodalEmbedding,
+  EMBEDDING_MODEL,
+} from "../src/lib/embeddings/gemini";
 import { composeListingText } from "../src/lib/embeddings/compose";
-import { fetchAndProcessListingImages, computeImageHash } from "../src/lib/embeddings/images";
+import {
+  fetchAndProcessListingImages,
+  computeImageHash,
+  type ImagePart,
+} from "../src/lib/embeddings/images";
+import { resolveEmbeddingStatus } from "../src/lib/embeddings/status";
 
 const BATCH_SIZE = 20;
-const DELAY_MS = 1500; // ~40 RPM, safe for free tier (100 RPM limit)
+const DELAY_MS = Number(process.env.EMBEDDING_BACKFILL_DELAY_MS ?? 15000);
 const IMAGE_EMBEDDINGS = process.env.ENABLE_IMAGE_EMBEDDINGS === "true";
 
 interface BackfillRow {
@@ -41,7 +50,9 @@ interface BackfillRow {
 }
 
 async function main() {
-  console.log(`Starting embedding backfill (model: ${EMBEDDING_MODEL}, images: ${IMAGE_EMBEDDINGS})...\n`);
+  console.log(
+    `Starting embedding backfill (model: ${EMBEDDING_MODEL}, images: ${IMAGE_EMBEDDINGS})...\n`
+  );
 
   let lastId: string | null = null;
   let processed = 0;
@@ -105,10 +116,11 @@ async function main() {
         });
 
         const imageUrls: string[] = (row.images as string[]) || [];
-        const imageHash = imageUrls.length > 0 ? computeImageHash(imageUrls) : null;
+        const imageHash =
+          imageUrls.length > 0 ? computeImageHash(imageUrls) : null;
 
         // Fetch and process images if enabled
-        let imageParts: { base64: string; mimeType: string }[] = [];
+        let imageParts: ImagePart[] = [];
         if (IMAGE_EMBEDDINGS && imageUrls.length > 0) {
           try {
             imageParts = await fetchAndProcessListingImages(imageUrls);
@@ -118,12 +130,25 @@ async function main() {
         }
 
         // Generate embedding
-        const embedding = imageParts.length > 0
-          ? await generateMultimodalEmbedding(text, imageParts)
-          : await generateEmbedding(text, "RETRIEVAL_DOCUMENT");
+        const embedding =
+          imageParts.length > 0
+            ? await generateMultimodalEmbedding(
+                text,
+                imageParts,
+                "RETRIEVAL_DOCUMENT",
+                { title: row.title }
+              )
+            : await generateEmbedding(text, "RETRIEVAL_DOCUMENT", {
+                title: row.title,
+              });
 
         const vecSql = pgvector.toSql(embedding);
         const imageCount = imageParts.length;
+        const embeddingStatus = resolveEmbeddingStatus({
+          imageEmbeddingsEnabled: IMAGE_EMBEDDINGS,
+          imageUrlCount: imageUrls.length,
+          processedImageCount: imageCount,
+        });
 
         await prisma.$executeRaw`
           UPDATE listing_search_docs
@@ -132,7 +157,7 @@ async function main() {
               embedding_image_hash = ${imageHash},
               embedding_image_count = ${imageCount},
               embedding_model = ${EMBEDDING_MODEL},
-              embedding_status = 'COMPLETED',
+              embedding_status = ${embeddingStatus},
               embedding_updated_at = NOW(),
               embedding_attempts = 0
           WHERE id = ${row.id}
@@ -141,7 +166,10 @@ async function main() {
         processed++;
         if (imageCount > 0) withImages++;
       } catch (err) {
-        console.error(`Failed for listing ${row.id}:`, err instanceof Error ? err.message : err);
+        console.error(
+          `Failed for listing ${row.id}:`,
+          err instanceof Error ? err.message : err
+        );
         await prisma.$executeRaw`
           UPDATE listing_search_docs
           SET embedding_status = 'FAILED',
@@ -166,9 +194,9 @@ async function main() {
 
   // Rebuild HNSW index for optimal recall with new vector distribution
   if (processed > 0) {
-    console.log("\nRebuilding HNSW index (CONCURRENTLY — non-blocking)...");
+    console.log("\nRebuilding GA HNSW index (CONCURRENTLY — non-blocking)...");
     await prisma.$executeRawUnsafe(
-      `REINDEX INDEX CONCURRENTLY idx_search_docs_embedding_hnsw`
+      `REINDEX INDEX CONCURRENTLY idx_search_docs_embedding_ga_hnsw`
     );
     console.log("HNSW index rebuild complete.");
   }

--- a/src/__tests__/db/semantic-embedding-isolation-migration.test.ts
+++ b/src/__tests__/db/semantic-embedding-isolation-migration.test.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+
+describe("semantic embedding version isolation migration", () => {
+  const migrationSql = () =>
+    fs.readFileSync(
+      path.resolve(
+        __dirname,
+        "../../../prisma/migrations/20260515000000_embedding_ga_version_isolation/migration.sql"
+      ),
+      "utf8"
+    );
+
+  it("filters semantic search candidates by embedding version and published status before ranking", () => {
+    const sql = migrationSql();
+
+    expect(sql).toContain("required_embedding_version text");
+    expect(sql).toContain("sd.embedding_model = required_embedding_version");
+    expect(sql).toContain(
+      "sd.embedding_status IN ('COMPLETED', 'PARTIAL')"
+    );
+    expect(sql.indexOf("sd.embedding_model = required_embedding_version")).toBeLessThan(
+      sql.indexOf("ORDER BY f.embedding <=> query_embedding")
+    );
+  });
+
+  it("version-scopes similar listings and the GA HNSW index", () => {
+    const sql = migrationSql();
+
+    expect(sql).toContain("get_similar_listings");
+    expect(sql).toContain("target_embedding");
+    expect(sql).toContain(
+      "embedding_model = required_embedding_version"
+    );
+    expect(sql).toContain("idx_search_docs_embedding_ga_hnsw");
+    expect(sql).toContain(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
+  });
+});

--- a/src/__tests__/db/semantic-embedding-isolation-migration.test.ts
+++ b/src/__tests__/db/semantic-embedding-isolation-migration.test.ts
@@ -11,6 +11,24 @@ describe("semantic embedding version isolation migration", () => {
       "utf8"
     );
 
+  const indexSql = () =>
+    [
+      "20260515010000_embedding_ga_model_status_index",
+      "20260515020000_embedding_ga_hnsw_index",
+    ]
+      .map((migration) =>
+        fs.readFileSync(
+          path.resolve(
+            __dirname,
+            "../../../prisma/migrations",
+            migration,
+            "migration.sql"
+          ),
+          "utf8"
+        )
+      )
+      .join("\n");
+
   it("filters semantic search candidates by embedding version and published status before ranking", () => {
     const sql = migrationSql();
 
@@ -22,18 +40,21 @@ describe("semantic embedding version isolation migration", () => {
     expect(sql.indexOf("sd.embedding_model = required_embedding_version")).toBeLessThan(
       sql.indexOf("ORDER BY f.embedding <=> query_embedding")
     );
+    expect(sql).not.toContain("CREATE INDEX CONCURRENTLY");
   });
 
   it("version-scopes similar listings and the GA HNSW index", () => {
     const sql = migrationSql();
+    const indexes = indexSql();
 
     expect(sql).toContain("get_similar_listings");
     expect(sql).toContain("target_embedding");
     expect(sql).toContain(
       "embedding_model = required_embedding_version"
     );
-    expect(sql).toContain("idx_search_docs_embedding_ga_hnsw");
-    expect(sql).toContain(
+    expect(indexes).toContain("idx_search_docs_embedding_model_status");
+    expect(indexes).toContain("idx_search_docs_embedding_ga_hnsw");
+    expect(indexes).toContain(
       "gemini-embedding-2.search-result.nosensitive-v1.d768"
     );
   });

--- a/src/__tests__/lib/embeddings/compose.test.ts
+++ b/src/__tests__/lib/embeddings/compose.test.ts
@@ -23,7 +23,7 @@ describe("composeListingText", () => {
     expect(text).toContain("0 of 3 slots available");
   });
 
-  it("includes all optional fields when present", () => {
+  it("includes non-sensitive optional fields when present", () => {
     const text = composeListingText({
       title: "Room",
       description: "Desc",
@@ -46,8 +46,25 @@ describe("composeListingText", () => {
     expect(text).toContain("Lease: MONTH_TO_MONTH");
     expect(text).toContain("Located in Austin, TX");
     expect(text).toContain("Available from 2026-04-01");
-    expect(text).toContain("Languages spoken: English, Spanish");
     expect(text).toContain("Booking mode: SHARED");
+  });
+
+  it("does not include sensitive housing attributes in embedding text", () => {
+    const text = composeListingText({
+      title: "Room",
+      description: "Desc",
+      price: 600,
+      genderPreference: "ANY",
+      householdGender: "MIXED",
+      householdLanguages: ["English", "Spanish"],
+      primaryHomeLanguage: "English",
+    });
+
+    expect(text).not.toContain("Gender preference");
+    expect(text).not.toContain("Household gender");
+    expect(text).not.toContain("Languages spoken");
+    expect(text).not.toContain("English");
+    expect(text).not.toContain("Spanish");
   });
 
   it("omits null/undefined optional fields", () => {

--- a/src/__tests__/lib/embeddings/gemini.test.ts
+++ b/src/__tests__/lib/embeddings/gemini.test.ts
@@ -28,9 +28,11 @@ jest.mock("@sentry/nextjs", () => ({ addBreadcrumb: jest.fn() }), {
 
 import {
   generateEmbedding,
+  generateBatchEmbeddings,
   generateQueryEmbedding,
   generateMultimodalEmbedding,
   EMBEDDING_MODEL,
+  EMBEDDING_PROVIDER_MODEL,
 } from "@/lib/embeddings/gemini";
 
 describe("generateEmbedding", () => {
@@ -54,7 +56,29 @@ describe("generateEmbedding", () => {
     await expect(generateEmbedding("test")).rejects.toThrow("No embedding");
   });
 
-  it("truncates input longer than MAX_INPUT_LENGTH", async () => {
+  it("formats document input with Embedding 2 retrieval document prefix", async () => {
+    mockEmbedContent.mockResolvedValueOnce({
+      embeddings: [{ values: [1] }],
+    });
+
+    await generateEmbedding("test text");
+
+    const calledWith = mockEmbedContent.mock.calls[0][0];
+    expect(calledWith.contents).toBe("title: none | text: test text");
+  });
+
+  it("does not send taskType for Embedding 2", async () => {
+    mockEmbedContent.mockResolvedValueOnce({
+      embeddings: [{ values: [1] }],
+    });
+
+    await generateEmbedding("test text");
+
+    const calledWith = mockEmbedContent.mock.calls[0][0];
+    expect(calledWith.config).toEqual({ outputDimensionality: 768 });
+  });
+
+  it("truncates formatted input longer than MAX_INPUT_LENGTH", async () => {
     const longText = "a".repeat(5000);
     mockEmbedContent.mockResolvedValueOnce({
       embeddings: [{ values: [1] }],
@@ -72,18 +96,18 @@ describe("generateQueryEmbedding", () => {
     jest.clearAllMocks();
   });
 
-  it("uses RETRIEVAL_QUERY task type", async () => {
+  it("formats query input with Embedding 2 search-result prefix", async () => {
     mockEmbedContent.mockResolvedValueOnce({
       embeddings: [{ values: [1, 0] }],
     });
 
     await generateQueryEmbedding("search query");
 
-    expect(mockEmbedContent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        config: expect.objectContaining({ taskType: "RETRIEVAL_QUERY" }),
-      })
+    const calledWith = mockEmbedContent.mock.calls[0][0];
+    expect(calledWith.contents).toBe(
+      "task: search result | query: search query"
     );
+    expect(calledWith.config).toEqual({ outputDimensionality: 768 });
   });
 });
 
@@ -104,7 +128,7 @@ describe("generateMultimodalEmbedding", () => {
     const calledWith = mockEmbedContent.mock.calls[0][0];
     expect(calledWith.contents).toEqual({
       parts: [
-        { text: "hello" },
+        { text: "title: none | text: hello" },
         { inlineData: { mimeType: "image/jpeg", data: "abc123" } },
       ],
     });
@@ -162,7 +186,7 @@ describe("generateMultimodalEmbedding", () => {
     expect(calledWith.contents.parts[0].text.length).toBeLessThanOrEqual(8000);
   });
 
-  it("uses RETRIEVAL_DOCUMENT as default taskType", async () => {
+  it("does not send taskType for default document multimodal embedding", async () => {
     mockEmbedContent.mockResolvedValueOnce({
       embeddings: [{ values: [1, 0] }],
     });
@@ -170,10 +194,10 @@ describe("generateMultimodalEmbedding", () => {
     await generateMultimodalEmbedding("text", []);
 
     const calledWith = mockEmbedContent.mock.calls[0][0];
-    expect(calledWith.config.taskType).toBe("RETRIEVAL_DOCUMENT");
+    expect(calledWith.config).toEqual({ outputDimensionality: 768 });
   });
 
-  it("passes RETRIEVAL_QUERY when specified", async () => {
+  it("formats multimodal query text when specified", async () => {
     mockEmbedContent.mockResolvedValueOnce({
       embeddings: [{ values: [1, 0] }],
     });
@@ -181,7 +205,9 @@ describe("generateMultimodalEmbedding", () => {
     await generateMultimodalEmbedding("text", [], "RETRIEVAL_QUERY");
 
     const calledWith = mockEmbedContent.mock.calls[0][0];
-    expect(calledWith.config.taskType).toBe("RETRIEVAL_QUERY");
+    expect(calledWith.contents.parts[0]).toEqual({
+      text: "task: search result | query: text",
+    });
   });
 
   it("throws on empty embeddings response", async () => {
@@ -211,7 +237,36 @@ describe("generateMultimodalEmbedding", () => {
 
     const calledWith = mockEmbedContent.mock.calls[0][0];
     expect(calledWith.contents.parts).toHaveLength(1);
-    expect(calledWith.contents.parts[0]).toHaveProperty("text", "text only");
+    expect(calledWith.contents.parts[0]).toHaveProperty(
+      "text",
+      "title: none | text: text only"
+    );
+  });
+});
+
+describe("generateBatchEmbeddings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("embeds each text as a separate Embedding 2 request", async () => {
+    mockEmbedContent
+      .mockResolvedValueOnce({ embeddings: [{ values: [1, 0] }] })
+      .mockResolvedValueOnce({ embeddings: [{ values: [0, 1] }] });
+
+    const result = await generateBatchEmbeddings(["one", "two"]);
+
+    expect(result).toHaveLength(2);
+    expect(mockEmbedContent).toHaveBeenCalledTimes(2);
+    expect(mockEmbedContent.mock.calls[0][0].contents).toBe(
+      "title: none | text: one"
+    );
+    expect(mockEmbedContent.mock.calls[1][0].contents).toBe(
+      "title: none | text: two"
+    );
+    expect(Array.isArray(mockEmbedContent.mock.calls[0][0].contents)).toBe(
+      false
+    );
   });
 });
 
@@ -220,11 +275,17 @@ describe("EMBEDDING_MODEL", () => {
     expect(typeof EMBEDDING_MODEL).toBe("string");
   });
 
-  it("equals gemini-embedding-2-preview", () => {
-    expect(EMBEDDING_MODEL).toBe("gemini-embedding-2-preview");
+  it("exports the stored embedding version", () => {
+    expect(EMBEDDING_MODEL).toBe(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
   });
 
-  it("uses MODEL constant in embedContent calls", async () => {
+  it("exports the provider model separately", () => {
+    expect(EMBEDDING_PROVIDER_MODEL).toBe("gemini-embedding-2");
+  });
+
+  it("uses provider model in embedContent calls", async () => {
     mockEmbedContent.mockResolvedValueOnce({
       embeddings: [{ values: [1, 0] }],
     });
@@ -232,6 +293,6 @@ describe("EMBEDDING_MODEL", () => {
     await generateEmbedding("test");
 
     const calledWith = mockEmbedContent.mock.calls[0][0];
-    expect(calledWith.model).toContain(EMBEDDING_MODEL);
+    expect(calledWith.model).toBe(EMBEDDING_PROVIDER_MODEL);
   });
 });

--- a/src/__tests__/lib/embeddings/query-cache.test.ts
+++ b/src/__tests__/lib/embeddings/query-cache.test.ts
@@ -40,7 +40,8 @@ describe("Query Embedding Cache", () => {
     const result = await getCachedQueryEmbedding("sunny room downtown");
     expect(mocks.generateQueryEmbedding).toHaveBeenCalledTimes(1);
     expect(mocks.generateQueryEmbedding).toHaveBeenCalledWith(
-      "sunny room downtown"
+      "sunny room downtown",
+      { embeddingVersion: "gemini-embedding-2-preview" }
     );
     expect(result).toBe(FAKE_EMBEDDING);
   });
@@ -122,6 +123,14 @@ describe("Query Embedding Cache", () => {
     it("different queries produce separate cache entries", async () => {
       await getCachedQueryEmbedding("bright studio");
       await getCachedQueryEmbedding("cozy apartment");
+      expect(mocks.generateQueryEmbedding).toHaveBeenCalledTimes(2);
+      expect(queryCacheStats().size).toBe(2);
+    });
+
+    it("different requested embedding versions produce separate cache entries", async () => {
+      await getCachedQueryEmbedding("bright studio", "embed-v1");
+      await getCachedQueryEmbedding("bright studio", "embed-v2");
+
       expect(mocks.generateQueryEmbedding).toHaveBeenCalledTimes(2);
       expect(queryCacheStats().size).toBe(2);
     });

--- a/src/__tests__/lib/embeddings/status.test.ts
+++ b/src/__tests__/lib/embeddings/status.test.ts
@@ -1,0 +1,44 @@
+import {
+  isPublishedEmbeddingStatus,
+  resolveEmbeddingStatus,
+} from "@/lib/embeddings/status";
+
+describe("embedding status helpers", () => {
+  it("treats COMPLETED and PARTIAL as published statuses", () => {
+    expect(isPublishedEmbeddingStatus("COMPLETED")).toBe(true);
+    expect(isPublishedEmbeddingStatus("PARTIAL")).toBe(true);
+    expect(isPublishedEmbeddingStatus("PENDING")).toBe(false);
+    expect(isPublishedEmbeddingStatus("FAILED")).toBe(false);
+    expect(isPublishedEmbeddingStatus(null)).toBe(false);
+  });
+
+  it("returns PARTIAL when image embeddings are enabled and some expected images failed", () => {
+    expect(
+      resolveEmbeddingStatus({
+        imageEmbeddingsEnabled: true,
+        imageUrlCount: 3,
+        processedImageCount: 1,
+      })
+    ).toBe("PARTIAL");
+  });
+
+  it("caps expected images at the processing limit", () => {
+    expect(
+      resolveEmbeddingStatus({
+        imageEmbeddingsEnabled: true,
+        imageUrlCount: 8,
+        processedImageCount: 5,
+      })
+    ).toBe("COMPLETED");
+  });
+
+  it("returns COMPLETED when image embeddings are disabled", () => {
+    expect(
+      resolveEmbeddingStatus({
+        imageEmbeddingsEnabled: false,
+        imageUrlCount: 3,
+        processedImageCount: 0,
+      })
+    ).toBe("COMPLETED");
+  });
+});

--- a/src/__tests__/lib/embeddings/sync.test.ts
+++ b/src/__tests__/lib/embeddings/sync.test.ts
@@ -21,7 +21,7 @@ jest.mock("@/lib/embeddings/gemini", () => ({
   generateEmbedding: (...args: unknown[]) => mockGenerateEmbedding(...args),
   generateMultimodalEmbedding: (...args: unknown[]) =>
     mockGenerateMultimodalEmbedding(...args),
-  EMBEDDING_MODEL: "gemini-embedding-2-preview",
+  EMBEDDING_MODEL: "gemini-embedding-2.search-result.nosensitive-v1.d768",
 }));
 
 const mockComposeListingText = jest.fn();
@@ -93,12 +93,18 @@ const makeDoc = (overrides: Partial<Record<string, unknown>> = {}) => ({
   embedding_text: null,
   embedding_status: "PENDING",
   embedding_image_hash: null,
+  embedding_model: null,
   ...overrides,
 });
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockQueryRaw.mockReset();
+  mockExecuteRaw.mockReset();
+  mockGenerateEmbedding.mockReset();
+  mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
   // Default: composeListingText returns a stable string
+  mockComposeListingText.mockReset();
   mockComposeListingText.mockReturnValue("composed text");
   mockFetchAndProcessListingImages.mockReset();
   mockFetchAndProcessListingImages.mockResolvedValue([]);
@@ -127,6 +133,7 @@ describe("syncListingEmbedding", () => {
         embedding_text: existingText,
         embedding_status: "COMPLETED",
         embedding_image_hash: null,
+        embedding_model: "gemini-embedding-2.search-result.nosensitive-v1.d768",
       }),
     ]);
 
@@ -135,6 +142,43 @@ describe("syncListingEmbedding", () => {
     // No PROCESSING claim, no Gemini call
     expect(mockExecuteRaw).not.toHaveBeenCalled();
     expect(mockGenerateEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("re-embeds when text and images are unchanged but embedding version changed", async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDoc({
+        embedding_text: "composed text",
+        embedding_status: "COMPLETED",
+        embedding_image_hash: null,
+        embedding_model: "gemini-embedding-2-preview",
+      }),
+    ]);
+    mockExecuteRaw.mockResolvedValueOnce(1);
+    mockGenerateEmbedding.mockResolvedValueOnce([0.1, 0.2]);
+    mockExecuteRaw.mockResolvedValueOnce(1);
+
+    await syncListingEmbedding(LISTING_ID);
+
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(1);
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-embeds unchanged failed rows even when version is current", async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeDoc({
+        embedding_text: "composed text",
+        embedding_status: "FAILED",
+        embedding_image_hash: null,
+        embedding_model: "gemini-embedding-2.search-result.nosensitive-v1.d768",
+      }),
+    ]);
+    mockExecuteRaw.mockResolvedValueOnce(1);
+    mockGenerateEmbedding.mockResolvedValueOnce([0.1, 0.2]);
+    mockExecuteRaw.mockResolvedValueOnce(1);
+
+    await syncListingEmbedding(LISTING_ID);
+
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(1);
   });
 
   it("claims row atomically before calling Gemini (PROCESSING guard)", async () => {
@@ -268,6 +312,7 @@ describe("image hash change detection", () => {
         embedding_text: "composed text", // matches mockComposeListingText return
         embedding_image_hash: "hash-abc", // matches mockComputeImageHash return
         embedding_status: "COMPLETED",
+        embedding_model: "gemini-embedding-2.search-result.nosensitive-v1.d768",
       }),
     ]);
 
@@ -415,7 +460,9 @@ describe("multimodal vs text-only embedding", () => {
 
     expect(mockGenerateMultimodalEmbedding).toHaveBeenCalledWith(
       "composed text",
-      imageParts
+      imageParts,
+      "RETRIEVAL_DOCUMENT",
+      { title: "Sunny Room" }
     );
     expect(mockGenerateEmbedding).not.toHaveBeenCalled();
   });
@@ -432,7 +479,8 @@ describe("multimodal vs text-only embedding", () => {
 
     expect(mockGenerateEmbedding).toHaveBeenCalledWith(
       "composed text",
-      "RETRIEVAL_DOCUMENT"
+      "RETRIEVAL_DOCUMENT",
+      { title: "Sunny Room" }
     );
     expect(mockGenerateMultimodalEmbedding).not.toHaveBeenCalled();
   });
@@ -450,9 +498,11 @@ describe("multimodal vs text-only embedding", () => {
       mockExecuteRaw.mock.calls[1][0] as TemplateStringsArray
     ).join("?");
     expect(updateSqlParts).toContain("embedding_model");
-    // The EMBEDDING_MODEL value "gemini-embedding-2-preview" is passed as a param
+    // The stored embedding profile version is passed as a param
     const updateParams = mockExecuteRaw.mock.calls[1].slice(1);
-    expect(updateParams).toContain("gemini-embedding-2-preview");
+    expect(updateParams).toContain(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
   });
 });
 

--- a/src/__tests__/lib/projections/semantic.test.ts
+++ b/src/__tests__/lib/projections/semantic.test.ts
@@ -19,6 +19,7 @@ import { rebuildUnitPublicProjection } from "@/lib/projections/unit-projection";
 import { handleTombstone } from "@/lib/projections/tombstone";
 import {
   __resetEmbeddingTokenBudgetForTesting,
+  buildSemanticProjectionText,
   EmbeddingBudgetExceededError,
   getSemanticInventoryCandidates,
   rebuildSemanticInventoryProjection,
@@ -123,6 +124,35 @@ async function getInventoryStatus(inventoryId: string): Promise<{
 }
 
 describe("Phase 03 semantic projection", () => {
+  it("excludes sensitive housing attributes from semantic projection text", () => {
+    const text = buildSemanticProjectionText({
+      inventory_id: "inv-1",
+      unit_id: "unit-1",
+      unit_identity_epoch_written_at: 1,
+      room_category: "PRIVATE_ROOM",
+      capacity_guests: 2,
+      total_beds: 3,
+      open_beds: 1,
+      price: "1200",
+      available_from: "2026-05-01",
+      available_until: null,
+      lease_min_months: null,
+      lease_max_months: null,
+      lease_negotiable: false,
+      gender_preference: "ANY",
+      household_gender: "MIXED",
+      public_cell_id: "cell-1",
+      public_area_name: "Austin",
+      projection_source_version: BigInt(1),
+      matching_inventory_count: 2,
+    });
+
+    expect(text).not.toContain("Gender preference");
+    expect(text).not.toContain("Household gender");
+    expect(text).not.toContain("ANY");
+    expect(text).not.toContain("MIXED");
+  });
+
   it("moves filter-published inventory to PENDING_EMBEDDING and enqueues EMBED_NEEDED", async () => {
     const { unitId, inventoryId } = await seedInventory();
 
@@ -175,6 +205,36 @@ describe("Phase 03 semantic projection", () => {
     const inventory = await getInventoryStatus(inventoryId);
     expect(inventory.publishStatus).toBe("PUBLISHED");
     expect(inventory.lastEmbeddedVersion).toBe("v-test");
+  });
+
+  it("passes the stored embedding version into the embedding provider", async () => {
+    const { unitId, inventoryId } = await seedInventory();
+    await projectFilterRows(unitId, inventoryId);
+    const generate = jest.fn(async () => [0.1, 0.2, 0.3]);
+
+    await withTx((tx) =>
+      rebuildSemanticInventoryProjection(
+        tx,
+        {
+          unitId,
+          inventoryId,
+          sourceVersion: BigInt(1),
+          unitIdentityEpoch: 1,
+          embeddingVersion: "v-provider",
+        },
+        { generateEmbedding: generate }
+      )
+    );
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.stringContaining("Room category:"),
+      "RETRIEVAL_DOCUMENT",
+      { embeddingVersion: "v-provider" }
+    );
+
+    const semanticRows = await fixture.getSemanticInventoryProjections();
+    const row = semanticRows.find((item) => item.inventoryId === inventoryId);
+    expect(row?.embeddingVersion).toBe("v-provider");
   });
 
   it("does not let stale source_version overwrite semantic projection", async () => {

--- a/src/__tests__/lib/search/hash.test.ts
+++ b/src/__tests__/lib/search/hash.test.ts
@@ -231,7 +231,7 @@ describe("search/hash", () => {
         },
       };
 
-      expect(generateQueryHash(params)).toBe("41d26badfeb46b49");
+      expect(generateQueryHash(params)).toBe("73fe121fbc8fff6b");
     });
   });
 

--- a/src/__tests__/lib/search/search-meta.test.ts
+++ b/src/__tests__/lib/search/search-meta.test.ts
@@ -1,5 +1,7 @@
 jest.mock("@/lib/embeddings/version", () => ({
-  getCurrentEmbeddingVersion: jest.fn(() => "gemini-embedding-2-preview"),
+  getReadEmbeddingVersion: jest.fn(
+    () => "gemini-embedding-2.search-result.nosensitive-v1.d768"
+  ),
 }));
 
 import { getSearchV2VersionMeta } from "@/lib/search/meta";
@@ -25,7 +27,7 @@ describe("getSearchV2VersionMeta", () => {
       })
     ).toEqual({
       projectionVersion: SEARCH_DOC_PROJECTION_VERSION,
-      embeddingVersion: "gemini-embedding-2-preview",
+      embeddingVersion: "gemini-embedding-2.search-result.nosensitive-v1.d768",
     });
   });
 });

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -61,7 +61,12 @@ jest.mock("@/lib/availability", () => ({
 }));
 
 jest.mock("@/lib/embeddings/version", () => ({
-  getCurrentEmbeddingVersion: jest.fn(() => "gemini-embedding-2-preview"),
+  getCurrentEmbeddingVersion: jest.fn(
+    () => "gemini-embedding-2.search-result.nosensitive-v1.d768"
+  ),
+  getReadEmbeddingVersion: jest.fn(
+    () => "gemini-embedding-2.search-result.nosensitive-v1.d768"
+  ),
 }));
 
 // Mock search-doc-queries
@@ -191,7 +196,10 @@ import { buildPublicAvailability } from "@/lib/search/public-availability";
 import { SEARCH_DOC_PROJECTION_VERSION } from "@/lib/search/search-doc-sync";
 import { prisma } from "@/lib/prisma";
 import { getAvailabilityForListings } from "@/lib/availability";
-import { getCurrentEmbeddingVersion } from "@/lib/embeddings/version";
+import {
+  getCurrentEmbeddingVersion,
+  getReadEmbeddingVersion,
+} from "@/lib/embeddings/version";
 import { isPhase04ProjectionReadsEnabled } from "@/lib/flags/phase04";
 import { executeProjectionSearchV2 } from "@/lib/search/projection-search";
 
@@ -286,6 +294,10 @@ const mockGetAvailabilityForListings =
 const mockGetCurrentEmbeddingVersion =
   getCurrentEmbeddingVersion as jest.MockedFunction<
     typeof getCurrentEmbeddingVersion
+  >;
+const mockGetReadEmbeddingVersion =
+  getReadEmbeddingVersion as jest.MockedFunction<
+    typeof getReadEmbeddingVersion
   >;
 const mockIsPhase04ProjectionReadsEnabled =
   isPhase04ProjectionReadsEnabled as jest.MockedFunction<
@@ -464,7 +476,7 @@ function setupDefaultMocks({
   );
   mockGetAvailabilityForListings.mockResolvedValue(new Map());
   mockGetCurrentEmbeddingVersion.mockReturnValue(
-    "gemini-embedding-2-preview"
+    "gemini-embedding-2.search-result.nosensitive-v1.d768"
   );
   mockTransformToListItems.mockImplementation((items) =>
     items.map((l) => ({
@@ -506,6 +518,12 @@ describe("search-v2-service", () => {
     (features as Record<string, unknown>).semanticSearch = false;
     mockIsPhase04ProjectionReadsEnabled.mockReturnValue(false);
     mockDecodeCursorAny.mockReturnValue(null);
+    mockGetCurrentEmbeddingVersion.mockReturnValue(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
+    mockGetReadEmbeddingVersion.mockReturnValue(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
   });
 
   describe("executeSearchV2", () => {
@@ -842,11 +860,73 @@ describe("search-v2-service", () => {
         SEARCH_DOC_PROJECTION_VERSION
       );
       expect(result.response?.meta.embeddingVersion).toBe(
-        "gemini-embedding-2-preview"
+        "gemini-embedding-2.search-result.nosensitive-v1.d768"
       );
       expect(result.response?.list.items[0]?.id).toBe("semantic-1");
       expect(mockGetListingsPaginated).not.toHaveBeenCalled();
-      expect(mockGetCurrentEmbeddingVersion).toHaveBeenCalled();
+      expect(mockGetReadEmbeddingVersion).toHaveBeenCalled();
+      expect(mockGenerateQueryHash).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeddingVersion:
+            "gemini-embedding-2.search-result.nosensitive-v1.d768",
+        })
+      );
+    });
+
+    it("does not include embeddingVersion in nonsemantic query hashes", async () => {
+      setupDefaultMocks();
+
+      await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+        },
+      });
+
+      expect(mockGenerateQueryHash).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          embeddingVersion: expect.any(String),
+        })
+      );
+    });
+
+    it("includes explicit housing filters in query hashes", async () => {
+      setupDefaultMocks();
+      mockParseSearchParams.mockReturnValue(
+        defaultParsedSearchParams({
+          filterParams: {
+            bounds: BOUNDS,
+            genderPreference: "NO_PREFERENCE",
+            householdGender: "MIXED",
+            bookingMode: "PER_SLOT",
+            minAvailableSlots: 2,
+          },
+        })
+      );
+
+      await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+          genderPreference: "NO_PREFERENCE",
+          householdGender: "MIXED",
+          bookingMode: "PER_SLOT",
+          minSlots: "2",
+        },
+      });
+
+      expect(mockGenerateQueryHash).toHaveBeenCalledWith(
+        expect.objectContaining({
+          genderPreference: "NO_PREFERENCE",
+          householdGender: "MIXED",
+          bookingMode: "PER_SLOT",
+          minAvailableSlots: 2,
+        })
+      );
     });
 
     it("uses vibeQuery for semantic ranking while preserving the location query", async () => {

--- a/src/__tests__/lib/search/semantic-search-query.test.ts
+++ b/src/__tests__/lib/search/semantic-search-query.test.ts
@@ -1,0 +1,134 @@
+const mockExecuteRawUnsafe = jest.fn();
+const mockQueryRawUnsafe = jest.fn();
+const mockGetCachedQueryEmbedding = jest.fn();
+const mockGetReadEmbeddingVersion = jest.fn();
+
+jest.mock("next/cache", () => ({
+  unstable_cache: jest.fn((fn: () => unknown) => fn),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn((fn) =>
+      fn({
+        $executeRawUnsafe: mockExecuteRawUnsafe,
+        $queryRawUnsafe: mockQueryRawUnsafe,
+      })
+    ),
+  },
+}));
+
+jest.mock("@/lib/env", () => ({
+  features: {
+    semanticSearch: true,
+    semanticWeight: 0.6,
+  },
+}));
+
+jest.mock("@/lib/embeddings/query-cache", () => ({
+  getCachedQueryEmbedding: (...args: unknown[]) =>
+    mockGetCachedQueryEmbedding(...args),
+}));
+
+jest.mock("@/lib/embeddings/version", () => ({
+  getReadEmbeddingVersion: (...args: unknown[]) =>
+    mockGetReadEmbeddingVersion(...args),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    sync: {
+      error: jest.fn(),
+    },
+  },
+}));
+
+import { semanticSearchQuery } from "@/lib/search/search-doc-queries";
+
+function semanticRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "listing-1",
+    title: "Room",
+    description: "Desc",
+    price: 1200,
+    images: [],
+    room_type: "PRIVATE",
+    lease_duration: null,
+    available_slots: 1,
+    total_slots: 2,
+    amenities: [],
+    house_rules: [],
+    household_languages: [],
+    primary_home_language: null,
+    gender_preference: null,
+    household_gender: null,
+    booking_mode: "SHARED",
+    move_in_date: null,
+    address: null,
+    city: "Austin",
+    state: "TX",
+    zip: null,
+    lat: 30.2,
+    lng: -97.7,
+    owner_id: "owner-1",
+    avg_rating: 5,
+    review_count: 1,
+    view_count: 10,
+    listing_created_at: new Date("2026-04-01T00:00:00.000Z"),
+    recommended_score: 0.9,
+    semantic_similarity: 0.8,
+    keyword_rank: 0,
+    combined_score: 0.8,
+    ...overrides,
+  };
+}
+
+describe("semanticSearchQuery version isolation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecuteRawUnsafe.mockResolvedValue(1);
+    mockQueryRawUnsafe
+      .mockResolvedValueOnce([semanticRow()])
+      .mockResolvedValueOnce([{ id: "listing-1" }]);
+    mockGetCachedQueryEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+    mockGetReadEmbeddingVersion.mockReturnValue(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
+  });
+
+  it("passes the read embedding version into SQL before ranking params", async () => {
+    await semanticSearchQuery(
+      {
+        vibeQuery: "bright airy room",
+        bounds: {
+          minLat: 30,
+          minLng: -98,
+          maxLat: 31,
+          maxLng: -97,
+        },
+      },
+      12,
+      0
+    );
+
+    const [sql, vectorSql, queryText, embeddingVersion] =
+      mockQueryRawUnsafe.mock.calls[0];
+
+    expect(sql).toContain("search_listings_semantic");
+    expect(sql).toContain("$3");
+    expect(vectorSql).toBe("[0.1,0.2,0.3]");
+    expect(queryText).toBe("bright airy room");
+    expect(embeddingVersion).toBe(
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
+  });
+
+  it("namespaces query embeddings by the same read embedding version", async () => {
+    await semanticSearchQuery({ vibeQuery: "bright airy room" }, 12, 0);
+
+    expect(mockGetCachedQueryEmbedding).toHaveBeenCalledWith(
+      "bright airy room",
+      "gemini-embedding-2.search-result.nosensitive-v1.d768"
+    );
+  });
+});

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -12,6 +12,7 @@ import { resolveListingDetailDateParams } from "@/lib/search/listing-detail-link
 import { resolvePublicAvailability } from "@/lib/search/public-availability";
 import { toPublicCoordinates } from "@/lib/search/public-coordinates";
 import { getPublicListingDetail } from "@/lib/listings/public-detail";
+import { getReadEmbeddingVersion } from "@/lib/embeddings/version";
 import ListingPageClient from "./ListingPageClient";
 
 const getListingWithLocation = cache(async (id: string) => {
@@ -58,9 +59,12 @@ const getSimilarListings = cache(async function getSimilarListings(
 ): Promise<SimilarListingRow[]> {
   if (!features.semanticSearch) return [];
   try {
+    const embeddingVersion = getReadEmbeddingVersion();
     const rows = await prisma.$queryRaw<
       SimilarListingRow[]
-    >`SELECT * FROM get_similar_listings(${listingId}, 4, 0.3)`;
+    >`SELECT * FROM get_similar_listings(
+        ${listingId}, ${embeddingVersion}, 4, 0.3
+      )`;
     return rows;
   } catch (err) {
     logger.sync.error("Failed to fetch similar listings", {

--- a/src/lib/embeddings/compose.ts
+++ b/src/lib/embeddings/compose.ts
@@ -54,18 +54,6 @@ export function composeListingText(listing: {
     parts.push(`Lease: ${listing.leaseDuration}.`);
   }
 
-  if (listing.genderPreference) {
-    parts.push(`Gender preference: ${listing.genderPreference}.`);
-  }
-
-  if (listing.householdGender) {
-    parts.push(`Household gender: ${listing.householdGender}.`);
-  }
-
-  if (listing.householdLanguages?.length) {
-    parts.push(`Languages spoken: ${listing.householdLanguages.join(", ")}.`);
-  }
-
   if (listing.bookingMode) {
     parts.push(`Booking mode: ${listing.bookingMode}.`);
   }

--- a/src/lib/embeddings/gemini.ts
+++ b/src/lib/embeddings/gemini.ts
@@ -1,14 +1,44 @@
 /**
  * Gemini Embedding API wrapper.
  * Uses lazy-initialized singleton (same pattern as prisma.ts).
- * L2 normalizes truncated 768-dim embeddings per Google's guidance.
+ * Stores a Roomshare embedding profile version separately from the provider
+ * model so persisted vectors never mix across prompt/schema revisions.
  */
 import { GoogleGenAI } from "@google/genai";
 
-const MODEL = "gemini-embedding-2-preview";
+const PROVIDER_MODEL = "gemini-embedding-2";
+const MODEL = "gemini-embedding-2.search-result.nosensitive-v1.d768";
+const LEGACY_PREVIEW_MODEL = "gemini-embedding-2-preview";
 const DIMENSIONS = 768;
 const MAX_RETRIES = 3;
 const MAX_INPUT_LENGTH = 8000; // ~2000 tokens, well within 8192 token limit
+
+type EmbeddingTaskType = "RETRIEVAL_QUERY" | "RETRIEVAL_DOCUMENT";
+type DocumentEmbeddingOptions = {
+  title?: string | null;
+  embeddingVersion?: string;
+};
+
+type EmbeddingProfile = {
+  version: string;
+  providerModel: string;
+  usesPromptFormatting: boolean;
+};
+
+const CURRENT_PROFILE: EmbeddingProfile = {
+  version: MODEL,
+  providerModel: PROVIDER_MODEL,
+  usesPromptFormatting: true,
+};
+
+const EMBEDDING_PROFILES: Record<string, EmbeddingProfile> = {
+  [CURRENT_PROFILE.version]: CURRENT_PROFILE,
+  [LEGACY_PREVIEW_MODEL]: {
+    version: LEGACY_PREVIEW_MODEL,
+    providerModel: LEGACY_PREVIEW_MODEL,
+    usesPromptFormatting: false,
+  },
+};
 
 // --- Lazy singleton (survives HMR in dev, fresh in production) ---
 const globalForGemini = globalThis as unknown as {
@@ -32,6 +62,45 @@ function getClient(): GoogleGenAI {
 function normalizeL2(vec: number[]): number[] {
   const mag = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));
   return mag === 0 ? vec : vec.map((v) => v / mag);
+}
+
+function truncateFormattedContent(value: string): string {
+  return value.slice(0, MAX_INPUT_LENGTH);
+}
+
+function formatEmbeddingInput(
+  text: string,
+  taskType: EmbeddingTaskType,
+  profile: EmbeddingProfile,
+  options: DocumentEmbeddingOptions = {}
+): string {
+  if (!profile.usesPromptFormatting) {
+    return truncateFormattedContent(text);
+  }
+
+  if (taskType === "RETRIEVAL_QUERY") {
+    return truncateFormattedContent(`task: search result | query: ${text}`);
+  }
+
+  const title = options.title?.trim() || "none";
+  return truncateFormattedContent(`title: ${title} | text: ${text}`);
+}
+
+function getEmbeddingProfile(version = MODEL): EmbeddingProfile {
+  const profile = EMBEDDING_PROFILES[version];
+  if (!profile) {
+    throw new Error(`[embedding] Unsupported embedding version: ${version}`);
+  }
+  return profile;
+}
+
+function buildEmbedConfig(
+  taskType: EmbeddingTaskType,
+  profile: EmbeddingProfile
+) {
+  return profile.usesPromptFormatting
+    ? { outputDimensionality: DIMENSIONS }
+    : { taskType, outputDimensionality: DIMENSIONS };
 }
 
 // --- Retry with exponential backoff + jitter ---
@@ -60,15 +129,17 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 /** Generate embedding for a single text (document indexing) */
 export async function generateEmbedding(
   text: string,
-  taskType: "RETRIEVAL_QUERY" | "RETRIEVAL_DOCUMENT" = "RETRIEVAL_DOCUMENT"
+  taskType: EmbeddingTaskType = "RETRIEVAL_DOCUMENT",
+  options: DocumentEmbeddingOptions = {}
 ): Promise<number[]> {
-  const truncated = text.slice(0, MAX_INPUT_LENGTH);
+  const profile = getEmbeddingProfile(options.embeddingVersion);
+  const formatted = formatEmbeddingInput(text, taskType, profile, options);
   try {
     const Sentry = await import("@sentry/nextjs");
     Sentry.addBreadcrumb({
       category: "embedding",
       message: `Generating embedding (${taskType})`,
-      data: { textLength: truncated.length, taskType },
+      data: { textLength: formatted.length, taskType },
       level: "info",
     });
   } catch {
@@ -76,9 +147,9 @@ export async function generateEmbedding(
   }
   const res = await withRetry(() =>
     getClient().models.embedContent({
-      model: MODEL,
-      contents: truncated,
-      config: { taskType, outputDimensionality: DIMENSIONS },
+      model: profile.providerModel,
+      contents: formatted,
+      config: buildEmbedConfig(taskType, profile),
     })
   );
   const values = res.embeddings?.[0]?.values;
@@ -99,21 +170,26 @@ export async function generateEmbedding(
 }
 
 /** Generate embedding optimized for search queries */
-export async function generateQueryEmbedding(query: string): Promise<number[]> {
-  return generateEmbedding(query, "RETRIEVAL_QUERY");
+export async function generateQueryEmbedding(
+  query: string,
+  options: Pick<DocumentEmbeddingOptions, "embeddingVersion"> = {}
+): Promise<number[]> {
+  return generateEmbedding(query, "RETRIEVAL_QUERY", options);
 }
 
 /** Generate embedding from text + images (multimodal fused vector) */
 export async function generateMultimodalEmbedding(
   text: string,
   images: { base64: string; mimeType: string }[],
-  taskType: "RETRIEVAL_QUERY" | "RETRIEVAL_DOCUMENT" = "RETRIEVAL_DOCUMENT"
+  taskType: EmbeddingTaskType = "RETRIEVAL_DOCUMENT",
+  options: DocumentEmbeddingOptions = {}
 ): Promise<number[]> {
-  const truncated = text.slice(0, MAX_INPUT_LENGTH);
+  const profile = getEmbeddingProfile(options.embeddingVersion);
+  const formatted = formatEmbeddingInput(text, taskType, profile, options);
   const parts: Array<
     { text: string } | { inlineData: { mimeType: string; data: string } }
   > = [
-    { text: truncated },
+    { text: formatted },
     ...images.map((img) => ({
       inlineData: { mimeType: img.mimeType, data: img.base64 },
     })),
@@ -125,7 +201,7 @@ export async function generateMultimodalEmbedding(
       category: "embedding",
       message: `Generating multimodal embedding (${taskType})`,
       data: {
-        textLength: truncated.length,
+        textLength: formatted.length,
         imageCount: images.length,
         taskType,
       },
@@ -137,9 +213,9 @@ export async function generateMultimodalEmbedding(
 
   const res = await withRetry(() =>
     getClient().models.embedContent({
-      model: MODEL,
+      model: profile.providerModel,
       contents: { parts },
-      config: { taskType, outputDimensionality: DIMENSIONS },
+      config: buildEmbedConfig(taskType, profile),
     })
   );
   const values = res.embeddings?.[0]?.values;
@@ -153,25 +229,16 @@ export async function generateBatchEmbeddings(
   texts: string[]
 ): Promise<number[][]> {
   if (!texts.length) return [];
-  const truncated = texts.map((t) => t.slice(0, MAX_INPUT_LENGTH));
-  // embedContent accepts string[] via contents parameter
-  const res = await withRetry(() =>
-    getClient().models.embedContent({
-      model: MODEL,
-      contents: truncated,
-      config: {
-        taskType: "RETRIEVAL_DOCUMENT",
-        outputDimensionality: DIMENSIONS,
-      },
-    })
-  );
-  if (!res.embeddings) throw new Error("[embedding] No embeddings returned");
-  return res.embeddings.map((e) => {
-    if (!e?.values?.length)
-      throw new Error("[embedding] Empty embedding in batch");
-    return normalizeL2(e.values);
-  });
+  const embeddings: number[][] = [];
+  for (const text of texts) {
+    embeddings.push(await generateEmbedding(text, "RETRIEVAL_DOCUMENT"));
+  }
+  return embeddings;
 }
 
 /** Export model name for cache key namespacing */
-export { MODEL as EMBEDDING_MODEL };
+export {
+  MODEL as EMBEDDING_MODEL,
+  PROVIDER_MODEL as EMBEDDING_PROVIDER_MODEL,
+  DIMENSIONS as EMBEDDING_DIMENSIONS,
+};

--- a/src/lib/embeddings/query-cache.ts
+++ b/src/lib/embeddings/query-cache.ts
@@ -9,7 +9,7 @@
  */
 
 import { generateQueryEmbedding } from "./gemini";
-import { getCurrentEmbeddingVersion } from "./version";
+import { getReadEmbeddingVersion } from "./version";
 
 const MAX_ENTRIES = 100;
 const TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -25,8 +25,8 @@ let hits = 0;
 let misses = 0;
 
 /** Normalize query for cache key: model-namespaced to prevent cross-model contamination */
-function cacheKey(query: string): string {
-  return `${getCurrentEmbeddingVersion()}:${query.trim().toLowerCase()}`;
+function cacheKey(query: string, embeddingVersion: string): string {
+  return `${embeddingVersion}:${query.trim().toLowerCase()}`;
 }
 
 /** Evict the oldest entry (first inserted — Map preserves insertion order) */
@@ -42,9 +42,10 @@ function evictOldest(): void {
  * On cache miss, calls `generateQueryEmbedding` and stores the result.
  */
 export async function getCachedQueryEmbedding(
-  query: string
+  query: string,
+  embeddingVersion = getReadEmbeddingVersion()
 ): Promise<number[]> {
-  const key = cacheKey(query);
+  const key = cacheKey(query, embeddingVersion);
 
   const existing = cache.get(key);
   if (existing && Date.now() - existing.createdAt < TTL_MS) {
@@ -61,7 +62,7 @@ export async function getCachedQueryEmbedding(
   }
 
   misses++;
-  const embedding = await generateQueryEmbedding(query);
+  const embedding = await generateQueryEmbedding(query, { embeddingVersion });
 
   // Evict if at capacity
   if (cache.size >= MAX_ENTRIES) {

--- a/src/lib/embeddings/status.ts
+++ b/src/lib/embeddings/status.ts
@@ -1,0 +1,26 @@
+export const PUBLISHED_EMBEDDING_STATUSES = ["COMPLETED", "PARTIAL"] as const;
+
+export type PublishedEmbeddingStatus =
+  (typeof PUBLISHED_EMBEDDING_STATUSES)[number];
+
+export function isPublishedEmbeddingStatus(
+  status: string | null | undefined
+): status is PublishedEmbeddingStatus {
+  return PUBLISHED_EMBEDDING_STATUSES.includes(
+    status as PublishedEmbeddingStatus
+  );
+}
+
+export function resolveEmbeddingStatus(input: {
+  imageEmbeddingsEnabled: boolean;
+  imageUrlCount: number;
+  processedImageCount: number;
+}): PublishedEmbeddingStatus {
+  const expectedImages = input.imageEmbeddingsEnabled
+    ? Math.min(input.imageUrlCount, 5)
+    : 0;
+
+  return expectedImages > 0 && input.processedImageCount < expectedImages
+    ? "PARTIAL"
+    : "COMPLETED";
+}

--- a/src/lib/embeddings/sync.ts
+++ b/src/lib/embeddings/sync.ts
@@ -21,6 +21,10 @@ import {
   computeImageHash,
   type ImagePart,
 } from "./images";
+import {
+  isPublishedEmbeddingStatus,
+  resolveEmbeddingStatus,
+} from "./status";
 import { features } from "@/lib/env";
 import { logger } from "@/lib/logger";
 
@@ -49,6 +53,7 @@ interface SearchDocRow {
   embedding_text: string | null;
   embedding_status: string | null;
   embedding_image_hash: string | null;
+  embedding_model: string | null;
 }
 
 /** Add Sentry breadcrumb (lazy import, no-op in test) */
@@ -79,7 +84,8 @@ export async function syncListingEmbedding(listingId: string): Promise<void> {
              house_rules, lease_duration, gender_preference, household_gender,
              household_languages, primary_home_language, available_slots,
              total_slots, city, state, address, move_in_date, booking_mode,
-             images, embedding_text, embedding_status, embedding_image_hash
+             images, embedding_text, embedding_status, embedding_image_hash,
+             embedding_model
       FROM listing_search_docs
       WHERE id = ${listingId}
     `;
@@ -114,10 +120,12 @@ export async function syncListingEmbedding(listingId: string): Promise<void> {
     const newImageHash =
       imageUrls.length > 0 ? computeImageHash(imageUrls) : null;
 
-    // Skip if BOTH text AND images unchanged (dedup)
+    // Skip only when content, images, version, and published status are current.
     if (
       doc.embedding_text === embeddingText &&
-      doc.embedding_image_hash === newImageHash
+      doc.embedding_image_hash === newImageHash &&
+      doc.embedding_model === EMBEDDING_MODEL &&
+      isPublishedEmbeddingStatus(doc.embedding_status)
     )
       return;
 
@@ -145,18 +153,22 @@ export async function syncListingEmbedding(listingId: string): Promise<void> {
     // Generate embedding (multimodal if images available, text-only otherwise)
     const embedding =
       imageParts.length > 0
-        ? await generateMultimodalEmbedding(embeddingText, imageParts)
-        : await generateEmbedding(embeddingText, "RETRIEVAL_DOCUMENT");
+        ? await generateMultimodalEmbedding(
+            embeddingText,
+            imageParts,
+            "RETRIEVAL_DOCUMENT",
+            { title: doc.title }
+          )
+        : await generateEmbedding(embeddingText, "RETRIEVAL_DOCUMENT", {
+            title: doc.title,
+          });
     const vecSql = pgvector.toSql(embedding);
 
-    // Determine status: COMPLETED if all images processed (or no images), PARTIAL if some failed
-    const expectedImages = features.imageEmbeddings
-      ? Math.min(imageUrls.length, 5)
-      : 0;
-    const embeddingStatus =
-      expectedImages > 0 && imageParts.length < expectedImages
-        ? "PARTIAL"
-        : "COMPLETED";
+    const embeddingStatus = resolveEmbeddingStatus({
+      imageEmbeddingsEnabled: features.imageEmbeddings,
+      imageUrlCount: imageUrls.length,
+      processedImageCount: imageParts.length,
+    });
 
     // Store embedding with metadata
     await prisma.$executeRaw`

--- a/src/lib/projections/semantic.ts
+++ b/src/lib/projections/semantic.ts
@@ -162,12 +162,6 @@ export function buildSemanticProjectionText(row: SemanticSourceRow): string {
   if (row.lease_negotiable) {
     parts.push("Lease is negotiable.");
   }
-  if (row.gender_preference) {
-    parts.push(`Gender preference: ${row.gender_preference}.`);
-  }
-  if (row.household_gender) {
-    parts.push(`Household gender: ${row.household_gender}.`);
-  }
   if (row.public_area_name) {
     parts.push(`Area: ${row.public_area_name}.`);
   } else if (row.public_cell_id) {
@@ -252,7 +246,8 @@ export async function rebuildSemanticInventoryProjection(
 
   const embedding = await (deps?.generateEmbedding ?? generateEmbedding)(
     text,
-    "RETRIEVAL_DOCUMENT"
+    "RETRIEVAL_DOCUMENT",
+    { embeddingVersion }
   );
   const vectorLiteral = pgvector.toSql(embedding);
   const sanitizedContentHash = hashSemanticContent(text);

--- a/src/lib/search/meta.ts
+++ b/src/lib/search/meta.ts
@@ -1,4 +1,4 @@
-import { getCurrentEmbeddingVersion } from "@/lib/embeddings/version";
+import { getReadEmbeddingVersion } from "@/lib/embeddings/version";
 import { SEARCH_DOC_PROJECTION_VERSION } from "./search-doc-sync";
 import type { SearchV2Meta } from "./types";
 import { RANKING_VERSION } from "./ranking";
@@ -16,7 +16,7 @@ export function getSearchV2VersionMeta(options: {
       ? SEARCH_DOC_PROJECTION_VERSION
       : undefined;
   const embeddingVersion = options.usedSemanticSearch
-    ? getCurrentEmbeddingVersion()
+    ? getReadEmbeddingVersion()
     : undefined;
   const rankerProfileVersion = options.rankerEnabled
     ? RANKING_VERSION

--- a/src/lib/search/query-hash.ts
+++ b/src/lib/search/query-hash.ts
@@ -31,7 +31,7 @@ export interface HashableSearchQuery {
 }
 
 export const SEARCH_QUERY_HASH_VERSION =
-  "2026-04-15.cfm-search-contract-v1";
+  "2026-04-28.semantic-embedding-version-v2";
 
 function quantizeBound(value: number): number {
   return Math.round(value / BOUNDS_EPSILON) * BOUNDS_EPSILON;

--- a/src/lib/search/search-doc-queries.ts
+++ b/src/lib/search/search-doc-queries.ts
@@ -61,7 +61,8 @@ import {
 import { toPublicCoordinates } from "./public-coordinates";
 import pgvector from "pgvector";
 import { getCachedQueryEmbedding } from "@/lib/embeddings/query-cache";
-import { getCurrentEmbeddingVersion } from "@/lib/embeddings/version";
+import { getReadEmbeddingVersion } from "@/lib/embeddings/version";
+import { PUBLISHED_EMBEDDING_STATUSES } from "@/lib/embeddings/status";
 import { logger } from "@/lib/logger";
 import { joinWhereClauseWithSecurityInvariant } from "@/lib/sql-safety";
 import { buildAvailabilitySqlFragments } from "@/lib/availability";
@@ -76,8 +77,6 @@ import {
 // Statement timeout for search queries (5 seconds)
 const SEARCH_QUERY_TIMEOUT_MS = 5000;
 const SEARCH_DEDUP_LOOK_AHEAD = 16;
-const PUBLISHED_EMBEDDING_STATUSES = ["COMPLETED", "PARTIAL"] as const;
-
 function isPresent<T>(value: T | null | undefined): value is T {
   return value != null;
 }
@@ -2256,8 +2255,11 @@ export async function semanticSearchQuery(
   const cappedQuery = queryText.slice(0, MAX_QUERY_LENGTH);
 
   try {
-    const embedding = await getCachedQueryEmbedding(cappedQuery);
-    const embeddingVersion = getCurrentEmbeddingVersion();
+    const embeddingVersion = getReadEmbeddingVersion();
+    const embedding = await getCachedQueryEmbedding(
+      cappedQuery,
+      embeddingVersion
+    );
     const vecSql = pgvector.toSql(embedding);
 
     // Lowercase array filters to match _lower columns
@@ -2275,18 +2277,20 @@ export async function semanticSearchQuery(
       `SELECT * FROM search_listings_semantic(
         $1::text::vector,
         $2,
-        $3::float, $4::float, $5::float, $6::float,
-        $7::numeric, $8::numeric,
-        $9::text[], $10::text[],
-        $11::text, $12::text, $13::text, $14::text,
-        $15::int, $16::text, $17::timestamptz, $18::text[],
-        $19::float,
-        $20::int,
-        $21::int
+        $3::text,
+        $4::float, $5::float, $6::float, $7::float,
+        $8::numeric, $9::numeric,
+        $10::text[], $11::text[],
+        $12::text, $13::text, $14::text, $15::text,
+        $16::int, $17::text, $18::timestamptz, $19::text[],
+        $20::float,
+        $21::int,
+        $22::int
       )`,
       [
         vecSql,
         cappedQuery,
+        embeddingVersion,
         filterParams.bounds?.minLat ?? null,
         filterParams.bounds?.minLng ?? null,
         filterParams.bounds?.maxLat ?? null,

--- a/src/lib/search/search-v2-service.ts
+++ b/src/lib/search/search-v2-service.ts
@@ -80,6 +80,7 @@ import {
 } from "@/lib/search/public-availability";
 import type { FilterParams } from "@/lib/search-types";
 import { isPhase04ProjectionReadsEnabled } from "@/lib/flags/phase04";
+import { getReadEmbeddingVersion } from "@/lib/embeddings/version";
 import { executeProjectionSearchV2 } from "@/lib/search/projection-search";
 import {
   getProjectionReadEligibility,
@@ -575,6 +576,18 @@ export async function executeSearchV2(
       };
     }
 
+    // Get sort option from parsed params (default to recommended)
+    const sortOption: SortOption =
+      (parsed.filterParams.sort as SortOption) || "recommended";
+    const hashVibeQuery = parsed.filterParams.vibeQuery?.trim();
+    const hashEmbeddingVersion =
+      features.semanticSearch &&
+      hashVibeQuery &&
+      hashVibeQuery.length >= 3 &&
+      sortOption === "recommended"
+        ? getReadEmbeddingVersion()
+        : undefined;
+
     const queryHash = generateQueryHash({
       query: parsed.filterParams.query,
       vibeQuery: parsed.filterParams.vibeQuery,
@@ -587,13 +600,16 @@ export async function executeSearchV2(
       leaseDuration: parsed.filterParams.leaseDuration,
       moveInDate: parsed.filterParams.moveInDate,
       endDate: parsed.filterParams.endDate,
+      genderPreference: parsed.filterParams.genderPreference,
+      householdGender: parsed.filterParams.householdGender,
+      bookingMode: parsed.filterParams.bookingMode,
+      minAvailableSlots: parsed.filterParams.minAvailableSlots,
       bounds: parsed.filterParams.bounds,
       nearMatches: parsed.filterParams.nearMatches,
+      ...(hashEmbeddingVersion
+        ? { embeddingVersion: hashEmbeddingVersion }
+        : {}),
     });
-
-    // Get sort option from parsed params (default to recommended)
-    const sortOption: SortOption =
-      (parsed.filterParams.sort as SortOption) || "recommended";
 
     if (isPhase04ProjectionReadsEnabled()) {
       const projectionEligibility = getProjectionReadEligibility(parsed);

--- a/src/scripts/resync-embeddings.ts
+++ b/src/scripts/resync-embeddings.ts
@@ -7,6 +7,7 @@
  */
 import { PrismaClient } from "@prisma/client";
 import { syncListingEmbedding } from "../lib/embeddings/sync";
+import { EMBEDDING_MODEL } from "../lib/embeddings/gemini";
 
 const prisma = new PrismaClient();
 const CONCURRENCY = 3; // Respect Gemini rate limits
@@ -14,7 +15,9 @@ const CONCURRENCY = 3; // Respect Gemini rate limits
 async function main() {
   const rows = await prisma.$queryRaw<{ id: string }[]>`
     SELECT id FROM listing_search_docs
-    WHERE embedding_status = 'PENDING'
+    WHERE embedding IS NULL
+       OR embedding_status IN ('PENDING', 'FAILED')
+       OR embedding_model IS DISTINCT FROM ${EMBEDDING_MODEL}
     ORDER BY listing_created_at ASC
   `;
 


### PR DESCRIPTION
## Summary

- Migrates semantic embedding/profile handling to the Gemini GA embedding profile.
- Adds version-aware semantic search database overloads and indexes so preview and GA vectors are not mixed during ranking.
- Updates embedding composition, sync, query cache, search query hashing, semantic projections, and resync/backfill tooling.

## DB migration notes

Schema/migration highlights:
- Adds migration `20260515000000_embedding_ga_version_isolation`.
- Creates version-filtered HNSW/index support for GA embeddings.
- Adds overloads for `search_listings_semantic` and `get_similar_listings` that require an embedding version.

Migration steps:
- Apply after PR #114 migrations because this branch stacks on the core search/projection changes.
- Backfill/resync embeddings using the updated scripts after deploy configuration is confirmed.

Rollback notes:
- Migration is additive: rollback can drop the new overloads/indexes listed in the migration header while leaving older overloads in place.
- Code rollback should be coordinated with embedding profile/backfill state to avoid comparing mixed vector profiles.

## Validation

- `NODE_OPTIONS=--experimental-vm-modules pnpm exec jest --runInBand src/__tests__/db/semantic-embedding-isolation-migration.test.ts src/__tests__/lib/embeddings/compose.test.ts src/__tests__/lib/embeddings/gemini.test.ts src/__tests__/lib/embeddings/query-cache.test.ts src/__tests__/lib/embeddings/status.test.ts src/__tests__/lib/embeddings/sync.test.ts src/__tests__/lib/projections/semantic.test.ts src/__tests__/lib/search/hash.test.ts src/__tests__/lib/search/search-meta.test.ts src/__tests__/lib/search/search-v2-service.test.ts src/__tests__/lib/search/semantic-search-query.test.ts`
  - Passed: 11 suites / 160 tests
- `pnpm typecheck`
  - Passed

## Stack

- Base PR: #114, `codex/core-roomshare-flows`
- This PR is intentionally stacked to preserve migration and search projection ordering.