### PR TITLE
[codex] Fix public search payload privacy

### DIFF
--- a/docs/review/production_readiness_matrix.md
+++ b/docs/review/production_readiness_matrix.md
@@ -1,0 +1,47 @@
+# Production Readiness Matrix
+
+Status values:
+
+- `NotStarted`: gate has not been run for this audit.
+- `Pass`: gate passed with recorded evidence.
+- `Fail`: gate failed and is release-blocking or needs triage.
+- `Triaged`: failure or gap is accepted with rationale in the risk register.
+- `Blocked`: gate cannot run because prerequisite setup is missing.
+- `Advisory`: useful signal, not release-blocking.
+
+| Area | Gate | Required evidence | Release blocking | Status | Evidence / notes |
+| --- | --- | --- | --- | --- | --- |
+| Baseline | Dirty worktree reconciled or intentionally preserved | `git status --short` captured | Yes | Pass | Current dirty worktree accepted as release candidate baseline by user. Branch `codex/search-ux-fixes`, HEAD `b3e3b0f4`, captured `2026-05-06T23:45:04Z`, 100 changed/untracked entries. |
+| Dependencies | Lockfile install succeeds | `pnpm install --frozen-lockfile` | Yes | Pass | Passed. pnpm reused/downloaded packages and ran `prisma generate`. Warning: build scripts ignored for several packages; review during supply-chain slice. |
+| Type safety | Typecheck passes | `pnpm run typecheck` | Yes | Pass | Passed. `prisma generate`, `next typegen`, and `tsc --noEmit` completed. |
+| Lint | ESLint passes | `pnpm run lint` | Yes | Pass | Passed with 19 warnings and 0 errors. Warnings are advisory unless tied to concrete failures during audit. |
+| Unit/API/component tests | Jest suite passes | `pnpm run test` | Yes | Fail | Failed: 8 suites failed, 16 tests failed, 7485 passed, 8 skipped. See `P1-TEST-001`. |
+| Build | Production build passes | `pnpm run build` | Yes | Pass | Passed. Warnings: custom Cache-Control headers, Sentry/OpenTelemetry dynamic dependency warnings, edge runtime disables static generation for edge pages. |
+| Public payload privacy | PII/public payload scan passes | `pnpm run scan:public-payload-pii -- <captured-payloads>` | Yes | Pass | Passed against real captured local payloads from `/api/search/v2`, `/api/search/listings`, `/api/map-listings`, and `/api/listings`: `{"ok":true,"scannedFiles":4}`. The no-arg scanner wrapper remains a separate follow-up under `P1-PRIVACY-001`; the concrete payload leak is fixed under `P0-PRIVACY-002`. |
+| Dependency audit | No untriaged high/critical vulnerable dependencies | `pnpm audit --audit-level high` | Yes | Fail | Failed with 13 vulnerabilities: 6 high, 5 moderate, 2 low. High advisories include lodash/lodash-es and basic-ftp transitive paths under `@lhci/cli`. See `P1-SUPPLY-001`. |
+| E2E smoke | Chromium Playwright suite passes | `pnpm run test:e2e:ci` | Yes | Blocked | Timed out after 10 minutes. Playwright artifact shows dedupe helper call `seedCollisionListings` failed with `{\"error\":\"Not found\"}` before timeout. A leftover Playwright process was stopped manually. See `P1-E2E-001`. |
+| Search/map E2E | Search release gate passes | `pnpm run test:e2e:search-release-gate` | Yes | Pass | Passed after Docker/Postgres became reachable: 36 passed, 16 skipped across SSR/client search release gate runs. |
+| Create listing E2E | Create-listing and dedupe suites pass | `pnpm exec playwright test tests/e2e/create-listing --project=chromium`; `pnpm exec playwright test tests/e2e/dedupe --project=chromium` | Yes | NotStarted | |
+| Auth | Protected routes and actions verified | Code review plus regression tests | Yes | NotStarted | |
+| Authorization | Users cannot access or mutate others' data | Code review plus tests | Yes | NotStarted | |
+| Validation | Public inputs validated server-side | Zod/schema/action/API review plus tests | Yes | NotStarted | |
+| Database | Constraints, indexes, cascades, and migrations safe | Prisma/migration review plus migration validation | Yes | NotStarted | |
+| Business invariants | Listings, availability, contact, messaging, booking, and dedupe invariants hold | State-machine review plus tests | Yes | NotStarted | |
+| Uploads/images | File type, size, storage permissions, and URL exposure safe | Upload review plus tests/mocks | Yes | NotStarted | |
+| Security controls | OWASP ASVS-relevant controls checked | Review ledger, scanner evidence, tests | Yes | NotStarted | |
+| Secrets | No secrets in repo, logs, or client bundle | Secret scan plus code/log review | Yes | NotStarted | |
+| CI security | CodeQL, Dependabot alerts, dependency review, and secret scanning configured or triaged | GitHub settings/workflow evidence | Yes | NotStarted | |
+| Observability | Sentry/logging/health checks active and safe | Staging evidence, runbook, log review | Yes | NotStarted | |
+| Performance | Critical pages have acceptable performance | Lighthouse/load/manual evidence | Advisory | NotStarted | |
+| Rollback | Rollback and migration plan exists | Runbook or deployment procedure | Yes | NotStarted | |
+| Staging parity | Staging behaves like production for critical flows | Smoke test report and env review | Yes | NotStarted | |
+
+## Release Candidate Rule
+
+Declare release candidate only when:
+
+- Every `Release blocking = Yes` row is `Pass` or `Triaged`.
+- Every `Triaged` row links to a risk-register entry with owner, rationale,
+  expiration or follow-up, and rollback/mitigation.
+- No open `P0` or `P1` findings remain in `docs/review/review_ledger.md`.
+- Fixed `P0` and `P1` findings have adversarial re-review evidence.

--- a/docs/review/review_ledger.md
+++ b/docs/review/review_ledger.md
@@ -1,0 +1,256 @@
+# Review Ledger
+
+This is the single source of truth for production-readiness findings and fix
+evidence. Do not record duplicates. Do not record unsupported speculation as a
+confirmed issue.
+
+## Ledger Status
+
+- Audit status: `Phase2TestingCiAudited`
+- Release candidate status: `NotReady`
+- Open P0 count: `0`
+- Open P1 count: `3`
+- Last updated: `2026-05-08`
+
+## Finding Schema
+
+Each confirmed finding must use this shape:
+
+```md
+### P1-AUTH-001 - Short title
+
+- Severity: P1
+- Confidence: High
+- Status: Open
+- Duplicate status: Unique
+- Slice: Auth/AuthZ/Sessions
+- Exact location: `src/path/file.ts:functionName` or route/action/migration
+- Evidence:
+- Failure scenario:
+- Impact:
+- Reproduction or test idea:
+- Suggested fix direction:
+- False-positive challenge:
+- Fix summary:
+- Files changed:
+- Tests added or updated:
+- Commands run:
+- Remaining risk:
+- Adversarial re-review:
+```
+
+Allowed statuses:
+
+- `Open`
+- `InProgress`
+- `FixedPendingReview`
+- `VerifiedFixed`
+- `PartiallyFixed`
+- `Blocked`
+- `Duplicate`
+- `RejectedFalsePositive`
+- `AcceptedRisk`
+
+## Confirmed Findings
+
+### P1-TEST-001 - Jest baseline gate fails
+
+- Severity: P1
+- Confidence: High
+- Status: Open
+- Duplicate status: Unique
+- Slice: Testing/CI/release gates
+- Exact location: `pnpm run test`
+- Evidence: Command exited 1. Jest reported 8 failed suites, 16 failed tests,
+  7485 passed tests, and 8 skipped tests.
+- Testing/CI slice update: A focused rerun of three representative failing
+  suites still failed: `src/__tests__/lib/search/search-query.test.ts`,
+  `src/__tests__/lib/search/search-doc-queries.test.ts`, and
+  `src/__tests__/lib/search-alerts.test.ts` had 8 failures and 102 passing
+  tests.
+- Root-cause evidence: Many failures are time-sensitive test-fixture failures.
+  `src/lib/search-params.ts` rejects dates before the current day in
+  `safeParseDate`, while failing tests use `2026-05-01`; the accepted baseline
+  was captured on `2026-05-06T23:45:04Z`. Search projection fixtures also use
+  `lastConfirmedAt: "2026-04-15T12:30:00.000Z"`, which crosses the
+  21-day host-managed stale threshold by the current audit date.
+- Failure scenario: The release candidate cannot pass the required unit, API,
+  hook, and component regression suite.
+- Impact: Release gate failure. The failed tests cover search pagination,
+  search alerts, URL date filters, search projection mapping, query hashing,
+  SlotBadge styling expectations, and search layout rendering.
+- Reproduction or test idea: Run `pnpm run test`; then run the failing suites
+  individually:
+  `src/__tests__/lib/search/search-v2-service.test.ts`,
+  `src/__tests__/lib/search-alerts.test.ts`,
+  `src/__tests__/hooks/useBatchedFilters.test.ts`,
+  `src/__tests__/lib/search/search-doc-queries.test.ts`,
+  `src/__tests__/lib/search/hash.test.ts`,
+  `src/__tests__/lib/search/search-query.test.ts`,
+  `src/__tests__/components/SlotBadge.test.tsx`, and
+  `src/__tests__/app/search/layout.test.tsx`.
+- Suggested fix direction: First stabilize date-dependent tests by freezing time
+  or using relative future fixtures. Then rerun the full failing-suite list to
+  identify remaining non-time-based regressions, including SlotBadge styling and
+  search layout rendering.
+- False-positive challenge: Not a false positive as a release gate result; the
+  command returned non-zero. Individual product impact still needs slice review.
+- Fix summary:
+- Files changed:
+- Tests added or updated:
+- Commands run: `pnpm run test`;
+  `pnpm exec jest src/__tests__/lib/search/search-query.test.ts src/__tests__/lib/search/search-doc-queries.test.ts src/__tests__/lib/search-alerts.test.ts --runInBand --silent`
+- Remaining risk: Full test suite is not a passing release gate.
+- Adversarial re-review:
+
+### P1-SUPPLY-001 - Dependency audit reports untriaged high vulnerabilities
+
+- Severity: P1
+- Confidence: High
+- Status: Open
+- Duplicate status: Unique
+- Slice: Dependencies/supply chain/secrets
+- Exact location: `pnpm audit --audit-level high`
+- Evidence: Command exited 1 with 13 vulnerabilities: 6 high, 5 moderate, and
+  2 low. High findings include lodash/lodash-es code injection advisories and
+  multiple `basic-ftp` advisories through `@lhci/cli` transitive dependency
+  paths.
+- Failure scenario: A release proceeds with known high-severity dependency
+  advisories that are not patched, removed, scoped to dev-only, or explicitly
+  accepted.
+- Impact: Supply-chain release gate failure. The current evidence points to
+  tooling transitive paths, but this still requires triage before release.
+- Reproduction or test idea: Run `pnpm audit --audit-level high` and inspect
+  advisories `GHSA-r5fr-rjxr-66jc`, `GHSA-6v7q-wjvx-w8wg`,
+  `GHSA-chqc-8p9q-pq6q`, `GHSA-rp42-5vxx-qpwr`, and
+  `GHSA-rpmf-866q-6p89`.
+- Suggested fix direction: Triage whether affected packages are dev-only, update
+  or replace vulnerable dependency chains, or document an accepted risk with
+  evidence and expiration.
+- False-positive challenge: Not a false positive as a scanner result; exploit
+  reachability and release-blocking severity require supply-chain review.
+- Fix summary:
+- Files changed:
+- Tests added or updated:
+- Commands run: `pnpm audit --audit-level high`
+- Remaining risk: No supply-chain exception or mitigation has been recorded.
+- Adversarial re-review:
+
+### P1-PRIVACY-001 - Public payload PII gate is not runnable without explicit payloads
+
+- Severity: P1
+- Confidence: High
+- Status: PartiallyFixed
+- Duplicate status: Unique
+- Slice: Testing/CI/release gates
+- Exact location: `pnpm run scan:public-payload-pii`
+- Evidence: Command exited 1 with usage output:
+  `Usage: node scripts/scan-public-payload-pii.js <payload.json> [more.json]`.
+- Testing/CI slice update: The scanner itself works when passed existing
+  fixtures. `node scripts/scan-public-payload-pii.js scripts/fixtures/public-payload-clean.json`
+  returns `{ "ok": true, "scannedFiles": 1 }`; the leak fixture returns
+  expected violations for exact address, unit number, phone, and exact point.
+- Failure scenario: The privacy gate cannot produce pass/fail evidence from the
+  standard release command because it has no default payload source.
+- Impact: Release gate is blocked for public payload PII verification. This does
+  not prove a PII leak, but it prevents evidence-backed release approval.
+- Reproduction or test idea: Run `pnpm run scan:public-payload-pii` from the repo
+  root.
+- Suggested fix direction: Change the release gate to pass deterministic public
+  payload fixtures, or add a wrapper script that generates/captures
+  representative payload JSON before invoking the scanner.
+- False-positive challenge: Not a product vulnerability finding yet; confirmed
+  as a verification-gate blocker.
+- Fix summary: The scanner remains an explicit-payload CLI, but the search/list/map public payload leak found during runtime verification was fixed through a shared public search payload sanitizer. Real local payloads from `/api/search/v2`, `/api/search/listings`, `/api/map-listings`, and `/api/listings` now scan cleanly when captured from the built app.
+- Files changed: `scripts/scan-public-payload-pii.js`, `src/lib/search/public-listing-payload.ts`, `src/lib/search/types.ts`, `src/lib/search/search-response.ts`, `src/lib/search/search-v2-service.ts`, `src/lib/search/projection-search.ts`, `src/lib/search/transform.ts`, `src/lib/search/v2-map-data.ts`, `src/lib/maps/sanitize-map-listings.ts`, `src/app/search/page.tsx`, `src/app/search/actions.ts`, `src/app/api/search/listings/route.ts`, `src/app/api/listings/route.ts`, and focused regression tests.
+- Tests added or updated: `src/__tests__/lib/search/public-listing-payload.test.ts`, `src/__tests__/lib/search/v2-map-data.test.ts`, `src/__tests__/scripts/scan-public-payload-pii.test.ts`, plus focused search/API/map tests.
+- Commands run: `pnpm run scan:public-payload-pii`;
+  `node scripts/scan-public-payload-pii.js scripts/fixtures/public-payload-clean.json`;
+  `node scripts/scan-public-payload-pii.js scripts/fixtures/public-payload-leak.json`;
+  `pnpm test -- src/__tests__/lib/search/public-listing-payload.test.ts src/__tests__/lib/maps/sanitize-map-listings.test.ts src/__tests__/lib/search/v2-map-data.test.ts src/__tests__/lib/search/search-v2-service.test.ts src/__tests__/app/search/actions.test.ts src/__tests__/api/search/v2/route.test.ts src/__tests__/api/map-listings.test.ts src/__tests__/api/map-listings-route.test.ts src/__tests__/api/listings.test.ts src/__tests__/scripts/scan-public-payload-pii.test.ts --runInBand`;
+  `pnpm run typecheck`;
+  `pnpm run test:e2e:search-release-gate`;
+  `pnpm run scan:public-payload-pii -- /tmp/roomshare-payload-search-v2.json /tmp/roomshare-payload-search-listings.json /tmp/roomshare-payload-map-listings.json /tmp/roomshare-payload-listings.json`
+- Remaining risk: The package script still requires explicit payload JSON files; a wrapper that captures deterministic payloads before scanning is still recommended before treating the no-arg privacy gate as fully fixed.
+- Adversarial re-review: Pass for the concrete search/list/map payload leak. The fixed implementation sanitizes all discovered browser-visible public search/list/map payload boundaries and the real captured payload scan returned `{"ok":true,"scannedFiles":4}`.
+
+### P0-PRIVACY-002 - Public search/list/map payloads exposed exact coordinates and raw grouping keys
+
+- Severity: P0
+- Confidence: High
+- Status: VerifiedFixed
+- Duplicate status: Unique
+- Slice: Privacy/Search/Map public payloads
+- Exact location: `/api/search/v2`, `/api/search/listings`, `/api/listings`, `/api/map-listings`, `/search` initial data, and `fetchMoreListings`
+- Evidence: Runtime payload scan previously failed for real search/map JSON. Triage identified high-precision `list.fullItems.*.location.lat/lng` and raw `groupKey` / `contextKey` values as the real privacy risk.
+- Failure scenario: Anonymous browser-visible search/list/map responses could expose exact listing coordinates or internal grouping identifiers.
+- Impact: Public payload privacy leak for listing discovery surfaces.
+- Reproduction or test idea: Capture public JSON from the search/list/map APIs and scan it with `scripts/scan-public-payload-pii.js`.
+- Suggested fix direction: Sanitize every browser-visible public search/list/map payload through one shared transform while keeping internal DB/query data unchanged.
+- False-positive challenge: Some original scanner hits were false positives from image URLs, coarsened coordinates, and snapshot version strings. The exact `fullItems` coordinates and raw grouping keys were not false positives.
+- Fix summary: Added `toPublicSearchListing` / `toPublicGroupMetadata`, changed public response types to `PublicSearchListing`, sanitized SSR initial listings, V2 fullItems, client search-listing API responses, `/api/listings`, load-more server action responses, map metadata, and projection/search-doc response paths. Scanner logic now distinguishes safe coarsened coordinates, image URLs, snapshot versions, and opaque `pg1_` group ids from real leaks.
+- Files changed: `src/lib/search/public-listing-payload.ts`, `src/lib/public-cache/cache-policy.ts`, `src/lib/search-types.ts`, `src/lib/search/types.ts`, `src/lib/search/search-response.ts`, `src/lib/search/search-v2-service.ts`, `src/lib/search/projection-search.ts`, `src/lib/search/transform.ts`, `src/lib/search/v2-map-data.ts`, `src/lib/maps/sanitize-map-listings.ts`, `src/app/search/page.tsx`, `src/app/search/actions.ts`, `src/app/api/search/listings/route.ts`, `src/app/api/listings/route.ts`, `scripts/scan-public-payload-pii.js`, and focused regression tests.
+- Tests added or updated: Sanitizer unit tests, map sanitizer tests, client-safe V2 map conversion tests, search V2 service tests, search load-more tests, API listings tests, and scanner tests.
+- Commands run: `pnpm test -- src/__tests__/lib/search/public-listing-payload.test.ts src/__tests__/lib/maps/sanitize-map-listings.test.ts src/__tests__/lib/search/v2-map-data.test.ts src/__tests__/lib/search/search-v2-service.test.ts src/__tests__/app/search/actions.test.ts src/__tests__/api/search/v2/route.test.ts src/__tests__/api/map-listings.test.ts src/__tests__/api/map-listings-route.test.ts src/__tests__/api/listings.test.ts src/__tests__/scripts/scan-public-payload-pii.test.ts --runInBand`; `pnpm run typecheck`; `pnpm run test:e2e:search-release-gate`; `pnpm run scan:public-payload-pii -- /tmp/roomshare-payload-search-v2.json /tmp/roomshare-payload-search-listings.json /tmp/roomshare-payload-map-listings.json /tmp/roomshare-payload-listings.json`
+- Remaining risk: Broader non-gate E2E coverage and a no-arg deterministic scanner wrapper remain separate release-readiness work.
+- Adversarial re-review: Approved. The real local payload scanner passed with `{"ok":true,"scannedFiles":4}`, and the search release gate passed after Docker/Postgres was available.
+
+### P1-E2E-001 - Chromium E2E smoke gate times out
+
+- Severity: P1
+- Confidence: High
+- Status: Open
+- Duplicate status: Unique
+- Slice: Testing/CI/release gates
+- Exact location: `pnpm run test:e2e:ci`
+- Evidence: Command timed out after 604 seconds. A leftover process remained:
+  `node .../@playwright/test/cli.js test --project=chromium --reporter=list,html`;
+  it was stopped manually after the timeout.
+- Testing/CI slice update: `playwright-report/data/eadab5862d058d9e58eba62699dd382b983fb419.md`
+  records a concrete failed test before timeout:
+  `dedupe/create-collision-cross-owner-no-modal.dedupe.spec.ts` failed because
+  `seedCollisionListings` returned `{"error":"Not found"}`. The helper route is
+  `src/app/api/test-helpers/route.ts`, and it returns 404 unless
+  `E2E_TEST_HELPERS === "true"` and the bearer token matches
+  `E2E_TEST_SECRET`.
+- Failure scenario: The release candidate cannot produce E2E smoke pass/fail
+  evidence within the baseline command timeout.
+- Impact: Release gate is blocked. Critical browser flows are not yet verified
+  for this release candidate.
+- Reproduction or test idea: Run `pnpm run test:e2e:ci` and inspect
+  `playwright-report` and `test-results` artifacts. If the full suite is too
+  large, run critical scoped suites after recording the full-suite blocker.
+- Suggested fix direction: First align local release-gate environment with CI
+  (`E2E_TEST_HELPERS=true`, `E2E_TEST_SECRET`, seeded DB, and feature flags) or
+  gate helper-dependent specs out of the local smoke command. Then split full
+  E2E from the release smoke so one failing helper path cannot hide suite-wide
+  progress behind a timeout.
+- False-positive challenge: Not a false positive as a baseline gate result; no
+  passing E2E evidence was produced.
+- Fix summary:
+- Files changed:
+- Tests added or updated:
+- Commands run: `pnpm run test:e2e:ci`
+- Remaining risk: Browser release smoke coverage is missing.
+- Adversarial re-review:
+
+## Deduplication Log
+
+| Candidate ID | Duplicate of | Rationale | Decision |
+| --- | --- | --- | --- |
+
+## Fix Order
+
+Fix order is determined after Phase 2 deduplication:
+
+1. P0 issues.
+2. P1 auth, authorization, privacy, data integrity, and build/deploy blockers.
+3. Other P1 critical-flow regressions.
+4. P2 issues that materially reduce launch confidence.
+5. P3 backlog.
+
+## Adversarial Re-Review Log
+
+| Finding ID | Reviewer | Result | Evidence | Follow-up |
+| --- | --- | --- | --- | --- |
+| P0-PRIVACY-002 | Codex Critic | Pass | Focused unit/API scanner tests passed, typecheck passed, search release gate passed, and captured public payload scan returned `{"ok":true,"scannedFiles":4}`. | Add a deterministic scanner capture wrapper later so `scan:public-payload-pii` can run as a no-arg release gate. |

--- a/scripts/scan-public-payload-pii.js
+++ b/scripts/scan-public-payload-pii.js
@@ -33,6 +33,46 @@ function pathJoin(parent, key) {
   return parent ? `${parent}.${key}` : String(key);
 }
 
+function hasAtMostDecimalPlaces(value, maxDecimals) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return false;
+  }
+
+  const factor = 10 ** maxDecimals;
+  return Math.abs(value * factor - Math.round(value * factor)) < 1e-9;
+}
+
+function isCoordinateKey(key) {
+  return /^(lat|latitude|lng|longitude)$/i.test(key);
+}
+
+function isSafePublicCoordinateValue(value) {
+  return hasAtMostDecimalPlaces(value, 2);
+}
+
+function isImageValuePath(currentPath) {
+  return /(^|\.)(image|images\.\d+)$/i.test(currentPath);
+}
+
+function isSnapshotVersionPath(currentPath) {
+  return /(^|\.)snapshotVersion$/i.test(currentPath);
+}
+
+function isGroupIdentityPath(currentPath) {
+  return /(^|\.)(groupKey|contextKey)$/i.test(currentPath);
+}
+
+function isPublicGroupIdentity(value) {
+  return typeof value === "string" && value.startsWith("pg1_");
+}
+
+function isLikelyImageUrl(value) {
+  return (
+    typeof value === "string" &&
+    (/^https?:\/\//i.test(value) || value.startsWith("/images/"))
+  );
+}
+
 function scanPublicPayloadForPii(payload, options = {}) {
   const violations = [];
   const allowedKeys = new Set(options.allowedKeys || []);
@@ -46,14 +86,23 @@ function scanPublicPayloadForPii(payload, options = {}) {
     if (isPlainObject(value)) {
       for (const [key, nested] of Object.entries(value)) {
         const nextPath = pathJoin(currentPath, key);
-        if (
+        const hasForbiddenKey =
           !allowedKeys.has(nextPath) &&
-          FORBIDDEN_KEY_PATTERNS.some((pattern) => pattern.test(key))
-        ) {
-          violations.push({
-            path: nextPath,
-            reason: "forbidden_public_key",
-          });
+          FORBIDDEN_KEY_PATTERNS.some((pattern) => pattern.test(key));
+        if (hasForbiddenKey) {
+          if (isCoordinateKey(key)) {
+            if (!isSafePublicCoordinateValue(nested)) {
+              violations.push({
+                path: nextPath,
+                reason: "exact_coordinate_value",
+              });
+            }
+          } else {
+            violations.push({
+              path: nextPath,
+              reason: "forbidden_public_key",
+            });
+          }
         }
         scan(nested, nextPath);
       }
@@ -61,6 +110,20 @@ function scanPublicPayloadForPii(payload, options = {}) {
     }
 
     if (typeof value !== "string") {
+      return;
+    }
+
+    if (isGroupIdentityPath(currentPath)) {
+      if (!isPublicGroupIdentity(value)) {
+        violations.push({ path: currentPath, reason: "raw_group_identity" });
+      }
+      return;
+    }
+
+    if (
+      isSnapshotVersionPath(currentPath) ||
+      (isImageValuePath(currentPath) && isLikelyImageUrl(value))
+    ) {
       return;
     }
 
@@ -102,7 +165,9 @@ function main(argv) {
   }
 
   if (allViolations.length > 0) {
-    console.error(JSON.stringify({ ok: false, violations: allViolations }, null, 2));
+    console.error(
+      JSON.stringify({ ok: false, violations: allViolations }, null, 2)
+    );
     return 1;
   }
 

--- a/src/__tests__/actions/saved-search.test.ts
+++ b/src/__tests__/actions/saved-search.test.ts
@@ -63,6 +63,10 @@ import { auth } from "@/auth";
 import { revalidatePath } from "next/cache";
 import { buildSearchUrl } from "@/lib/search-utils";
 
+const SAVED_SEARCH_TEST_NOW = new Date("2026-04-01T12:00:00.000Z");
+const SAVED_SEARCH_MOVE_IN_DATE = "2026-05-01";
+const SAVED_SEARCH_END_DATE = "2026-07-01";
+
 describe("Saved Search Actions", () => {
   const mockSession = {
     user: { id: "user-123", name: "Test User", email: "test@example.com" },
@@ -86,6 +90,10 @@ describe("Saved Search Actions", () => {
       offers: [],
     });
     mockCheckSuspension.mockResolvedValue({ suspended: false });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe("saveSearch", () => {
@@ -184,6 +192,8 @@ describe("Saved Search Actions", () => {
     });
 
     it("persists endDate in filters and canonical search spec", async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(SAVED_SEARCH_TEST_NOW);
       (prisma.savedSearch.count as jest.Mock).mockResolvedValue(0);
       (prisma.savedSearch.create as jest.Mock).mockResolvedValue({
         id: "search-123",
@@ -194,8 +204,8 @@ describe("Saved Search Actions", () => {
         name: "Date Range",
         filters: {
           query: "apartment",
-          moveInDate: "2026-05-01",
-          endDate: "2026-07-01",
+          moveInDate: SAVED_SEARCH_MOVE_IN_DATE,
+          endDate: SAVED_SEARCH_END_DATE,
         },
       });
 
@@ -203,18 +213,18 @@ describe("Saved Search Actions", () => {
         .calls[0][0];
       expect(createArgs.data.filters).toEqual(
         expect.objectContaining({
-          moveInDate: "2026-05-01",
-          endDate: "2026-07-01",
+          moveInDate: SAVED_SEARCH_MOVE_IN_DATE,
+          endDate: SAVED_SEARCH_END_DATE,
         })
       );
       expect(createArgs.data.searchSpecJson.filters).toEqual(
         expect.objectContaining({
-          moveInDate: "2026-05-01",
-          endDate: "2026-07-01",
+          moveInDate: SAVED_SEARCH_MOVE_IN_DATE,
+          endDate: SAVED_SEARCH_END_DATE,
         })
       );
       expect(buildSearchUrl(createArgs.data.filters)).toContain(
-        "endDate=2026-07-01"
+        `endDate=${SAVED_SEARCH_END_DATE}`
       );
     });
 

--- a/src/__tests__/api/listings-post.test.ts
+++ b/src/__tests__/api/listings-post.test.ts
@@ -165,6 +165,15 @@ const mockSession = {
   user: { id: "user-123", name: "Test User", email: "test@example.com" },
 };
 
+function futureDateInput(daysFromNow: number): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + daysFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+const VALID_MOVE_IN_DATE = futureDateInput(30);
+
 const validBody = {
   title: "Cozy Room in Downtown",
   description: "A nice place to stay with great amenities and city views",
@@ -177,7 +186,7 @@ const validBody = {
   zip: "94102",
   roomType: "Private Room",
   totalSlots: "1",
-  moveInDate: "2026-05-01",
+  moveInDate: VALID_MOVE_IN_DATE,
   images: [
     "https://test-project.supabase.co/storage/v1/object/public/images/listings/user-123/test.jpg",
   ],

--- a/src/__tests__/api/listings.test.ts
+++ b/src/__tests__/api/listings.test.ts
@@ -158,11 +158,38 @@ import { parseSearchParams } from "@/lib/search-params";
 import { checkSuspension, checkEmailVerified } from "@/app/actions/suspension";
 import { upsertSearchDocSync } from "@/lib/search/search-doc-sync";
 import { triggerInstantAlerts } from "@/lib/search-alerts";
+import { buildPublicAvailability } from "@/lib/search/public-availability";
+import type { ListingData } from "@/lib/search-types";
 
 describe("Listings API", () => {
   const mockSession = {
     user: { id: "user-123", name: "Test User", email: "test@example.com" },
   };
+  const makeListing = (overrides: Partial<ListingData> = {}): ListingData => ({
+    id: "listing-1",
+    title: "Cozy Room",
+    description: "Private source description",
+    price: 1200,
+    images: ["listing.jpg"],
+    availableSlots: 1,
+    totalSlots: 2,
+    amenities: [],
+    houseRules: [],
+    householdLanguages: [],
+    location: {
+      address: "123 Private St",
+      city: "Portland",
+      state: "OR",
+      zip: "97201",
+      lat: 45.51234,
+      lng: -122.61234,
+    },
+    publicAvailability: buildPublicAvailability({
+      availableSlots: 1,
+      totalSlots: 2,
+    }),
+    ...overrides,
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -177,8 +204,8 @@ describe("Listings API", () => {
     it("returns paginated listings successfully", async () => {
       const mockResult = {
         items: [
-          { id: "listing-1", title: "Cozy Room" },
-          { id: "listing-2", title: "Sunny Apartment" },
+          makeListing(),
+          makeListing({ id: "listing-2", title: "Sunny Apartment" }),
         ],
         total: 2,
         page: 1,
@@ -192,7 +219,10 @@ describe("Listings API", () => {
 
       expect(response.status).toBe(200);
       const data = await response.json();
-      expect(data.items).toEqual(mockResult.items);
+      expect(data.items.map((item: { id: string }) => item.id)).toEqual([
+        "listing-1",
+        "listing-2",
+      ]);
       expect(data.total).toBe(2);
       expect(data.page).toBe(1);
       // Security: prevent CDN caching of user-generated listing data
@@ -202,11 +232,10 @@ describe("Listings API", () => {
     it("does not leak address or zip in listing location", async () => {
       const mockResult = {
         items: [
-          {
+          makeListing({
             id: "listing-1",
             title: "Cozy Room",
-            location: { city: "Portland", state: "OR", lat: 45.5, lng: -122.6 },
-          },
+          }),
         ],
         total: 1,
         page: 1,

--- a/src/__tests__/app/search/actions.test.ts
+++ b/src/__tests__/app/search/actions.test.ts
@@ -102,6 +102,7 @@ jest.mock("@/lib/timeout-wrapper", () => {
 
 import { fetchMoreListings } from "@/app/search/actions";
 import { TimeoutError, DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
+import { buildPublicAvailability } from "@/lib/search/public-availability";
 
 describe("fetchMoreListings", () => {
   beforeEach(() => {
@@ -112,7 +113,7 @@ describe("fetchMoreListings", () => {
 
   it("wraps executeSearchV2 with withTimeout using DATABASE timeout", async () => {
     const v2Data = {
-      response: { list: { nextCursor: "cursor-2" } },
+      response: { list: { fullItems: [{ id: "1" }], nextCursor: "cursor-2" } },
       paginatedResult: {
         items: [{ id: "1" }],
         nextCursor: "cursor-2",
@@ -178,7 +179,9 @@ describe("fetchMoreListings", () => {
 
   it("returns V2 result when it succeeds within timeout", async () => {
     const v2Data = {
-      response: { list: { nextCursor: "next" } },
+      response: {
+        list: { fullItems: [{ id: "a" }, { id: "b" }], nextCursor: "next" },
+      },
       paginatedResult: {
         items: [{ id: "a" }, { id: "b" }],
         nextCursor: "next",
@@ -197,6 +200,68 @@ describe("fetchMoreListings", () => {
       })
     );
     expect(result.meta).toBeTruthy();
+  });
+
+  it("sanitizes raw paginated V2 items when fullItems is unavailable", async () => {
+    const publicAvailability = buildPublicAvailability({
+      availableSlots: 1,
+      totalSlots: 2,
+    });
+    const v2Data = {
+      response: {
+        list: { nextCursor: "next" },
+      },
+      paginatedResult: {
+        items: [
+          {
+            id: "private-1",
+            title: "Private listing",
+            description: "Call 555-123-4567",
+            price: 1200,
+            images: ["img.jpg"],
+            availableSlots: 1,
+            totalSlots: 2,
+            amenities: [],
+            houseRules: [],
+            householdLanguages: [],
+            ownerId: "owner-secret",
+            location: {
+              address: "123 Private St",
+              city: "Austin",
+              state: "TX",
+              zip: "78701",
+              lat: 30.26721,
+              lng: -97.74312,
+            },
+            publicAvailability,
+            groupKey: "private-unit:1",
+          },
+        ],
+        nextCursor: "next",
+        hasNextPage: true,
+      },
+    };
+    mockExecuteSearchV2.mockResolvedValue(v2Data);
+
+    const result = await fetchMoreListings("c1", { q: "sf" });
+    const serialized = JSON.stringify(result.items[0]);
+
+    expect(result.items[0]).toEqual(
+      expect.objectContaining({
+        id: "private-1",
+        description: "",
+        location: {
+          city: "Austin",
+          state: "TX",
+          lat: 30.27,
+          lng: -97.74,
+        },
+      })
+    );
+    expect(serialized).not.toContain("owner-secret");
+    expect(serialized).not.toContain("123 Private St");
+    expect(serialized).not.toContain("78701");
+    expect(serialized).not.toContain("private-unit");
   });
 
   it("returns a structured snapshotExpired result when the pinned search cursor is stale", async () => {

--- a/src/__tests__/components/SearchForm.test.tsx
+++ b/src/__tests__/components/SearchForm.test.tsx
@@ -139,6 +139,18 @@ jest.mock("sonner", () => ({
 import SearchForm from "@/components/SearchForm";
 import { MAP_FLY_TO_EVENT } from "@/components/SearchForm";
 
+function futureDateInput(daysFromNow: number): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + daysFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+const VALID_MOVE_IN_DATE = futureDateInput(30);
+const VALID_END_DATE = futureDateInput(60);
+const LATER_MOVE_IN_DATE = futureDateInput(60);
+const EARLIER_END_DATE = futureDateInput(30);
+
 // Polyfill requestSubmit for JSDOM
 beforeAll(() => {
   if (!HTMLFormElement.prototype.requestSubmit) {
@@ -362,13 +374,13 @@ describe("SearchForm", () => {
 
       await user.click(screen.getByRole("button", { name: /filters/i }));
       fireEvent.change(screen.getByPlaceholderText("Select move-in date"), {
-        target: { value: "2026-06-01" },
+        target: { value: VALID_MOVE_IN_DATE },
       });
       await user.click(screen.getByRole("button", { name: "Wifi" }));
       fireEvent.click(screen.getByTestId("filter-modal-apply"));
 
       const pushCall = mockPush.mock.calls[0]?.[0] ?? "";
-      expect(pushCall).toContain("moveInDate=2026-06-01");
+      expect(pushCall).toContain(`moveInDate=${VALID_MOVE_IN_DATE}`);
       expect(pushCall).toContain("amenities=Wifi");
     });
 
@@ -820,8 +832,8 @@ describe("SearchForm", () => {
     });
 
     it("preserves a valid moveInDate/endDate range on search submit", async () => {
-      mockSearchParams.set("moveInDate", "2026-05-01");
-      mockSearchParams.set("endDate", "2026-06-01");
+      mockSearchParams.set("moveInDate", VALID_MOVE_IN_DATE);
+      mockSearchParams.set("endDate", VALID_END_DATE);
       mockSearchParams.set("lat", "37.7749");
       mockSearchParams.set("lng", "-122.4194");
 
@@ -831,8 +843,8 @@ describe("SearchForm", () => {
       jest.advanceTimersByTime(500);
 
       const pushCall = mockPush.mock.calls[0]?.[0] ?? "";
-      expect(pushCall).toContain("moveInDate=2026-05-01");
-      expect(pushCall).toContain("endDate=2026-06-01");
+      expect(pushCall).toContain(`moveInDate=${VALID_MOVE_IN_DATE}`);
+      expect(pushCall).toContain(`endDate=${VALID_END_DATE}`);
     });
 
     it("lets the filters drawer create a valid search range", async () => {
@@ -840,16 +852,16 @@ describe("SearchForm", () => {
 
       await user.click(screen.getByRole("button", { name: /filters/i }));
       fireEvent.change(screen.getByPlaceholderText("Select move-in date"), {
-        target: { value: "2026-05-01" },
+        target: { value: VALID_MOVE_IN_DATE },
       });
       fireEvent.change(screen.getByPlaceholderText("Select end date"), {
-        target: { value: "2026-06-01" },
+        target: { value: VALID_END_DATE },
       });
       fireEvent.click(screen.getByTestId("filter-modal-apply"));
 
       const pushCall = mockPush.mock.calls[0]?.[0] ?? "";
-      expect(pushCall).toContain("moveInDate=2026-05-01");
-      expect(pushCall).toContain("endDate=2026-06-01");
+      expect(pushCall).toContain(`moveInDate=${VALID_MOVE_IN_DATE}`);
+      expect(pushCall).toContain(`endDate=${VALID_END_DATE}`);
     });
 
     it("drops invalid endDate values from the applied search range", async () => {
@@ -857,15 +869,15 @@ describe("SearchForm", () => {
 
       await user.click(screen.getByRole("button", { name: /filters/i }));
       fireEvent.change(screen.getByPlaceholderText("Select move-in date"), {
-        target: { value: "2026-06-01" },
+        target: { value: LATER_MOVE_IN_DATE },
       });
       fireEvent.change(screen.getByPlaceholderText("Select end date"), {
-        target: { value: "2026-05-01" },
+        target: { value: EARLIER_END_DATE },
       });
       fireEvent.click(screen.getByTestId("filter-modal-apply"));
 
       const pushCall = mockPush.mock.calls[0]?.[0] ?? "";
-      expect(pushCall).toContain("moveInDate=2026-06-01");
+      expect(pushCall).toContain(`moveInDate=${LATER_MOVE_IN_DATE}`);
       expect(pushCall).not.toContain("endDate=");
     });
 

--- a/src/__tests__/components/search/InlineFilterStrip.test.tsx
+++ b/src/__tests__/components/search/InlineFilterStrip.test.tsx
@@ -15,6 +15,23 @@ const mockUseMediaQuery = jest.fn();
 const mockPending = { ...emptyFilterValues };
 const mockCommitted = { ...emptyFilterValues };
 
+function futureDateInput(daysFromNow: number): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + daysFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+function formatDateLabel(dateInput: string, includeYear = false): string {
+  return new Date(`${dateInput}T00:00:00`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    ...(includeYear ? { year: "numeric" as const } : {}),
+  });
+}
+
+const FILTER_MOVE_IN_DATE = futureDateInput(30);
+
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockRouterPush,
@@ -261,11 +278,11 @@ describe("InlineFilterStrip", () => {
     Object.assign(mockCommitted, {
       minPrice: "1200",
       maxPrice: "1800",
-      moveInDate: "2026-05-01",
+      moveInDate: FILTER_MOVE_IN_DATE,
       roomType: "Private Room",
     });
     mockSearchParams = new URLSearchParams(
-      "minPrice=1200&maxPrice=1800&moveInDate=2026-05-01&roomType=Private+Room"
+      `minPrice=1200&maxPrice=1800&moveInDate=${FILTER_MOVE_IN_DATE}&roomType=Private+Room`
     );
 
     render(<InlineFilterStrip />);
@@ -274,7 +291,7 @@ describe("InlineFilterStrip", () => {
       "$1,200-$1,800"
     );
     expect(screen.getByTestId("mobile-filter-move-in")).toHaveTextContent(
-      "May 1"
+      formatDateLabel(FILTER_MOVE_IN_DATE)
     );
     expect(screen.getByTestId("mobile-filter-room-type")).toHaveTextContent(
       "Private Room"
@@ -285,7 +302,7 @@ describe("InlineFilterStrip", () => {
     mockUseMediaQuery.mockReturnValue(false);
     mockMobileResultsView = "list";
     mockSearchParams = new URLSearchParams(
-      "minPrice=1200&maxPrice=1800&moveInDate=2026-05-01&roomType=Private+Room"
+      `minPrice=1200&maxPrice=1800&moveInDate=${FILTER_MOVE_IN_DATE}&roomType=Private+Room`
     );
 
     render(<InlineFilterStrip />);
@@ -294,7 +311,9 @@ describe("InlineFilterStrip", () => {
       name: "Applied filters",
     });
     expect(appliedRegion).toHaveTextContent("$1,200 - $1,800");
-    expect(appliedRegion).toHaveTextContent("Move-in: May 1, 2026");
+    expect(appliedRegion).toHaveTextContent(
+      `Move-in: ${formatDateLabel(FILTER_MOVE_IN_DATE, true)}`
+    );
     expect(appliedRegion).toHaveTextContent("+1 more");
   });
 });

--- a/src/__tests__/components/search/SearchResultsClient.test.tsx
+++ b/src/__tests__/components/search/SearchResultsClient.test.tsx
@@ -180,6 +180,18 @@ beforeAll(() => {
   })) as jest.Mock;
 });
 
+function futureMonthDate(monthsFromNow: number): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(1);
+  date.setMonth(date.getMonth() + monthsFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+const SEARCH_MOVE_IN_DATE = futureMonthDate(2);
+const SEARCH_END_DATE = futureMonthDate(3);
+const SEARCH_LONG_END_DATE = futureMonthDate(5);
+
 const createMockListing = (
   id: string,
   title?: string,
@@ -263,17 +275,17 @@ describe("SearchResultsClient", () => {
       render(
         <SearchResultsClient
           {...defaultProps}
-          searchParamsString="q=test&moveInDate=2026-05-01&endDate=2026-06-01"
+          searchParamsString={`q=test&moveInDate=${SEARCH_MOVE_IN_DATE}&endDate=${SEARCH_END_DATE}`}
         />
       );
 
       expect(screen.getByTestId("listing-1")).toHaveAttribute(
         "data-href",
-        "/listings/1?startDate=2026-05-01&endDate=2026-06-01"
+        `/listings/1?startDate=${SEARCH_MOVE_IN_DATE}&endDate=${SEARCH_END_DATE}`
       );
       expect(screen.getByTestId("listing-2")).toHaveAttribute(
         "data-href",
-        "/listings/2?startDate=2026-05-01&endDate=2026-06-01"
+        `/listings/2?startDate=${SEARCH_MOVE_IN_DATE}&endDate=${SEARCH_END_DATE}`
       );
     });
 
@@ -281,7 +293,7 @@ describe("SearchResultsClient", () => {
       render(
         <SearchResultsClient
           {...defaultProps}
-          searchParamsString="q=test&moveInDate=2026-05-01"
+          searchParamsString={`q=test&moveInDate=${SEARCH_MOVE_IN_DATE}`}
         />
       );
 
@@ -308,7 +320,7 @@ describe("SearchResultsClient", () => {
       render(
         <SearchResultsClient
           {...defaultProps}
-          searchParamsString="q=test&moveInDate=2026-05-01&endDate=2026-06-01"
+          searchParamsString={`q=test&moveInDate=${SEARCH_MOVE_IN_DATE}&endDate=${SEARCH_END_DATE}`}
         />
       );
 
@@ -316,8 +328,8 @@ describe("SearchResultsClient", () => {
       expect(mockSplitStayCard).toHaveBeenCalledWith(
         expect.objectContaining({
           listingDetailDateParams: {
-            moveInDate: "2026-05-01",
-            endDate: "2026-06-01",
+            moveInDate: SEARCH_MOVE_IN_DATE,
+            endDate: SEARCH_END_DATE,
             startDate: null,
           },
         })
@@ -375,7 +387,7 @@ describe("SearchResultsClient", () => {
           initialNextCursor={null}
           initialTotal={0}
           hasConfirmedZeroResults={true}
-          searchParamsString="q=test&bookingMode=WHOLE_UNIT&moveInDate=2026-05-01&endDate=2026-08-01"
+          searchParamsString={`q=test&bookingMode=WHOLE_UNIT&moveInDate=${SEARCH_MOVE_IN_DATE}&endDate=${SEARCH_LONG_END_DATE}`}
           filterParams={{}}
         />
       );
@@ -385,8 +397,8 @@ describe("SearchResultsClient", () => {
           expect.objectContaining({
             query: "test",
             bookingMode: "WHOLE_UNIT",
-            moveInDate: "2026-05-01",
-            endDate: "2026-08-01",
+            moveInDate: SEARCH_MOVE_IN_DATE,
+            endDate: SEARCH_LONG_END_DATE,
           })
         );
       });
@@ -396,7 +408,7 @@ describe("SearchResultsClient", () => {
       render(
         <SearchResultsClient
           {...defaultProps}
-          searchParamsString="q=test&moveInDate=2026-05-01&endDate=2026-08-01"
+          searchParamsString={`q=test&moveInDate=${SEARCH_MOVE_IN_DATE}&endDate=${SEARCH_LONG_END_DATE}`}
         />
       );
 

--- a/src/__tests__/hooks/useBatchedFilters.test.ts
+++ b/src/__tests__/hooks/useBatchedFilters.test.ts
@@ -50,6 +50,17 @@ const createMockSearchParams = (
   return urlSearchParams;
 };
 
+function futureDateInput(daysFromNow: number): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + daysFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+const VALID_MOVE_IN_DATE = futureDateInput(30);
+const VALID_END_DATE = futureDateInput(60);
+const LATER_MOVE_IN_DATE = futureDateInput(90);
+
 // --- Unit tests for readFiltersFromURL (pure function, no hooks needed) ---
 
 describe("readFiltersFromURL", () => {
@@ -692,29 +703,29 @@ describe("useBatchedFilters hook", () => {
       act(() => {
         result.current.commit({
           roomType: "Private Room",
-          moveInDate: "2026-05-01",
-          endDate: "2026-06-01",
+          moveInDate: VALID_MOVE_IN_DATE,
+          endDate: VALID_END_DATE,
         });
       });
 
       expect(result.current.pending.roomType).toBe("Private Room");
-      expect(result.current.pending.moveInDate).toBe("2026-05-01");
-      expect(result.current.pending.endDate).toBe("2026-06-01");
+      expect(result.current.pending.moveInDate).toBe(VALID_MOVE_IN_DATE);
+      expect(result.current.pending.endDate).toBe(VALID_END_DATE);
 
       const calledUrl = mockRouter.push.mock.calls[0][0] as string;
       const searchUrl = new URL(calledUrl, "http://localhost");
 
       expect(searchUrl.searchParams.get("sort")).toBeNull();
       expect(searchUrl.searchParams.get("roomType")).toBe("Private Room");
-      expect(searchUrl.searchParams.get("moveInDate")).toBe("2026-05-01");
-      expect(searchUrl.searchParams.get("endDate")).toBe("2026-06-01");
+      expect(searchUrl.searchParams.get("moveInDate")).toBe(VALID_MOVE_IN_DATE);
+      expect(searchUrl.searchParams.get("endDate")).toBe(VALID_END_DATE);
     });
 
     it("drops endDate when commit overrides produce an invalid range", () => {
       (useSearchParams as jest.Mock).mockReturnValue(
         createMockSearchParams({
-          moveInDate: "2026-05-01",
-          endDate: "2026-06-01",
+          moveInDate: VALID_MOVE_IN_DATE,
+          endDate: VALID_END_DATE,
         })
       );
 
@@ -722,17 +733,19 @@ describe("useBatchedFilters hook", () => {
 
       act(() => {
         result.current.commit({
-          moveInDate: "2026-07-01",
+          moveInDate: LATER_MOVE_IN_DATE,
         });
       });
 
-      expect(result.current.pending.moveInDate).toBe("2026-07-01");
+      expect(result.current.pending.moveInDate).toBe(LATER_MOVE_IN_DATE);
       expect(result.current.pending.endDate).toBe("");
 
       const calledUrl = mockRouter.push.mock.calls[0][0] as string;
       const searchUrl = new URL(calledUrl, "http://localhost");
 
-      expect(searchUrl.searchParams.get("moveInDate")).toBe("2026-07-01");
+      expect(searchUrl.searchParams.get("moveInDate")).toBe(
+        LATER_MOVE_IN_DATE
+      );
       expect(searchUrl.searchParams.get("endDate")).toBeNull();
     });
   });

--- a/src/__tests__/lib/maps/sanitize-map-listings.test.ts
+++ b/src/__tests__/lib/maps/sanitize-map-listings.test.ts
@@ -2,6 +2,7 @@ import {
   sanitizeMapListing,
   sanitizeMapListings,
 } from "@/lib/maps/sanitize-map-listings";
+import { PUBLIC_GROUP_KEY_PREFIX } from "@/lib/search/public-listing-payload";
 
 describe("sanitize-map-listings", () => {
   it("filters out invalid coordinates including 0,0 and non-finite values", () => {
@@ -60,5 +61,38 @@ describe("sanitize-map-listings", () => {
         groupSummary: null,
       })
     );
+  });
+
+  it("replaces raw group identifiers and drops private status reasons", () => {
+    const listing = sanitizeMapListing({
+      id: "listing-private-map",
+      price: 1200,
+      availableSlots: 1,
+      location: { lat: 30.2672, lng: -97.7431 },
+      groupKey: "private-unit-key:12",
+      groupSummary: {
+        groupKey: "private-unit-key:12",
+        siblingIds: ["sibling-1"],
+        availableFromDates: ["2026-06-01"],
+        combinedOpenSlots: 1,
+        combinedTotalSlots: 2,
+        groupOverflow: false,
+      },
+      groupContext: {
+        siblingCount: 1,
+        dateCount: 1,
+        completeness: "complete",
+        contextKey: "private-unit-key:12",
+      },
+      statusReason: "PRIVATE_REASON",
+    });
+
+    expect(listing?.groupKey).toMatch(
+      new RegExp(`^${PUBLIC_GROUP_KEY_PREFIX}`)
+    );
+    expect(listing?.groupSummary?.groupKey).toBe(listing?.groupKey);
+    expect(listing?.groupContext?.contextKey).toBe(listing?.groupKey);
+    expect(JSON.stringify(listing)).not.toContain("private-unit-key");
+    expect(listing?.statusReason).toBeNull();
   });
 });

--- a/src/__tests__/lib/search-alerts.test.ts
+++ b/src/__tests__/lib/search-alerts.test.ts
@@ -94,6 +94,21 @@ describe("search-alerts", () => {
     user: mockUser,
   };
 
+  function futureDateInput(daysFromNow: number): string {
+    const date = new Date();
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCDate(date.getUTCDate() + daysFromNow);
+    return date.toISOString().slice(0, 10);
+  }
+
+  function futureDate(daysFromNow: number): Date {
+    return new Date(`${futureDateInput(daysFromNow)}T00:00:00.000Z`);
+  }
+
+  const SAVED_MOVE_IN_DATE = futureDateInput(30);
+  const SAVED_END_DATE = futureDateInput(60);
+  const LISTING_ENDS_BEFORE_SAVED_END_DATE = futureDateInput(45);
+
   function buildPublicListing(id = "listing-123") {
     return {
       id,
@@ -106,10 +121,10 @@ describe("search-alerts", () => {
       availableSlots: 1,
       totalSlots: 1,
       openSlots: 1,
-      moveInDate: new Date("2026-05-01T00:00:00.000Z"),
+      moveInDate: futureDate(30),
       availableUntil: null,
       minStayMonths: 1,
-      lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+      lastConfirmedAt: futureDate(-10),
     };
   }
 
@@ -314,8 +329,8 @@ describe("search-alerts", () => {
         const dateRangeSearch = {
           ...mockSavedSearch,
           filters: {
-            moveInDate: "2026-05-01",
-            endDate: "2026-06-01",
+            moveInDate: SAVED_MOVE_IN_DATE,
+            endDate: SAVED_END_DATE,
           },
         };
         (prisma.savedSearch.findMany as jest.Mock).mockResolvedValue([
@@ -594,8 +609,8 @@ describe("search-alerts", () => {
             name: "NYC Rooms",
             filters: {
               query: "New York",
-              moveInDate: "2026-05-01",
-              endDate: "2026-06-01",
+              moveInDate: SAVED_MOVE_IN_DATE,
+              endDate: SAVED_END_DATE,
             },
             active: true,
             alertEnabled: true,
@@ -631,7 +646,7 @@ describe("search-alerts", () => {
         "searchAlert",
         mockUser.email,
         expect.objectContaining({
-          ctaHref: expect.stringContaining("endDate=2026-06-01"),
+          ctaHref: expect.stringContaining(`endDate=${SAVED_END_DATE}`),
         })
       );
       expect(prisma.notification.create).toHaveBeenCalledWith({
@@ -854,8 +869,8 @@ describe("search-alerts", () => {
         const dateRangeSearch = {
           ...instantSearch,
           filters: {
-            moveInDate: "2026-05-01",
-            endDate: "2026-06-01",
+            moveInDate: SAVED_MOVE_IN_DATE,
+            endDate: SAVED_END_DATE,
           },
         };
         (prisma.savedSearch.findMany as jest.Mock).mockResolvedValue([
@@ -864,7 +879,7 @@ describe("search-alerts", () => {
 
         const result = await triggerInstantAlerts({
           ...newListing,
-          availableUntil: "2026-05-15",
+          availableUntil: LISTING_ENDS_BEFORE_SAVED_END_DATE,
         });
 
         expect(result.sent).toBe(0);
@@ -875,8 +890,8 @@ describe("search-alerts", () => {
         const dateRangeSearch = {
           ...instantSearch,
           filters: {
-            moveInDate: "2026-05-01",
-            endDate: "2026-06-01",
+            moveInDate: SAVED_MOVE_IN_DATE,
+            endDate: SAVED_END_DATE,
           },
         };
         (prisma.savedSearch.findMany as jest.Mock).mockResolvedValue([
@@ -887,8 +902,8 @@ describe("search-alerts", () => {
 
         const result = await triggerInstantAlerts({
           ...newListing,
-          moveInDate: new Date("2026-05-01T00:00:00.000Z"),
-          availableUntil: new Date("2026-06-01T00:00:00.000Z"),
+          moveInDate: futureDate(30),
+          availableUntil: futureDate(60),
         });
 
         expect(result.sent).toBe(1);

--- a/src/__tests__/lib/search/hash.test.ts
+++ b/src/__tests__/lib/search/hash.test.ts
@@ -22,6 +22,7 @@ describe("search/hash", () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    jest.useRealTimers();
   });
 
   describe("generateQueryHash", () => {
@@ -206,6 +207,9 @@ describe("search/hash", () => {
     });
 
     it("matches the versioned golden hash for a representative normalized query", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2026-04-01T12:00:00.000Z"));
+
       const params: HashableFilterParams = {
         query: "Austin",
         vibeQuery: "quiet roommates",

--- a/src/__tests__/lib/search/projection-search.test.ts
+++ b/src/__tests__/lib/search/projection-search.test.ts
@@ -196,7 +196,10 @@ describe("Phase 04 projection search", () => {
     });
 
     expect(result.response?.list.fullItems).toHaveLength(1);
-    expect(result.response?.list.fullItems?.[0]?.groupKey).toBe("unit-a:1");
+    expect(result.response?.list.fullItems?.[0]?.groupKey).toEqual(
+      expect.stringMatching(/^pg1_/)
+    );
+    expect(result.response?.list.fullItems?.[0]?.groupKey).not.toBe("unit-a:1");
     expect(
       result.response?.list.fullItems?.[0]?.groupSummary?.members
     ).toHaveLength(2);

--- a/src/__tests__/lib/search/public-listing-payload.test.ts
+++ b/src/__tests__/lib/search/public-listing-payload.test.ts
@@ -1,0 +1,143 @@
+import {
+  PUBLIC_GROUP_KEY_PREFIX,
+  toPublicGroupKey,
+  toPublicMapListing,
+  toPublicSearchListing,
+} from "@/lib/search/public-listing-payload";
+import type { ListingData, MapListingData } from "@/lib/search-types";
+import { buildPublicAvailability } from "@/lib/search/public-availability";
+
+function makeListing(overrides: Partial<ListingData> = {}): ListingData {
+  const listing: ListingData = {
+    id: "listing-private-1",
+    title: "Private source listing",
+    description: "Call 555-123-4567 for the exact address.",
+    price: 1500,
+    images: ["https://images.example/listing.jpg"],
+    availableSlots: 1,
+    totalSlots: 2,
+    amenities: ["Wifi"],
+    houseRules: ["No Smoking"],
+    householdLanguages: ["English"],
+    primaryHomeLanguage: "English",
+    ownerId: "owner-secret-1",
+    location: {
+      address: "123 Private St Apt 9",
+      city: "Austin",
+      state: "TX",
+      zip: "78701",
+      lat: 30.26721,
+      lng: -97.74312,
+    },
+    publicAvailability: buildPublicAvailability({
+      availableSlots: 1,
+      totalSlots: 2,
+    }),
+    groupKey: "unit-secret-1:42",
+    groupSummary: {
+      groupKey: "unit-secret-1:42",
+      siblingIds: ["listing-private-2"],
+      availableFromDates: ["2026-06-01"],
+      combinedOpenSlots: 1,
+      combinedTotalSlots: 2,
+      groupOverflow: false,
+      members: [
+        {
+          listingId: "listing-private-1",
+          availableFrom: "2026-06-01",
+          availableUntil: null,
+          openSlots: 1,
+          totalSlots: 2,
+          isCanonical: true,
+        },
+      ],
+    },
+    groupContext: {
+      siblingCount: 1,
+      dateCount: 1,
+      completeness: "complete",
+      contextKey: "unit-secret-1:42",
+    },
+    statusReason: "PRIVATE_MODERATION_REASON",
+    ...overrides,
+  };
+
+  return listing;
+}
+
+describe("public listing payload sanitizer", () => {
+  it("removes private listing fields from browser-visible search cards", () => {
+    const publicListing = toPublicSearchListing(makeListing());
+    const serialized = JSON.parse(JSON.stringify(publicListing));
+
+    expect(serialized.ownerId).toBeUndefined();
+    expect(serialized.location.address).toBeUndefined();
+    expect(serialized.location.zip).toBeUndefined();
+    expect(serialized.statusReason).toBeUndefined();
+    expect(serialized.description).toBe("");
+    expect(serialized.location).toEqual({
+      city: "Austin",
+      state: "TX",
+      lat: 30.27,
+      lng: -97.74,
+    });
+  });
+
+  it("replaces raw group metadata with opaque public ids", () => {
+    const publicListing = toPublicSearchListing(makeListing());
+
+    expect(publicListing.groupKey).toMatch(
+      new RegExp(`^${PUBLIC_GROUP_KEY_PREFIX}`)
+    );
+    expect(publicListing.groupSummary?.groupKey).toBe(publicListing.groupKey);
+    expect(publicListing.groupContext?.contextKey).toBe(publicListing.groupKey);
+    expect(publicListing.groupKey).not.toContain("unit-secret-1");
+    expect(publicListing.groupSummary?.groupKey).not.toContain("unit-secret-1");
+    expect(publicListing.groupContext?.contextKey).not.toContain(
+      "unit-secret-1"
+    );
+  });
+
+  it("keeps public group key conversion deterministic and idempotent", () => {
+    const publicKey = toPublicGroupKey("unit-secret-1:42");
+
+    expect(publicKey).toBe(toPublicGroupKey("unit-secret-1:42"));
+    expect(toPublicGroupKey(publicKey)).toBe(publicKey);
+  });
+
+  it("sanitizes map listing group metadata without exposing status reasons", () => {
+    const mapListing: MapListingData = {
+      id: "map-private-1",
+      title: "Map private",
+      price: 1400,
+      availableSlots: 1,
+      totalSlots: 2,
+      images: ["map.jpg"],
+      location: { lat: 30.26721, lng: -97.74312 },
+      publicAvailability: buildPublicAvailability({
+        availableSlots: 1,
+        totalSlots: 2,
+      }),
+      groupKey: "unit-secret-map:7",
+      groupContext: {
+        siblingCount: 1,
+        dateCount: 1,
+        completeness: "complete",
+        contextKey: "unit-secret-map:7",
+      },
+      statusReason: "PRIVATE_MAP_REASON",
+    };
+
+    const publicMapListing = toPublicMapListing(mapListing);
+
+    expect(publicMapListing.location).toEqual({ lat: 30.27, lng: -97.74 });
+    expect(publicMapListing.groupKey).toMatch(
+      new RegExp(`^${PUBLIC_GROUP_KEY_PREFIX}`)
+    );
+    expect(publicMapListing.groupContext?.contextKey).toMatch(
+      new RegExp(`^${PUBLIC_GROUP_KEY_PREFIX}`)
+    );
+    expect(publicMapListing.groupKey).not.toContain("unit-secret-map");
+    expect(publicMapListing.statusReason).toBeNull();
+  });
+});

--- a/src/__tests__/lib/search/search-doc-queries.test.ts
+++ b/src/__tests__/lib/search/search-doc-queries.test.ts
@@ -16,6 +16,25 @@ import {
 import { buildPublicAvailability } from "@/lib/search/public-availability";
 import { joinWhereClauseWithSecurityInvariant } from "@/lib/sql-safety";
 
+function dateInputFromNow(daysFromNow: number): string {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + daysFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+function timestampFromNow(daysFromNow: number): string {
+  const date = new Date();
+  date.setUTCHours(12, 30, 0, 0);
+  date.setUTCDate(date.getUTCDate() + daysFromNow);
+  return date.toISOString();
+}
+
+const HOST_MOVE_IN_DATE = dateInputFromNow(30);
+const HOST_AVAILABLE_UNTIL = dateInputFromNow(210);
+const RECENT_LAST_CONFIRMED_AT = timestampFromNow(-7);
+const STALE_LAST_CONFIRMED_AT = timestampFromNow(-30);
+
 describe("buildSearchDocWhereConditions", () => {
   it("excludes listings with null coordinates from map results (F1.1)", () => {
     const { conditions } = buildSearchDocWhereConditions({});
@@ -379,9 +398,9 @@ describe("SearchDoc projection mapping", () => {
       totalSlots: 4,
       availabilitySource: "HOST_MANAGED" as const,
       openSlots: 2,
-      availableUntil: "2026-12-01",
+      availableUntil: HOST_AVAILABLE_UNTIL,
       minStayMonths: 3,
-      lastConfirmedAt: "2026-04-15T12:30:00.000Z",
+      lastConfirmedAt: RECENT_LAST_CONFIRMED_AT,
       status: "ACTIVE",
       statusReason: null,
       needsMigrationReview: false,
@@ -391,7 +410,7 @@ describe("SearchDoc projection mapping", () => {
       primaryHomeLanguage: "English",
       leaseDuration: "6_months",
       roomType: "private",
-      moveInDate: "2026-06-01",
+      moveInDate: HOST_MOVE_IN_DATE,
       viewCount: 10,
       city: "San Francisco",
       state: "CA",
@@ -419,7 +438,7 @@ describe("SearchDoc projection mapping", () => {
   it("suppresses stale HOST_MANAGED rows from list projection", () => {
     const results = mapRawListingsToPublic([
       createHostManagedRaw({
-        lastConfirmedAt: "2026-03-20T12:30:00.000Z",
+        lastConfirmedAt: STALE_LAST_CONFIRMED_AT,
       }),
     ]);
 
@@ -475,7 +494,7 @@ describe("SearchDoc projection mapping", () => {
   it("suppresses stale HOST_MANAGED rows from map projection", () => {
     const results = mapRawMapListingsToPublic([
       createHostManagedRaw({
-        lastConfirmedAt: "2026-03-20T12:30:00.000Z",
+        lastConfirmedAt: STALE_LAST_CONFIRMED_AT,
       }),
     ]);
 
@@ -513,10 +532,10 @@ describe("SearchDoc projection mapping", () => {
         availabilitySource: "HOST_MANAGED",
         openSlots: 2,
         totalSlots: 4,
-        availableFrom: "2026-06-01",
-        availableUntil: "2026-12-01",
+        availableFrom: HOST_MOVE_IN_DATE,
+        availableUntil: HOST_AVAILABLE_UNTIL,
         minStayMonths: 3,
-        lastConfirmedAt: "2026-04-15T12:30:00.000Z",
+        lastConfirmedAt: RECENT_LAST_CONFIRMED_AT,
       })
     );
     expect(mapResult.publicAvailability).toMatchObject(
@@ -538,7 +557,7 @@ describe("SearchDoc projection mapping", () => {
       }),
       createHostManagedRaw({
         id: "stale-host-managed",
-        lastConfirmedAt: "2026-03-20T12:30:00.000Z",
+        lastConfirmedAt: STALE_LAST_CONFIRMED_AT,
       }),
       createHostManagedRaw({
         id: "needs-migration-review",

--- a/src/__tests__/lib/search/search-query.test.ts
+++ b/src/__tests__/lib/search/search-query.test.ts
@@ -6,7 +6,20 @@ import {
   serializeSearchQuery,
 } from "@/lib/search/search-query";
 
+const SEARCH_QUERY_TEST_NOW = new Date("2026-04-01T12:00:00.000Z");
+const FUTURE_MOVE_IN_DATE = "2026-05-01";
+const FUTURE_END_DATE = "2026-06-01";
+
+function freezeSearchQueryClock(): void {
+  jest.useFakeTimers();
+  jest.setSystemTime(SEARCH_QUERY_TEST_NOW);
+}
+
 describe("search-query", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("normalizes array params, drops invalid price ranges, and canonicalizes pagination", () => {
     const query = normalizeSearchQuery(
       new URLSearchParams(
@@ -146,32 +159,40 @@ describe("search-query", () => {
   });
 
   it("preserves explicit endDate values through normalization and serialization", () => {
+    freezeSearchQueryClock();
+
     const query = normalizeSearchQuery(
-      new URLSearchParams("moveInDate=2026-05-01&endDate=2026-06-01")
+      new URLSearchParams(
+        `moveInDate=${FUTURE_MOVE_IN_DATE}&endDate=${FUTURE_END_DATE}`
+      )
     );
 
-    expect(query.moveInDate).toBe("2026-05-01");
-    expect(query.endDate).toBe("2026-06-01");
+    expect(query.moveInDate).toBe(FUTURE_MOVE_IN_DATE);
+    expect(query.endDate).toBe(FUTURE_END_DATE);
 
     const params = serializeSearchQuery(query);
-    expect(params.get("moveInDate")).toBe("2026-05-01");
-    expect(params.get("endDate")).toBe("2026-06-01");
+    expect(params.get("moveInDate")).toBe(FUTURE_MOVE_IN_DATE);
+    expect(params.get("endDate")).toBe(FUTURE_END_DATE);
 
     expect(buildCanonicalSearchUrl(query, { includePagination: false })).toBe(
-      "/search?endDate=2026-06-01&moveInDate=2026-05-01"
+      `/search?endDate=${FUTURE_END_DATE}&moveInDate=${FUTURE_MOVE_IN_DATE}`
     );
   });
 
   it("normalizes inbound startDate aliases back to canonical search params", () => {
+    freezeSearchQueryClock();
+
     const query = normalizeSearchQuery(
-      new URLSearchParams("startDate=2026-05-01&endDate=2026-06-01")
+      new URLSearchParams(
+        `startDate=${FUTURE_MOVE_IN_DATE}&endDate=${FUTURE_END_DATE}`
+      )
     );
 
-    expect(query.moveInDate).toBe("2026-05-01");
-    expect(query.endDate).toBe("2026-06-01");
+    expect(query.moveInDate).toBe(FUTURE_MOVE_IN_DATE);
+    expect(query.endDate).toBe(FUTURE_END_DATE);
 
     expect(buildCanonicalSearchUrl(query, { includePagination: false })).toBe(
-      "/search?endDate=2026-06-01&moveInDate=2026-05-01"
+      `/search?endDate=${FUTURE_END_DATE}&moveInDate=${FUTURE_MOVE_IN_DATE}`
     );
   });
 

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -175,10 +175,7 @@ jest.mock("@/lib/timeout-wrapper", () => ({
 // ============================================================================
 
 import { executeSearchV2 } from "@/lib/search/search-v2-service";
-import {
-  getListingsPaginated,
-  getMapListingsResult,
-} from "@/lib/data";
+import { getListingsPaginated, getMapListingsResult } from "@/lib/data";
 import {
   isSearchDocEnabled,
   getSearchDocListingsByIds,
@@ -316,9 +313,8 @@ const mockClampBoundsToMaxSpan = clampBoundsToMaxSpan as jest.MockedFunction<
   typeof clampBoundsToMaxSpan
 >;
 const mockWithTimeout = withTimeout as jest.MockedFunction<typeof withTimeout>;
-const mockPrismaListingFindMany = prisma.listing.findMany as jest.MockedFunction<
-  typeof prisma.listing.findMany
->;
+const mockPrismaListingFindMany = prisma.listing
+  .findMany as jest.MockedFunction<typeof prisma.listing.findMany>;
 const mockGetAvailabilityForListings =
   getAvailabilityForListings as jest.MockedFunction<
     typeof getAvailabilityForListings
@@ -344,7 +340,9 @@ const mockIsPhase04ForceClustersOnlyActive =
     typeof isPhase04ForceClustersOnlyActive
   >;
 const mockExecuteProjectionSearchV2 =
-  executeProjectionSearchV2 as jest.MockedFunction<typeof executeProjectionSearchV2>;
+  executeProjectionSearchV2 as jest.MockedFunction<
+    typeof executeProjectionSearchV2
+  >;
 
 // ============================================================================
 // Shared test fixtures
@@ -588,7 +586,9 @@ describe("search-v2-service", () => {
             nextCursor: null,
             total: 0,
           },
-          map: { geojson: { type: "FeatureCollection" as const, features: [] } },
+          map: {
+            geojson: { type: "FeatureCollection" as const, features: [] },
+          },
         },
         paginatedResult: {
           items: [],
@@ -699,9 +699,7 @@ describe("search-v2-service", () => {
     });
 
     it("strips fallback pins while preserving map metadata when cluster-only kill switch is active", async () => {
-      const mapListings = [
-        makeMapListingData({ id: "map-cluster-only" }),
-      ];
+      const mapListings = [makeMapListingData({ id: "map-cluster-only" })];
       setupDefaultMocks({
         listItems: [makeListingData({ id: "listing-cluster-only" })],
         mapListings,
@@ -954,6 +952,66 @@ describe("search-v2-service", () => {
       );
     });
 
+    it("returns public card payloads in fullItems without exact location or private fields", async () => {
+      const rawListing = makeListingData({
+        id: "private-listing-1",
+        ownerId: "owner-secret-1",
+        description: "Call 555-123-4567 for the apartment number.",
+        location: {
+          address: "123 Private St Apt 4",
+          city: "Austin",
+          state: "TX",
+          zip: "78701",
+          lat: 30.26721,
+          lng: -97.74312,
+        },
+        groupKey: "private-unit-key:12",
+        groupSummary: {
+          groupKey: "private-unit-key:12",
+          siblingIds: ["sibling-1"],
+          availableFromDates: ["2026-06-01"],
+          combinedOpenSlots: 1,
+          combinedTotalSlots: 2,
+          groupOverflow: false,
+        },
+        groupContext: {
+          siblingCount: 1,
+          dateCount: 1,
+          completeness: "complete",
+          contextKey: "private-unit-key:12",
+        },
+        statusReason: "PRIVATE_REASON",
+      });
+      setupDefaultMocks({ listItems: [rawListing] });
+
+      const result = await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+        },
+      });
+
+      const fullItem = result.response!.list.fullItems?.[0];
+      const serialized = JSON.stringify(fullItem);
+
+      expect(fullItem).toBeDefined();
+      expect(fullItem?.description).toBe("");
+      expect(fullItem?.location).toEqual({
+        city: "Austin",
+        state: "TX",
+        lat: 30.27,
+        lng: -97.74,
+      });
+      expect(serialized).not.toContain("owner-secret-1");
+      expect(serialized).not.toContain("123 Private St");
+      expect(serialized).not.toContain("78701");
+      expect(serialized).not.toContain("private-unit-key");
+      expect(serialized).not.toContain("PRIVATE_REASON");
+      expect(result.paginatedResult!.items[0].ownerId).toBe("owner-secret-1");
+    });
+
     it("preserves host-managed publicAvailability across list and map response surfaces", async () => {
       const hostManagedAvailability = buildPublicAvailability({
         availabilitySource: "HOST_MANAGED",
@@ -1184,13 +1242,16 @@ describe("search-v2-service", () => {
         })
       );
       const semanticListing = makeListingData({ id: "semantic-1" });
-      mockSemanticSearchQuery.mockResolvedValue([{ id: "semantic-row-1" }] as never);
+      mockSemanticSearchQuery.mockResolvedValue([
+        { id: "semantic-row-1" },
+      ] as never);
       mockMapSemanticRowsToListingData.mockReturnValue([semanticListing]);
 
       const result = await executeSearchV2({
         rawParams: {
           q: "Irving",
           what: "quiet roommates",
+          vibeQuery: "quiet roommates",
           minLat: "32.8",
           maxLat: "32.9",
           minLng: "-96.99",
@@ -1231,20 +1292,37 @@ describe("search-v2-service", () => {
 
       const now = new Date();
       const moveInDate = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
-      const availableUntil = new Date(now.getTime() + 120 * 24 * 60 * 60 * 1000);
+      const availableUntil = new Date(
+        now.getTime() + 120 * 24 * 60 * 60 * 1000
+      );
       const staleConfirmedAt = new Date(
         now.getTime() - 22 * 24 * 60 * 60 * 1000
       );
       const semanticItems = [
-        makeListingData({ id: "eligible-host", availableSlots: 4, totalSlots: 4 }),
-        makeListingData({ id: "invalid-host", availableSlots: 4, totalSlots: 4 }),
+        makeListingData({
+          id: "eligible-host",
+          availableSlots: 4,
+          totalSlots: 4,
+        }),
+        makeListingData({
+          id: "invalid-host",
+          availableSlots: 4,
+          totalSlots: 4,
+        }),
         makeListingData({ id: "stale-host", availableSlots: 4, totalSlots: 4 }),
-        makeListingData({ id: "legacy-review", availableSlots: 2, totalSlots: 2 }),
+        makeListingData({
+          id: "legacy-review",
+          availableSlots: 2,
+          totalSlots: 2,
+        }),
       ];
 
-      mockSemanticSearchQuery.mockResolvedValue(
-        [{ id: "row-1" }, { id: "row-2" }, { id: "row-3" }, { id: "row-4" }] as never
-      );
+      mockSemanticSearchQuery.mockResolvedValue([
+        { id: "row-1" },
+        { id: "row-2" },
+        { id: "row-3" },
+        { id: "row-4" },
+      ] as never);
       mockMapSemanticRowsToListingData.mockReturnValue(semanticItems);
       mockPrismaListingFindMany.mockResolvedValue([
         {
@@ -1325,6 +1403,7 @@ describe("search-v2-service", () => {
         rawParams: {
           q: "Irving",
           what: "quiet roommates",
+          vibeQuery: "quiet roommates",
           minLat: "32.8",
           maxLat: "32.9",
           minLng: "-96.99",
@@ -1350,8 +1429,8 @@ describe("search-v2-service", () => {
     });
 
     it("fills semantic page 1 from later eligible matches and computes next page from eligible rows", async () => {
-      setupDefaultMocks();
       (features as Record<string, unknown>).semanticSearch = true;
+      setupDefaultMocks();
       mockParseSearchParams.mockReturnValue(
         defaultParsedSearchParams({
           filterParams: {
@@ -1362,10 +1441,11 @@ describe("search-v2-service", () => {
         })
       );
 
-      const now = new Date("2026-04-15T12:30:00.000Z");
-      const staleConfirmedAt = new Date("2026-03-20T12:30:00.000Z");
-      const moveInDate = new Date("2026-06-01T00:00:00.000Z");
-      const availableUntil = new Date("2026-12-01T00:00:00.000Z");
+      const dayMs = 24 * 60 * 60 * 1000;
+      const now = new Date();
+      const staleConfirmedAt = new Date(now.getTime() - 45 * dayMs);
+      const moveInDate = new Date(now.getTime() + 30 * dayMs);
+      const availableUntil = new Date(now.getTime() + 210 * dayMs);
       const semanticRows = [
         { id: "filtered-invalid" },
         { id: "filtered-stale" },
@@ -1499,15 +1579,14 @@ describe("search-v2-service", () => {
         "eligible-2",
       ]);
       expect(result.response?.list.nextCursor).toBe("cursor-page-2");
-      expect(mockSemanticSearchQuery.mock.calls.map((call) => call[2])).toEqual([
-        0,
-        3,
-      ]);
+      expect(mockSemanticSearchQuery.mock.calls.map((call) => call[2])).toEqual(
+        [0, 3]
+      );
     });
 
     it("keeps later semantic pages stable after filtering ineligible ranked matches", async () => {
-      setupDefaultMocks();
       (features as Record<string, unknown>).semanticSearch = true;
+      setupDefaultMocks();
       mockParseSearchParams.mockReturnValue(
         defaultParsedSearchParams({
           requestedPage: 2,
@@ -1519,10 +1598,11 @@ describe("search-v2-service", () => {
         })
       );
 
-      const now = new Date("2026-04-15T12:30:00.000Z");
-      const staleConfirmedAt = new Date("2026-03-20T12:30:00.000Z");
-      const moveInDate = new Date("2026-06-01T00:00:00.000Z");
-      const availableUntil = new Date("2026-12-01T00:00:00.000Z");
+      const dayMs = 24 * 60 * 60 * 1000;
+      const now = new Date();
+      const staleConfirmedAt = new Date(now.getTime() - 45 * dayMs);
+      const moveInDate = new Date(now.getTime() + 30 * dayMs);
+      const availableUntil = new Date(now.getTime() + 210 * dayMs);
       const semanticRows = [
         { id: "filtered-invalid" },
         { id: "filtered-stale" },
@@ -1654,11 +1734,9 @@ describe("search-v2-service", () => {
       expect(result.paginatedResult?.total).toBe(4);
       expect(result.paginatedResult?.totalPages).toBe(2);
       expect(mockEncodeCursor).not.toHaveBeenCalled();
-      expect(mockSemanticSearchQuery.mock.calls.map((call) => call[2])).toEqual([
-        0,
-        3,
-        6,
-      ]);
+      expect(mockSemanticSearchQuery.mock.calls.map((call) => call[2])).toEqual(
+        [0, 3, 6]
+      );
     });
 
     it("falls back to broadened area results when semantic ranking returns no rows", async () => {

--- a/src/__tests__/lib/search/v2-map-data.test.ts
+++ b/src/__tests__/lib/search/v2-map-data.test.ts
@@ -51,4 +51,70 @@ describe("searchV2MapToListings", () => {
     expect(listings[0].groupContext?.contextKey).toBe("pg1_public-key");
     expect(listings[0].location).toEqual({ lat: 30.27, lng: -97.74 });
   });
+
+  it("handles partial map features without exposing raw metadata", () => {
+    const listings = searchV2MapToListings({
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: {
+              type: "Point",
+              coordinates: [-97.7431, 30.2672],
+            },
+            properties: {
+              id: "partial-listing",
+              title: "Partial listing",
+              price: null,
+              availableSlots: "bad-value",
+              image: "cover.jpg",
+              groupContext: {
+                siblingCount: 1,
+                dateCount: 1,
+                completeness: "complete",
+                contextKey: "raw-unit-key:1",
+              },
+            },
+          },
+          {
+            type: "Feature",
+            geometry: {
+              type: "Point",
+              coordinates: [0, 0],
+            },
+            properties: {
+              id: "invalid-listing",
+              title: "Invalid listing",
+              price: 1500,
+              availableSlots: 1,
+              image: "bad.jpg",
+            },
+          },
+        ],
+      },
+      pins: [{ id: "partial-listing", tier: "primary" }],
+    } as any);
+
+    expect(listings).toHaveLength(1);
+    expect(listings[0]).toMatchObject({
+      id: "partial-listing",
+      title: "Partial listing",
+      price: 0,
+      availableSlots: 0,
+      totalSlots: 0,
+      images: ["cover.jpg"],
+      location: { lat: 30.27, lng: -97.74 },
+      groupKey: null,
+      groupSummary: null,
+      groupContext: null,
+      tier: "primary",
+      publicAvailability: {
+        availabilitySource: "HOST_MANAGED",
+        openSlots: 0,
+        totalSlots: 0,
+      },
+    });
+    expect(JSON.stringify(listings[0])).not.toContain("raw-unit-key");
+  });
 });

--- a/src/__tests__/lib/search/v2-map-data.test.ts
+++ b/src/__tests__/lib/search/v2-map-data.test.ts
@@ -1,0 +1,54 @@
+import { searchV2MapToListings } from "@/lib/search/v2-map-data";
+import { buildPublicAvailability } from "@/lib/search/public-availability";
+import type { SearchV2Map } from "@/lib/search/types";
+
+function makeMap(contextKey: string): SearchV2Map {
+  return {
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [-97.74312, 30.26721],
+          },
+          properties: {
+            id: "map-1",
+            title: "Map listing",
+            price: 1200,
+            image: "map.jpg",
+            availableSlots: 1,
+            publicAvailability: buildPublicAvailability({
+              availableSlots: 1,
+              totalSlots: 2,
+            }),
+            groupContext: {
+              siblingCount: 1,
+              dateCount: 1,
+              completeness: "complete",
+              contextKey,
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+describe("searchV2MapToListings", () => {
+  it("drops legacy raw group contexts from browser-side map conversion", () => {
+    const listings = searchV2MapToListings(makeMap("raw-unit-key:1"));
+
+    expect(listings).toHaveLength(1);
+    expect(listings[0].groupContext).toBeNull();
+    expect(JSON.stringify(listings[0])).not.toContain("raw-unit-key");
+  });
+
+  it("keeps already-public group contexts and coarsens coordinates", () => {
+    const listings = searchV2MapToListings(makeMap("pg1_public-key"));
+
+    expect(listings[0].groupContext?.contextKey).toBe("pg1_public-key");
+    expect(listings[0].location).toEqual({ lat: 30.27, lng: -97.74 });
+  });
+});

--- a/src/__tests__/scripts/scan-public-payload-pii.test.ts
+++ b/src/__tests__/scripts/scan-public-payload-pii.test.ts
@@ -1,0 +1,78 @@
+const {
+  scanPublicPayloadForPii,
+} = require("../../../scripts/scan-public-payload-pii.js");
+
+describe("scan-public-payload-pii", () => {
+  it("allows coarsened public coordinates, image URLs, snapshot versions, and public group ids", () => {
+    const violations = scanPublicPayloadForPii({
+      meta: { snapshotVersion: "phase04-unit-v1" },
+      list: {
+        fullItems: [
+          {
+            id: "listing-1",
+            images: [
+              "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?w=600",
+            ],
+            location: { city: "Austin", state: "TX", lat: 30.27, lng: -97.74 },
+            groupKey: "pg1_public-key",
+            groupSummary: { groupKey: "pg1_public-key" },
+            groupContext: { contextKey: "pg1_public-key" },
+          },
+        ],
+      },
+      map: {
+        geojson: {
+          features: [
+            {
+              properties: {
+                image:
+                  "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?w=600",
+                groupContext: { contextKey: "pg1_public-key" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("rejects exact coordinates and raw group identities", () => {
+    const violations = scanPublicPayloadForPii({
+      list: {
+        fullItems: [
+          {
+            location: {
+              lat: 30.26721,
+              lng: -97.74312,
+            },
+            groupKey: "private-unit-key:12",
+            groupContext: { contextKey: "private-unit-key:12" },
+          },
+        ],
+      },
+    });
+
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "list.fullItems.0.location.lat",
+          reason: "exact_coordinate_value",
+        }),
+        expect.objectContaining({
+          path: "list.fullItems.0.location.lng",
+          reason: "exact_coordinate_value",
+        }),
+        expect.objectContaining({
+          path: "list.fullItems.0.groupKey",
+          reason: "raw_group_identity",
+        }),
+        expect.objectContaining({
+          path: "list.fullItems.0.groupContext.contextKey",
+          reason: "raw_group_identity",
+        }),
+      ])
+    );
+  });
+});

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -29,6 +29,7 @@ import {
 import { features } from "@/lib/env";
 import { syncListingEmbedding } from "@/lib/embeddings/sync";
 import { normalizeAddress } from "@/lib/search/normalize-address";
+import { toPublicSearchListings } from "@/lib/search/public-listing-payload";
 import {
   checkCollisionRateLimit,
   findCollisions,
@@ -104,13 +105,16 @@ export async function GET(request: Request) {
     });
 
     // Private, no-store: prevent caching of user-generated listing data
-    return NextResponse.json(result, {
-      headers: {
-        "Cache-Control": "private, no-store",
-        "x-request-id": requestId,
-        Vary: "Accept-Encoding",
-      },
-    });
+    return NextResponse.json(
+      { ...result, items: toPublicSearchListings(result.items) },
+      {
+        headers: {
+          "Cache-Control": "private, no-store",
+          "x-request-id": requestId,
+          Vary: "Accept-Encoding",
+        },
+      }
+    );
   } catch (error) {
     // Detect user-facing validation errors (return 400 instead of 500).
     // getListingsPaginated wraps errors via wrapDatabaseError; original message is in error.cause.message.

--- a/src/app/api/search/listings/route.ts
+++ b/src/app/api/search/listings/route.ts
@@ -53,6 +53,7 @@ import {
   recordSearchZeroResults,
 } from "@/lib/search/search-telemetry";
 import { buildPublicCacheHeadersForListings } from "@/lib/public-cache/headers";
+import { toPublicSearchListings } from "@/lib/search/public-listing-payload";
 
 export const runtime = "nodejs";
 
@@ -76,7 +77,9 @@ export async function GET(request: NextRequest) {
       const searchParams = request.nextUrl.searchParams;
       const rawParams = buildRawParamsFromSearchParams(searchParams);
       const parsed = parseSearchParams(rawParams);
-      const normalizedQuery = normalizeSearchQuery(rawParams as RawSearchParams);
+      const normalizedQuery = normalizeSearchQuery(
+        rawParams as RawSearchParams
+      );
       const testScenario = resolveSearchScenario({
         headerValue: request.headers.get(SEARCH_SCENARIO_HEADER),
       });
@@ -148,9 +151,7 @@ export async function GET(request: NextRequest) {
             );
             if (result.unboundedSearch) return result;
             if (!result.response || result.error) {
-              throw new Error(
-                result.error || "V2 search returned no response"
-              );
+              throw new Error(result.error || "V2 search returned no response");
             }
             return result;
           });
@@ -228,10 +229,13 @@ export async function GET(request: NextRequest) {
 
       // V2 success path
       if (v2Result?.response && v2Result.paginatedResult) {
-        const { items: listings, total: rawTotal } = v2Result.paginatedResult;
+        const { items: rawListings, total: rawTotal } =
+          v2Result.paginatedResult;
+        const listings =
+          v2Result.response.list.fullItems ??
+          toPublicSearchListings(rawListings);
         const total = rawTotal;
-        const nextCursor =
-          v2Result.response.list.nextCursor ?? null;
+        const nextCursor = v2Result.response.list.nextCursor ?? null;
         const nearMatchExpansion =
           "nearMatchExpansion" in v2Result.paginatedResult
             ? v2Result.paginatedResult.nearMatchExpansion
@@ -292,22 +296,19 @@ export async function GET(request: NextRequest) {
           resultCount: total,
         });
 
-        return NextResponse.json(
-          state,
-          {
-            headers: {
-              "Cache-Control":
-                "public, s-maxage=60, max-age=30, stale-while-revalidate=120",
-              ...buildPublicCacheHeadersForListings({
-                listings,
-                projectionEpoch: v2Result.response.meta.projectionEpoch,
-                embeddingVersion: v2Result.response.meta.embeddingVersion,
-              }),
-              "x-request-id": requestId,
-              Vary: "Accept-Encoding",
-            },
-          }
-        );
+        return NextResponse.json(state, {
+          headers: {
+            "Cache-Control":
+              "public, s-maxage=60, max-age=30, stale-while-revalidate=120",
+            ...buildPublicCacheHeadersForListings({
+              listings: rawListings,
+              projectionEpoch: v2Result.response.meta.projectionEpoch,
+              embeddingVersion: v2Result.response.meta.embeddingVersion,
+            }),
+            "x-request-id": requestId,
+            Vary: "Accept-Encoding",
+          },
+        });
       }
 
       // V1 fallback path
@@ -336,7 +337,7 @@ export async function GET(request: NextRequest) {
                 kind: "degraded",
                 source: "v1-fallback",
                 data: {
-                  items: paginatedResult.items,
+                  items: toPublicSearchListings(paginatedResult.items),
                   nextCursor: null,
                   total: paginatedResult.total,
                 },
@@ -345,7 +346,7 @@ export async function GET(request: NextRequest) {
             : ({
                 kind: "ok",
                 data: {
-                  items: paginatedResult.items,
+                  items: toPublicSearchListings(paginatedResult.items),
                   nextCursor: null,
                   total: paginatedResult.total,
                 },
@@ -371,25 +372,19 @@ export async function GET(request: NextRequest) {
             : 0,
       });
 
-      return NextResponse.json(
-        state,
-        {
-          headers: {
-            "Cache-Control":
-              "public, s-maxage=60, max-age=30, stale-while-revalidate=120",
-            ...buildPublicCacheHeadersForListings({
-              listings:
-                state.kind === "ok" || state.kind === "degraded"
-                  ? state.data.items
-                  : [],
-              projectionEpoch: state.meta.projectionEpoch,
-              embeddingVersion: state.meta.embeddingVersion,
-            }),
-            "x-request-id": requestId,
-            Vary: "Accept-Encoding",
-          },
-        }
-      );
+      return NextResponse.json(state, {
+        headers: {
+          "Cache-Control":
+            "public, s-maxage=60, max-age=30, stale-while-revalidate=120",
+          ...buildPublicCacheHeadersForListings({
+            listings: paginatedResult.items,
+            projectionEpoch: state.meta.projectionEpoch,
+            embeddingVersion: state.meta.embeddingVersion,
+          }),
+          "x-request-id": requestId,
+          Vary: "Accept-Encoding",
+        },
+      });
     } catch (error) {
       logger.sync.error("Search listings API error", {
         error: sanitizeErrorMessage(error),

--- a/src/app/search/actions.ts
+++ b/src/app/search/actions.ts
@@ -2,7 +2,8 @@
 
 import { headers } from "next/headers";
 import { executeSearchV2 } from "@/lib/search/search-v2-service";
-import { type ListingData } from "@/lib/data";
+import type { PublicSearchListing } from "@/lib/search-types";
+import { toPublicSearchListings } from "@/lib/search/public-listing-payload";
 import {
   buildRawParamsFromSearchParams,
   type RawSearchParams,
@@ -31,7 +32,7 @@ import {
 } from "@/lib/search/search-telemetry";
 
 export interface FetchMoreResult {
-  items: ListingData[];
+  items: PublicSearchListing[];
   nextCursor: string | null;
   hasNextPage: boolean;
   meta?: SearchResponseMeta;
@@ -54,7 +55,10 @@ export async function fetchMoreListings(
   const requestStartTime = performance.now();
   try {
     const normalizedQuery = normalizeSearchQuery(rawParams as RawSearchParams);
-    const fallbackMeta = createSearchResponseMeta(normalizedQuery, "v1-fallback");
+    const fallbackMeta = createSearchResponseMeta(
+      normalizedQuery,
+      "v1-fallback"
+    );
     const testScenario = resolveSearchScenario({
       override: scenarioOverride ?? null,
     });
@@ -232,7 +236,9 @@ export async function fetchMoreListings(
             resultCount: v2Result.paginatedResult.items.length,
           });
           return {
-            items: v2Result.paginatedResult.items,
+            items:
+              v2Result.response?.list.fullItems ??
+              toPublicSearchListings(v2Result.paginatedResult.items),
             nextCursor: v2Result.paginatedResult.nextCursor ?? null,
             hasNextPage: v2Result.paginatedResult.hasNextPage ?? false,
             meta: finalMeta,

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/lib/search/search-telemetry";
 import { V2MapDataSetter } from "@/components/search/V2MapDataSetter";
 import type { SearchV2Response } from "@/lib/search/types";
+import { toPublicSearchListings } from "@/lib/search/public-listing-payload";
 
 type SearchPageSearchParams = {
   q?: string;
@@ -305,7 +306,9 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
     });
 
     if (scenarioState.kind === "location-required") {
-      return renderLocationRequiredState(locationLabel || q || what || "your search");
+      return renderLocationRequiredState(
+        locationLabel || q || what || "your search"
+      );
     }
 
     if (scenarioState.kind === "rate-limited") {
@@ -518,6 +521,10 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   }
 
   const { items: listings, total: rawTotal } = paginatedResult;
+  const publicListings =
+    usedV2 && v2Response?.list.fullItems
+      ? v2Response.list.fullItems
+      : toPublicSearchListings(listings);
   // IMPORTANT: Keep null distinct from 0 - null means "unknown count (>100 results)"
   // whereas 0 means "confirmed zero results"
   const total = rawTotal;
@@ -530,7 +537,8 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 
   // Only show zero-results UI when we have confirmed zero results (total === 0)
   // Not when total is null (unknown count, >100 results)
-  const hasConfirmedZeroResults = total !== null && total === 0;
+  const hasConfirmedZeroResults =
+    total !== null && total === 0 && listings.length === 0;
 
   // Build search params string for client-side "Load more" fetches
   // Include all filter/sort params but NOT cursor/page (those are managed client-side)
@@ -587,7 +595,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
         <InlineFilterStrip
           desktopSummary={{
             total,
-            visibleCount: listings.length,
+            visibleCount: publicListings.length,
             locationLabel: displayLocation,
             browseMode,
           }}
@@ -619,7 +627,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
             ) : null}
             <SearchResultsClient
               key={normalizedKeyString}
-              initialListings={listings}
+              initialListings={publicListings}
               initialNextCursor={initialNextCursor}
               initialTotal={total}
               savedListingIds={[]}

--- a/src/components/search/SearchResultsClient.tsx
+++ b/src/components/search/SearchResultsClient.tsx
@@ -28,8 +28,8 @@ import { getFilterSuggestions } from "@/app/actions/filter-suggestions";
 import { useMobileSearch } from "@/contexts/MobileSearchContext";
 import { useSearchMapUI } from "@/contexts/SearchMapUIContext";
 import { useSearchTestScenario } from "@/contexts/SearchTestScenarioContext";
-import type { ListingData, FilterSuggestion } from "@/lib/data";
-import type { FilterParams } from "@/lib/search-types";
+import type { FilterSuggestion } from "@/lib/data";
+import type { FilterParams, PublicSearchListing } from "@/lib/search-types";
 import {
   getSearchQueryHash,
   SEARCH_RESPONSE_VERSION,
@@ -59,7 +59,7 @@ import { cn } from "@/lib/utils";
  */
 const MAX_ACCUMULATED = 60;
 
-function getSeenGroupKeys(listings: ListingData[]): Set<string> {
+function getSeenGroupKeys(listings: PublicSearchListing[]): Set<string> {
   return new Set(
     listings
       .map((listing) => listing.groupKey)
@@ -67,7 +67,9 @@ function getSeenGroupKeys(listings: ListingData[]): Set<string> {
   );
 }
 
-function dedupeListingsForDisplay(listings: ListingData[]): ListingData[] {
+function dedupeListingsForDisplay(
+  listings: PublicSearchListing[]
+): PublicSearchListing[] {
   const seenIds = new Set<string>();
   const seenGroupKeys = new Set<string>();
 
@@ -98,7 +100,7 @@ function formatMobileResultsLabel(
 }
 
 interface SearchResultsClientProps {
-  initialListings: ListingData[];
+  initialListings: PublicSearchListing[];
   initialNextCursor: string | null;
   initialTotal: number | null;
   savedListingIds: string[];
@@ -161,7 +163,7 @@ export function SearchResultsClient({
   const { shouldShowMap } = useSearchMapUI();
   const testScenario = useSearchTestScenario();
   const [isHydrated, setIsHydrated] = useState(false);
-  const [extraListings, setExtraListings] = useState<ListingData[]>([]);
+  const [extraListings, setExtraListings] = useState<PublicSearchListing[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(
     initialNextCursor
   );
@@ -212,7 +214,7 @@ export function SearchResultsClient({
 
   // --- Client-side search fetch (when feature flag enabled) ---
   const [clientFetchedListings, setClientFetchedListings] = useState<
-    ListingData[] | null
+    PublicSearchListing[] | null
   >(null);
   const [clientFetchedTotal, setClientFetchedTotal] = useState<number | null>(
     null

--- a/src/lib/maps/sanitize-map-listings.ts
+++ b/src/lib/maps/sanitize-map-listings.ts
@@ -6,6 +6,7 @@ import type {
 import { buildPublicAvailability } from "@/lib/search/public-availability";
 import type { PublicAvailabilitySource } from "@/lib/search/public-availability";
 import { toPublicCoordinates } from "@/lib/search/public-coordinates";
+import { toPublicGroupMetadata } from "@/lib/search/public-listing-payload";
 
 type MapListingInput = {
   id: string;
@@ -114,6 +115,11 @@ export function sanitizeMapListing(
           : Math.max(1, toSafeSlotCount(listing.minStayMonths, 1)),
       lastConfirmedAt: toSafeDate(listing.lastConfirmedAt),
     });
+  const publicGroupMetadata = toPublicGroupMetadata({
+    groupKey: toOptionalTrimmedString(listing.groupKey) ?? null,
+    groupSummary: listing.groupSummary ?? null,
+    groupContext: listing.groupContext ?? null,
+  });
 
   return {
     id: listing.id,
@@ -131,13 +137,16 @@ export function sanitizeMapListing(
     availabilitySource: publicAvailability.availabilitySource,
     openSlots: toSafeSlotCount(publicAvailability.openSlots),
     availableUntil: toSafeDate(publicAvailability.availableUntil),
-    minStayMonths: Math.max(1, toSafeSlotCount(publicAvailability.minStayMonths, 1)),
+    minStayMonths: Math.max(
+      1,
+      toSafeSlotCount(publicAvailability.minStayMonths, 1)
+    ),
     lastConfirmedAt: toSafeDate(publicAvailability.lastConfirmedAt),
     status: toOptionalTrimmedString(listing.status),
-    statusReason: toOptionalTrimmedString(listing.statusReason) ?? null,
-    groupKey: toOptionalTrimmedString(listing.groupKey) ?? null,
-    groupSummary: listing.groupSummary ?? null,
-    groupContext: listing.groupContext ?? null,
+    statusReason: null,
+    groupKey: publicGroupMetadata.groupKey,
+    groupSummary: publicGroupMetadata.groupSummary,
+    groupContext: publicGroupMetadata.groupContext,
     location: {
       city: toOptionalTrimmedString(listing.location?.city),
       state: toOptionalTrimmedString(listing.location?.state),

--- a/src/lib/public-cache/cache-policy.ts
+++ b/src/lib/public-cache/cache-policy.ts
@@ -25,7 +25,7 @@ function base64UrlDecode(value: string): string {
   return Buffer.from(value, "base64url").toString("utf8");
 }
 
-function getPublicCacheSigningSecret(): string {
+export function getPublicCacheSigningSecret(): string {
   const secret =
     process.env.PUBLIC_CACHE_CURSOR_SECRET ||
     process.env.PUBLIC_CACHE_KEY_SECRET ||
@@ -79,7 +79,9 @@ export function signPublicCacheCursor(
     cursor.enqueuedAt instanceof Date
       ? cursor.enqueuedAt.toISOString()
       : new Date(cursor.enqueuedAt).toISOString();
-  const payload = base64UrlEncode(JSON.stringify({ id: cursor.id, enqueuedAt }));
+  const payload = base64UrlEncode(
+    JSON.stringify({ id: cursor.id, enqueuedAt })
+  );
   return `v1.${payload}.${signPayload(payload)}`;
 }
 
@@ -148,7 +150,10 @@ export function normalizeCacheInvalidationReason(reason: string): string {
   if (normalized.includes("IDENTITY")) {
     return "IDENTITY_MUTATION";
   }
-  if (normalized.includes("REPUBLICATION") || normalized.includes("REPUBLISH")) {
+  if (
+    normalized.includes("REPUBLICATION") ||
+    normalized.includes("REPUBLISH")
+  ) {
     return "REPUBLISH";
   }
   return "PUBLIC_CACHE_INVALIDATE";

--- a/src/lib/search-types.ts
+++ b/src/lib/search-types.ts
@@ -94,6 +94,21 @@ export interface ListingData {
   isNearMatch?: boolean;
 }
 
+/**
+ * Browser-visible listing card payload for search/list discovery surfaces.
+ *
+ * This intentionally excludes owner ids and exact address fields. Coordinates
+ * are present only after public coarsening at the serialization boundary.
+ */
+export type PublicSearchListing = Omit<ListingData, "ownerId" | "location"> & {
+  location: {
+    city: string;
+    state: string;
+    lat: number;
+    lng: number;
+  };
+};
+
 export type SortOption =
   | "recommended"
   | "price_asc"

--- a/src/lib/search/projection-search.ts
+++ b/src/lib/search/projection-search.ts
@@ -41,6 +41,7 @@ import {
   transformToListItems,
   transformToMapResponse,
 } from "./transform";
+import { toPublicSearchListings } from "./public-listing-payload";
 import {
   buildPublicAvailability,
   type PublicAvailability,
@@ -723,7 +724,7 @@ function buildResult(input: {
     meta,
     list: {
       items: transformToListItems(items),
-      fullItems: items,
+      fullItems: toPublicSearchListings(items),
       nextCursor: input.nextCursor,
       total: input.total,
     },

--- a/src/lib/search/public-listing-payload.ts
+++ b/src/lib/search/public-listing-payload.ts
@@ -1,0 +1,208 @@
+import { createHmac } from "crypto";
+import { getPublicCacheSigningSecret } from "@/lib/public-cache/cache-policy";
+import type {
+  GroupContextPresentation,
+  GroupSummary,
+  ListingData,
+  MapListingData,
+  PublicSearchListing,
+} from "@/lib/search-types";
+import { toPublicCoordinates } from "@/lib/search/public-coordinates";
+import {
+  buildPublicAvailability,
+  type PublicAvailability,
+} from "@/lib/search/public-availability";
+
+export const PUBLIC_GROUP_KEY_PREFIX = "pg1_";
+
+type GroupMetadataInput = {
+  groupKey?: string | null;
+  groupSummary?: GroupSummary | null;
+  groupContext?: GroupContextPresentation | null;
+};
+
+export type PublicGroupMetadata = {
+  groupKey: string | null;
+  groupSummary: GroupSummary | null;
+  groupContext: GroupContextPresentation | null;
+};
+
+function toNonEmptyString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function toPublicGroupKey(
+  groupKey: string | null | undefined
+): string | null {
+  const rawGroupKey = toNonEmptyString(groupKey);
+  if (!rawGroupKey) {
+    return null;
+  }
+  if (rawGroupKey.startsWith(PUBLIC_GROUP_KEY_PREFIX)) {
+    return rawGroupKey;
+  }
+
+  const digest = createHmac("sha256", getPublicCacheSigningSecret())
+    .update(`search-public-group:${rawGroupKey}`)
+    .digest("base64url")
+    .slice(0, 24);
+
+  return `${PUBLIC_GROUP_KEY_PREFIX}${digest}`;
+}
+
+function publicContextFallbackKey(
+  groupContext: GroupContextPresentation
+): string {
+  return [
+    "context",
+    groupContext.siblingCount,
+    groupContext.dateCount,
+    groupContext.completeness,
+    groupContext.secondaryLabel ?? "",
+  ].join(":");
+}
+
+export function toPublicGroupMetadata(
+  input: GroupMetadataInput
+): PublicGroupMetadata {
+  const publicGroupKey =
+    toPublicGroupKey(input.groupKey) ??
+    toPublicGroupKey(input.groupSummary?.groupKey) ??
+    null;
+  const summarySourceKey =
+    input.groupSummary?.groupKey ??
+    input.groupKey ??
+    input.groupContext?.contextKey ??
+    (input.groupSummary
+      ? [
+          "summary",
+          input.groupSummary.siblingIds.join(","),
+          input.groupSummary.availableFromDates.join(","),
+          input.groupSummary.combinedOpenSlots,
+          input.groupSummary.combinedTotalSlots,
+        ].join(":")
+      : null);
+
+  const groupSummary = input.groupSummary
+    ? {
+        ...input.groupSummary,
+        groupKey:
+          toPublicGroupKey(summarySourceKey) ??
+          publicGroupKey ??
+          PUBLIC_GROUP_KEY_PREFIX,
+        siblingIds: input.groupSummary.siblingIds.slice(),
+        availableFromDates: input.groupSummary.availableFromDates.slice(),
+        members: input.groupSummary.members?.map((member) => ({ ...member })),
+        windows: input.groupSummary.windows?.map((window) => ({ ...window })),
+      }
+    : null;
+
+  const groupContext = input.groupContext
+    ? {
+        ...input.groupContext,
+        contextKey:
+          toPublicGroupKey(input.groupContext.contextKey) ??
+          toPublicGroupKey(publicContextFallbackKey(input.groupContext)) ??
+          PUBLIC_GROUP_KEY_PREFIX,
+      }
+    : null;
+
+  return {
+    groupKey: publicGroupKey,
+    groupSummary,
+    groupContext,
+  };
+}
+
+function normalizePublicAvailability(
+  listing: ListingData | MapListingData
+): PublicAvailability {
+  return (
+    listing.publicAvailability ??
+    buildPublicAvailability({
+      availabilitySource: listing.availabilitySource,
+      openSlots: listing.openSlots,
+      availableSlots: listing.availableSlots,
+      totalSlots: listing.totalSlots,
+      moveInDate: listing.moveInDate,
+      availableUntil: listing.availableUntil,
+      minStayMonths: listing.minStayMonths,
+      lastConfirmedAt: listing.lastConfirmedAt,
+    })
+  );
+}
+
+export function toPublicSearchListing(
+  listing: ListingData
+): PublicSearchListing {
+  const publicAvailability = normalizePublicAvailability(listing);
+  const publicCoordinates = toPublicCoordinates(listing.location);
+  const publicGroupMetadata = toPublicGroupMetadata(listing);
+
+  return {
+    id: listing.id,
+    title: listing.title,
+    description: "",
+    price: listing.price,
+    images: listing.images.slice(),
+    availableSlots: publicAvailability.openSlots,
+    totalSlots: publicAvailability.totalSlots,
+    amenities: listing.amenities.slice(),
+    houseRules: listing.houseRules.slice(),
+    householdLanguages: listing.householdLanguages.slice(),
+    primaryHomeLanguage: listing.primaryHomeLanguage,
+    genderPreference: listing.genderPreference,
+    householdGender: listing.householdGender,
+    leaseDuration: listing.leaseDuration,
+    roomType: listing.roomType,
+    moveInDate: listing.moveInDate,
+    location: {
+      city: listing.location.city,
+      state: listing.location.state,
+      lat: publicCoordinates.lat,
+      lng: publicCoordinates.lng,
+    },
+    publicAvailability,
+    availabilitySource: publicAvailability.availabilitySource,
+    openSlots: publicAvailability.openSlots,
+    availableUntil: listing.availableUntil,
+    minStayMonths: publicAvailability.minStayMonths,
+    lastConfirmedAt: listing.lastConfirmedAt,
+    status: listing.status,
+    groupKey: publicGroupMetadata.groupKey,
+    groupSummary: publicGroupMetadata.groupSummary,
+    groupContext: publicGroupMetadata.groupContext,
+    isNearMatch: listing.isNearMatch,
+  };
+}
+
+export function toPublicSearchListings(
+  listings: ListingData[]
+): PublicSearchListing[] {
+  return listings.map(toPublicSearchListing);
+}
+
+export function toPublicMapListing(listing: MapListingData): MapListingData {
+  const publicCoordinates = toPublicCoordinates(listing.location);
+  const publicGroupMetadata = toPublicGroupMetadata(listing);
+
+  return {
+    ...listing,
+    location: {
+      ...listing.location,
+      lat: publicCoordinates.lat,
+      lng: publicCoordinates.lng,
+    },
+    groupKey: publicGroupMetadata.groupKey,
+    groupSummary: publicGroupMetadata.groupSummary,
+    groupContext: publicGroupMetadata.groupContext,
+    statusReason: null,
+  };
+}
+
+export function toPublicMapListings(
+  listings: MapListingData[]
+): MapListingData[] {
+  return listings.map(toPublicMapListing);
+}

--- a/src/lib/search/search-response.ts
+++ b/src/lib/search/search-response.ts
@@ -1,4 +1,4 @@
-import type { ListingData, MapListingData } from "@/lib/search-types";
+import type { MapListingData, PublicSearchListing } from "@/lib/search-types";
 import { generateSearchQueryHash } from "./query-hash";
 import type { NormalizedSearchQuery } from "./search-query";
 
@@ -21,7 +21,7 @@ export interface SearchResponseMeta {
 }
 
 export interface SearchListPayload {
-  items: ListingData[];
+  items: PublicSearchListing[];
   nextCursor: string | null;
   total: number | null;
   nearMatchExpansion?: string;
@@ -54,7 +54,10 @@ export type SearchMapState = SearchState<SearchMapPayload>;
 export function createSearchResponseMeta(
   query: NormalizedSearchQuery,
   backendSource: SearchBackendSource,
-  extras?: Omit<SearchResponseMeta, "queryHash" | "backendSource" | "responseVersion">
+  extras?: Omit<
+    SearchResponseMeta,
+    "queryHash" | "backendSource" | "responseVersion"
+  >
 ): SearchResponseMeta {
   return {
     queryHash: getSearchQueryHash(query),

--- a/src/lib/search/search-v2-service.ts
+++ b/src/lib/search/search-v2-service.ts
@@ -41,6 +41,7 @@ import {
   determineMode,
   shouldIncludePins,
 } from "@/lib/search/transform";
+import { toPublicSearchListings } from "@/lib/search/public-listing-payload";
 import {
   isRankingEnabled,
   buildScoreMap,
@@ -104,7 +105,9 @@ function getEmptyMapResponse(): SearchV2Response["map"] {
   };
 }
 
-function getSnapshotMapMode(mapPayload: SearchV2Response["map"]): "geojson" | "pins" {
+function getSnapshotMapMode(
+  mapPayload: SearchV2Response["map"]
+): "geojson" | "pins" {
   return mapPayload.pins ? "pins" : "geojson";
 }
 
@@ -254,7 +257,10 @@ interface SemanticListingAvailabilityRow {
 
 async function resolveEligibleSemanticItems(
   items: ListingData[],
-  filterParams: Pick<FilterParams, "moveInDate" | "endDate" | "minAvailableSlots">
+  filterParams: Pick<
+    FilterParams,
+    "moveInDate" | "endDate" | "minAvailableSlots"
+  >
 ): Promise<ListingData[]> {
   if (items.length === 0) {
     return [];
@@ -316,12 +322,12 @@ async function resolveEligibleSemanticItems(
 
       return Boolean(
         listingRow &&
-          resolvedAvailability &&
-          isListingEligibleForPublicSearch({
-            statusReason: listingRow?.statusReason,
-            resolvedAvailability,
-          }) &&
-          item.availableSlots >= requiredSlots
+        resolvedAvailability &&
+        isListingEligibleForPublicSearch({
+          statusReason: listingRow?.statusReason,
+          resolvedAvailability,
+        }) &&
+        item.availableSlots >= requiredSlots
       );
     });
 }
@@ -359,14 +365,16 @@ async function getSemanticEligibleListPage(
       break;
     }
 
-    const batchItems = mapSemanticRowsToListingData(semanticRows).filter((item) => {
-      if (seenListingIds.has(item.id)) {
-        return false;
-      }
+    const batchItems = mapSemanticRowsToListingData(semanticRows).filter(
+      (item) => {
+        if (seenListingIds.has(item.id)) {
+          return false;
+        }
 
-      seenListingIds.add(item.id);
-      return true;
-    });
+        seenListingIds.add(item.id);
+        return true;
+      }
+    );
 
     if (batchItems.length === 0) {
       break;
@@ -392,7 +400,8 @@ async function getSemanticEligibleListPage(
     total,
     page,
     limit: pageSize,
-    totalPages: hasNextPage || total === null ? null : Math.ceil(total / pageSize),
+    totalPages:
+      hasNextPage || total === null ? null : Math.ceil(total / pageSize),
     hasNextPage,
     nextCursor: hasNextPage ? encodeCursor(page + 1) : null,
   };
@@ -480,12 +489,17 @@ async function hydrateSnapshotPage(options: {
     };
   }
 
-  const snapshotResult = await loadValidQuerySnapshot(options.cursor.snapshotId);
+  const snapshotResult = await loadValidQuerySnapshot(
+    options.cursor.snapshotId
+  );
   if (!snapshotResult.ok) {
     return {
       response: null,
       paginatedResult: null,
-      snapshotExpired: buildSnapshotExpired(options.queryHash, snapshotResult.reason),
+      snapshotExpired: buildSnapshotExpired(
+        options.queryHash,
+        snapshotResult.reason
+      ),
     };
   }
 
@@ -520,7 +534,7 @@ async function hydrateSnapshotPage(options: {
       },
       list: {
         items: transformToListItems(items),
-        fullItems: items,
+        fullItems: toPublicSearchListings(items),
         nextCursor,
         total,
       },
@@ -822,11 +836,10 @@ export async function executeSearchV2(
           );
         } else {
           // First page - get first page with keyset cursor
-          const firstPageResult =
-            await getSearchDocListingsFirstPage(
-              filterParams,
-              keysetSnapshot
-            );
+          const firstPageResult = await getSearchDocListingsFirstPage(
+            filterParams,
+            keysetSnapshot
+          );
           return finalizeListResult(
             firstPageResult,
             firstPageResult.nextCursor
@@ -914,12 +927,8 @@ export async function executeSearchV2(
     const warnings: string[] = [];
 
     if (listSettled.status === "fulfilled") {
-      ({
-        listResult,
-        nextCursor,
-        usedSoftVibeFallback,
-        usedSemanticSearch,
-      } = listSettled.value);
+      ({ listResult, nextCursor, usedSoftVibeFallback, usedSemanticSearch } =
+        listSettled.value);
     } else {
       logger.sync.error("[SearchV2] List query failed", {
         error:
@@ -964,7 +973,9 @@ export async function executeSearchV2(
     }
 
     // Determine mode based on mapListings count (not list total)
-    const mode = forceClustersOnly ? "geojson" : determineMode(mapListings.length);
+    const mode = forceClustersOnly
+      ? "geojson"
+      : determineMode(mapListings.length);
     const versionMeta = getSearchV2VersionMeta({
       useSearchDoc,
       usedSemanticSearch,
@@ -1053,12 +1064,13 @@ export async function executeSearchV2(
     });
     const mapResponse = applyPhase04MapKillSwitches(transformedMapResponse);
 
-    let responseMetaBase: import("@/lib/search/search-response").SearchResponseMeta = {
-      queryHash,
-      backendSource: "v2",
-      responseVersion: SEARCH_RESPONSE_VERSION,
-      ...versionMeta,
-    };
+    let responseMetaBase: import("@/lib/search/search-response").SearchResponseMeta =
+      {
+        queryHash,
+        backendSource: "v2",
+        responseVersion: SEARCH_RESPONSE_VERSION,
+        ...versionMeta,
+      };
     let listNextCursor = nextCursor;
 
     if (snapshotContractEnabled && !snapshotCursor && !keysetCursor) {
@@ -1126,7 +1138,7 @@ export async function executeSearchV2(
       },
       list: {
         items: listItems,
-        fullItems: listResult.items,
+        fullItems: toPublicSearchListings(listResult.items),
         nextCursor: listNextCursor,
         total: listResult.total,
       },

--- a/src/lib/search/split-stay.ts
+++ b/src/lib/search/split-stay.ts
@@ -1,8 +1,8 @@
-import type { ListingData } from "@/lib/data";
+import type { PublicSearchListing } from "@/lib/search-types";
 
 export interface SplitStayPair {
-  first: ListingData;
-  second: ListingData;
+  first: PublicSearchListing;
+  second: PublicSearchListing;
   /** Total combined price for the full stay */
   combinedPrice: number;
   /** Label like "2 weeks + 2 weeks" */
@@ -19,7 +19,7 @@ export interface SplitStayPair {
  * data not yet in the schema.
  */
 export function findSplitStays(
-  listings: ListingData[],
+  listings: PublicSearchListing[],
   stayMonths?: number
 ): SplitStayPair[] {
   // Only suggest split stays for 6+ month durations with enough listings

--- a/src/lib/search/testing/search-scenarios.ts
+++ b/src/lib/search/testing/search-scenarios.ts
@@ -1,9 +1,9 @@
-import type { ListingData, MapListingData } from "@/lib/search-types";
+import type { MapListingData, PublicSearchListing } from "@/lib/search-types";
 import type { NormalizedSearchQuery } from "@/lib/search/search-query";
 import { buildPublicAvailability } from "@/lib/search/public-availability";
+import { toPublicCoordinates } from "@/lib/search/public-coordinates";
 import {
   createSearchResponseMeta,
-  type SearchListPayload,
   type SearchListState,
   type SearchMapState,
   type SearchResponseMeta,
@@ -34,7 +34,7 @@ const RESPONSE_DELAY_MS = {
 export type SearchScenario = (typeof SEARCH_SCENARIOS)[number];
 
 export interface SearchScenarioLoadMoreResult {
-  items: ListingData[];
+  items: PublicSearchListing[];
   nextCursor: string | null;
   hasNextPage: boolean;
   meta: SearchResponseMeta;
@@ -54,7 +54,7 @@ interface ScenarioContext {
 }
 
 interface ScenarioListData {
-  items: ListingData[];
+  items: PublicSearchListing[];
   nextCursor: string | null;
   total: number;
   nearMatchExpansion?: string;
@@ -112,15 +112,19 @@ function createListing(
   price: number,
   latOffset: number,
   lngOffset: number,
-  overrides: Partial<ListingData> = {}
-): ListingData {
+  overrides: Partial<PublicSearchListing> = {}
+): PublicSearchListing {
   const anchor = getAnchor(query);
   const locationLabel = getLocationLabel(query);
+  const publicCoordinates = toPublicCoordinates({
+    lat: anchor.lat + latOffset,
+    lng: anchor.lng + lngOffset,
+  });
 
   return {
     id: `scenario-${suffix}`,
     title: `${locationLabel} Room ${suffix.toUpperCase()}`,
-    description: `Deterministic scenario listing ${suffix} for ${locationLabel}.`,
+    description: "",
     price,
     images: ["/images/team/surya.webp"],
     availableSlots: overrides.availableSlots ?? 1,
@@ -136,14 +140,11 @@ function createListing(
     roomType: overrides.roomType ?? "Private Room",
     moveInDate:
       overrides.moveInDate ?? new Date("2026-06-01T00:00:00.000Z"),
-    ownerId: overrides.ownerId ?? "scenario-owner",
     location: {
-      address: `${suffix.toUpperCase()} Example St`,
       city: locationLabel.split(",")[0] || "Austin",
       state: locationLabel.split(",")[1]?.trim() || "TX",
-      zip: "78701",
-      lat: Number((anchor.lat + latOffset).toFixed(5)),
-      lng: Number((anchor.lng + lngOffset).toFixed(5)),
+      lat: publicCoordinates.lat,
+      lng: publicCoordinates.lng,
     },
     publicAvailability:
       overrides.publicAvailability ??
@@ -157,7 +158,7 @@ function createListing(
   };
 }
 
-function buildBaseListings(query: NormalizedSearchQuery): ListingData[] {
+function buildBaseListings(query: NormalizedSearchQuery): PublicSearchListing[] {
   return [
     createListing(query, "a", 900, 0.012, -0.015, {
       amenities: ["Wifi", "Parking"],
@@ -189,9 +190,9 @@ function buildBaseListings(query: NormalizedSearchQuery): ListingData[] {
 }
 
 function applyScenarioFilters(
-  listings: ListingData[],
+  listings: PublicSearchListing[],
   query: NormalizedSearchQuery
-): ListingData[] {
+): PublicSearchListing[] {
   return listings.filter((listing) => {
     if (query.minPrice !== undefined && listing.price < query.minPrice) {
       return false;
@@ -222,9 +223,9 @@ function applyScenarioFilters(
 }
 
 function sortScenarioListings(
-  listings: ListingData[],
+  listings: PublicSearchListing[],
   query: NormalizedSearchQuery
-): ListingData[] {
+): PublicSearchListing[] {
   const next = [...listings];
 
   switch (query.sort) {
@@ -239,7 +240,7 @@ function sortScenarioListings(
     default:
       return [next[2], next[0], next[4], next[1], next[5], next[3]].filter(
         Boolean
-      ) as ListingData[];
+      ) as PublicSearchListing[];
   }
 }
 
@@ -255,7 +256,7 @@ function parseScenarioCursor(cursor?: string | null): number {
 }
 
 function paginateScenarioListings(
-  listings: ListingData[],
+  listings: PublicSearchListing[],
   cursor?: string | null
 ): ScenarioListData {
   const currentPage = parseScenarioCursor(cursor);
@@ -304,7 +305,7 @@ function buildSlowScenarioData(
   };
 }
 
-function toMapListings(listings: ListingData[]): MapListingData[] {
+function toMapListings(listings: PublicSearchListing[]): MapListingData[] {
   return listings.map((listing) => ({
     id: listing.id,
     title: listing.title,

--- a/src/lib/search/transform.ts
+++ b/src/lib/search/transform.ts
@@ -28,6 +28,7 @@ import {
   type PublicAvailability,
 } from "./public-availability";
 import { toPublicCoordinates } from "./public-coordinates";
+import { toPublicGroupMetadata } from "./public-listing-payload";
 
 type AvailabilityLike = Pick<
   ListingData | MapListingData,
@@ -100,6 +101,7 @@ export function transformToListItem(listing: ListingData): SearchV2ListItem {
   const badges: string[] = [];
   const publicAvailability = getNormalizedPublicAvailability(listing);
   const publicCoordinates = toPublicCoordinates(listing.location);
+  const publicGroupMetadata = toPublicGroupMetadata(listing);
 
   // Add near-match badge if applicable
   if (listing.isNearMatch) {
@@ -122,8 +124,8 @@ export function transformToListItem(listing: ListingData): SearchV2ListItem {
     availableSlots: publicAvailability.openSlots,
     totalSlots: publicAvailability.totalSlots,
     publicAvailability,
-    groupSummary: listing.groupSummary ?? null,
-    groupContext: listing.groupContext ?? null,
+    groupSummary: publicGroupMetadata.groupSummary,
+    groupContext: publicGroupMetadata.groupContext,
     // scoreHint is reserved for future relevance scoring
   };
 }
@@ -157,6 +159,7 @@ export function transformToGeoJSON(
   const features = listings.map((listing) => {
     const publicAvailability = getNormalizedPublicAvailability(listing);
     const publicCoordinates = toPublicCoordinates(listing.location);
+    const publicGroupMetadata = toPublicGroupMetadata(listing);
 
     return {
       type: "Feature" as const,
@@ -174,7 +177,7 @@ export function transformToGeoJSON(
         image: listing.images[0] ?? null,
         availableSlots: publicAvailability.openSlots,
         publicAvailability,
-        groupContext: listing.groupContext ?? null,
+        groupContext: publicGroupMetadata.groupContext,
       } satisfies SearchV2FeatureProperties,
     };
   });
@@ -248,7 +251,9 @@ export function transformToPins(
   return tieredGroups.map((group) => {
     // Explicitly pick best listing by lowest rank (highest score), not just [0]
     const bestListing = getBestListingInGroup(group.listings, rankMap);
-    const sourceListing = listings.find((listing) => listing.id === bestListing.id);
+    const sourceListing = listings.find(
+      (listing) => listing.id === bestListing.id
+    );
     const publicAvailability = sourceListing
       ? getNormalizedPublicAvailability(sourceListing)
       : buildPublicAvailability({

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -10,7 +10,7 @@ import type { PublicAvailability } from "./public-availability";
 import type {
   GroupContextPresentation,
   GroupSummary,
-  ListingData,
+  PublicSearchListing,
 } from "@/lib/search-types";
 
 // ============================================================================
@@ -134,8 +134,8 @@ export interface SearchV2Meta {
 /** List section of the response */
 export interface SearchV2List {
   items: SearchV2ListItem[];
-  /** Full-fidelity card payload for first-party web clients */
-  fullItems?: ListingData[];
+  /** Public card payload for first-party web clients */
+  fullItems?: PublicSearchListing[];
   /** Base64url encoded cursor for next page, null if no more pages */
   nextCursor: string | null;
   /** Exact total if ≤100, null if >100 (hybrid count optimization) */

--- a/src/lib/search/v2-map-data.ts
+++ b/src/lib/search/v2-map-data.ts
@@ -1,18 +1,113 @@
 import type { MapListingData } from "@/lib/data";
-import type { SearchV2Map } from "./types";
+import { buildPublicAvailability } from "./public-availability";
+import type { SearchV2FeatureProperties, SearchV2Map } from "./types";
 import type { GroupContextPresentation } from "@/lib/search-types";
 import { toPublicCoordinates } from "./public-coordinates";
 
 const PUBLIC_GROUP_KEY_PREFIX = "pg1_";
 
+type PartialMapFeatureProperties = Partial<
+  Omit<SearchV2FeatureProperties, "publicAvailability" | "groupContext">
+> & {
+  publicAvailability?: unknown;
+  groupContext?: unknown;
+  totalSlots?: unknown;
+  avgRating?: unknown;
+  reviewCount?: unknown;
+  recommendedScore?: unknown;
+  createdAt?: unknown;
+};
+
+function toFiniteNumber(value: unknown, fallback = 0): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function toSafeSlotCount(value: unknown, fallback = 0): number {
+  return Math.max(0, Math.trunc(toFiniteNumber(value, fallback)));
+}
+
+function toSafeDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+function hasValidCoordinateRange(lat: number, lng: number): boolean {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180 &&
+    !(lat === 0 && lng === 0)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
 function isPublicGroupContext(
-  groupContext: GroupContextPresentation | null | undefined
+  groupContext: unknown
 ): groupContext is GroupContextPresentation {
   return (
-    !!groupContext &&
+    isRecord(groupContext) &&
     typeof groupContext.contextKey === "string" &&
-    groupContext.contextKey.startsWith(PUBLIC_GROUP_KEY_PREFIX)
+    groupContext.contextKey.startsWith(PUBLIC_GROUP_KEY_PREFIX) &&
+    typeof groupContext.siblingCount === "number" &&
+    typeof groupContext.dateCount === "number" &&
+    typeof groupContext.completeness === "string"
   );
+}
+
+function toMapPublicAvailability(properties: PartialMapFeatureProperties) {
+  const publicAvailability = isRecord(properties.publicAvailability)
+    ? properties.publicAvailability
+    : null;
+
+  const availableSlots = toSafeSlotCount(
+    publicAvailability?.openSlots ?? properties.availableSlots
+  );
+  const totalSlots = toSafeSlotCount(
+    publicAvailability?.totalSlots ?? properties.totalSlots,
+    availableSlots
+  );
+
+  return buildPublicAvailability({
+    availabilitySource:
+      publicAvailability?.availabilitySource === "LEGACY_BOOKING" ||
+      publicAvailability?.availabilitySource === "HOST_MANAGED"
+        ? publicAvailability.availabilitySource
+        : undefined,
+    openSlots: availableSlots,
+    totalSlots,
+    availableFrom:
+      typeof publicAvailability?.availableFrom === "string"
+        ? publicAvailability.availableFrom
+        : null,
+    availableUntil:
+      typeof publicAvailability?.availableUntil === "string"
+        ? publicAvailability.availableUntil
+        : null,
+    minStayMonths: toSafeSlotCount(publicAvailability?.minStayMonths, 1),
+    lastConfirmedAt:
+      typeof publicAvailability?.lastConfirmedAt === "string"
+        ? publicAvailability.lastConfirmedAt
+        : null,
+  });
 }
 
 export function searchV2MapToListings(mapData: SearchV2Map): MapListingData[] {
@@ -32,28 +127,31 @@ export function searchV2MapToListings(mapData: SearchV2Map): MapListingData[] {
         return listings;
       }
 
-      const [lng, lat] = coordinates;
-      if (
-        !Number.isFinite(lng) ||
-        !Number.isFinite(lat) ||
-        lat < -90 ||
-        lat > 90 ||
-        lng < -180 ||
-        lng > 180
-      ) {
+      const lng = toFiniteNumber(coordinates[0], Number.NaN);
+      const lat = toFiniteNumber(coordinates[1], Number.NaN);
+      if (!hasValidCoordinateRange(lat, lng)) {
+        return listings;
+      }
+
+      const properties = feature.properties as PartialMapFeatureProperties;
+      if (typeof properties.id !== "string" || properties.id.length === 0) {
         return listings;
       }
 
       const publicCoordinates = toPublicCoordinates({ lat, lng });
-      const publicAvailability = feature.properties.publicAvailability;
+      const publicAvailability = toMapPublicAvailability(properties);
 
       listings.push({
-        id: feature.properties.id,
-        title: feature.properties.title ?? "",
-        price: Math.max(0, feature.properties.price ?? 0),
+        id: properties.id,
+        title:
+          typeof properties.title === "string" ? properties.title.trim() : "",
+        price: Math.max(0, toFiniteNumber(properties.price, 0)),
         availableSlots: publicAvailability.openSlots,
         totalSlots: publicAvailability.totalSlots,
-        images: feature.properties.image ? [feature.properties.image] : [],
+        images:
+          typeof properties.image === "string" && properties.image.length > 0
+            ? [properties.image]
+            : [],
         location: {
           lat: publicCoordinates.lat,
           lng: publicCoordinates.lng,
@@ -61,10 +159,21 @@ export function searchV2MapToListings(mapData: SearchV2Map): MapListingData[] {
         publicAvailability,
         groupKey: null,
         groupSummary: null,
-        groupContext: isPublicGroupContext(feature.properties.groupContext)
-          ? feature.properties.groupContext
+        groupContext: isPublicGroupContext(properties.groupContext)
+          ? properties.groupContext
           : null,
-        tier: pinTierMap.get(feature.properties.id),
+        tier: pinTierMap.get(properties.id),
+        avgRating: toFiniteNumber(properties.avgRating, 0),
+        reviewCount: toSafeSlotCount(properties.reviewCount),
+        recommendedScore:
+          properties.recommendedScore == null
+            ? null
+            : Number.isFinite(
+                  toFiniteNumber(properties.recommendedScore, Number.NaN)
+                )
+              ? toFiniteNumber(properties.recommendedScore)
+              : null,
+        createdAt: toSafeDate(properties.createdAt),
       });
 
       return listings;

--- a/src/lib/search/v2-map-data.ts
+++ b/src/lib/search/v2-map-data.ts
@@ -1,6 +1,19 @@
 import type { MapListingData } from "@/lib/data";
-import { sanitizeMapListings } from "@/lib/maps/sanitize-map-listings";
 import type { SearchV2Map } from "./types";
+import type { GroupContextPresentation } from "@/lib/search-types";
+import { toPublicCoordinates } from "./public-coordinates";
+
+const PUBLIC_GROUP_KEY_PREFIX = "pg1_";
+
+function isPublicGroupContext(
+  groupContext: GroupContextPresentation | null | undefined
+): groupContext is GroupContextPresentation {
+  return (
+    !!groupContext &&
+    typeof groupContext.contextKey === "string" &&
+    groupContext.contextKey.startsWith(PUBLIC_GROUP_KEY_PREFIX)
+  );
+}
 
 export function searchV2MapToListings(mapData: SearchV2Map): MapListingData[] {
   const pinTierMap = new Map<string, "primary" | "mini">();
@@ -12,37 +25,50 @@ export function searchV2MapToListings(mapData: SearchV2Map): MapListingData[] {
     }
   }
 
-  return sanitizeMapListings(
-    mapData.geojson.features
-      .filter((feature) => {
-        const coordinates = feature.geometry?.coordinates;
-        if (!Array.isArray(coordinates) || coordinates.length < 2) {
-          return false;
-        }
+  return mapData.geojson.features.reduce<MapListingData[]>(
+    (listings, feature) => {
+      const coordinates = feature.geometry?.coordinates;
+      if (!Array.isArray(coordinates) || coordinates.length < 2) {
+        return listings;
+      }
 
-        const [lng, lat] = coordinates;
-        return (
-          Number.isFinite(lng) &&
-          Number.isFinite(lat) &&
-          lat >= -90 &&
-          lat <= 90 &&
-          lng >= -180 &&
-          lng <= 180
-        );
-      })
-      .map((feature) => {
-        const [lng, lat] = feature.geometry.coordinates;
-        return {
-          id: feature.properties.id,
-          title: feature.properties.title ?? "",
-          price: feature.properties.price,
-          availableSlots: feature.properties.availableSlots,
-          publicAvailability: feature.properties.publicAvailability,
-          groupContext: feature.properties.groupContext ?? null,
-          images: feature.properties.image ? [feature.properties.image] : [],
-          location: { lng, lat },
-          tier: pinTierMap.get(feature.properties.id),
-        };
-      })
+      const [lng, lat] = coordinates;
+      if (
+        !Number.isFinite(lng) ||
+        !Number.isFinite(lat) ||
+        lat < -90 ||
+        lat > 90 ||
+        lng < -180 ||
+        lng > 180
+      ) {
+        return listings;
+      }
+
+      const publicCoordinates = toPublicCoordinates({ lat, lng });
+      const publicAvailability = feature.properties.publicAvailability;
+
+      listings.push({
+        id: feature.properties.id,
+        title: feature.properties.title ?? "",
+        price: Math.max(0, feature.properties.price ?? 0),
+        availableSlots: publicAvailability.openSlots,
+        totalSlots: publicAvailability.totalSlots,
+        images: feature.properties.image ? [feature.properties.image] : [],
+        location: {
+          lat: publicCoordinates.lat,
+          lng: publicCoordinates.lng,
+        },
+        publicAvailability,
+        groupKey: null,
+        groupSummary: null,
+        groupContext: isPublicGroupContext(feature.properties.groupContext)
+          ? feature.properties.groupContext
+          : null,
+        tier: pinTierMap.get(feature.properties.id),
+      });
+
+      return listings;
+    },
+    []
   );
 }

--- a/tests/e2e/journeys/24-listing-management.spec.ts
+++ b/tests/e2e/journeys/24-listing-management.spec.ts
@@ -22,7 +22,7 @@ test.beforeEach(async () => {
 
 // ─── J31: Edit Listing and Verify ─────────────────────────────────────────────
 test.describe("J31: Edit Listing and Verify", () => {
-  test("navigate to own listing → edit → change title + price → save → verify", async ({
+  test("navigate to own listing → edit availability → save → verify", async ({
     page,
     nav,
   }) => {
@@ -66,90 +66,100 @@ test.describe("J31: Edit Listing and Verify", () => {
     await editBtn.first().click();
     await page.waitForLoadState("domcontentloaded");
 
-    // Step 4: Edit title
-    const titleField = page
-      .getByLabel(/title/i)
-      .or(page.locator('input[name="title"]'));
-    if (
-      await titleField
-        .first()
-        .isVisible()
-        .catch(() => false)
-    ) {
-      await titleField.first().clear();
-      await titleField.first().fill("Sunny Mission Room Updated");
-    }
+    // Step 4: Edit the current host-managed availability form
+    const openSlotsField = page
+      .getByLabel(/open slots/i)
+      .or(page.locator("#openSlots"));
+    const totalSlotsField = page
+      .getByLabel(/total slots/i)
+      .or(page.locator("#totalSlots"));
 
-    // Step 5: Save
+    await expect(openSlotsField.first()).toBeVisible({ timeout: 10000 });
+    await expect(totalSlotsField.first()).toBeVisible({ timeout: 10000 });
+
+    const parseSlotValue = async (
+      locator: typeof openSlotsField,
+      fallback: number
+    ) => {
+      const raw = await locator.first().inputValue();
+      const parsed = Number.parseInt(raw, 10);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+
+    const originalOpenSlots = await parseSlotValue(openSlotsField, 1);
+    const originalTotalSlots = await parseSlotValue(totalSlotsField, 2);
+    const editableTotalSlots = Math.max(originalTotalSlots, 2);
+    const updatedOpenSlots =
+      originalOpenSlots >= editableTotalSlots
+        ? Math.max(1, editableTotalSlots - 1)
+        : Math.min(editableTotalSlots, originalOpenSlots + 1);
+    const listingPath = new URL(cardHref, page.url()).pathname;
+
+    if (editableTotalSlots !== originalTotalSlots) {
+      await totalSlotsField.first().clear();
+      await totalSlotsField.first().fill(String(editableTotalSlots));
+    }
+    await openSlotsField.first().clear();
+    await openSlotsField.first().fill(String(updatedOpenSlots));
+
+    // Step 5: Save and verify the versioned availability PATCH succeeds
     const saveBtn = page
       .getByRole("button", { name: /save|update|submit/i })
       .or(page.locator('button[type="submit"]'));
-    if (
-      await saveBtn
-        .first()
-        .isVisible()
-        .catch(() => false)
-    ) {
-      await saveBtn.first().click();
-      await page.waitForLoadState("domcontentloaded");
-    }
+    await expect(saveBtn.first()).toBeVisible({ timeout: 10000 });
 
-    // Step 6: Verify changes
-    const updatedTitle = page.getByText(/Sunny Mission Room Updated/i);
+    const updateResponse = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes(`/api/listings/${listingPath.split("/").pop()}`) &&
+        response.request().method() === "PATCH"
+    );
+
+    await saveBtn.first().click();
+    const response = await updateResponse;
+    expect(response.ok()).toBeTruthy();
+    const updatedListing = await response.json();
+    expect(updatedListing.openSlots).toBe(updatedOpenSlots);
+
     await expect
       .poll(
-        async () => {
-          const hasToast = await page
-            .locator(selectors.toast)
-            .isVisible()
-            .catch(() => false);
-          const hasUpdated = await updatedTitle.isVisible().catch(() => false);
-          return hasToast || hasUpdated;
-        },
-        { timeout: 15000 }
+        () => page.url().includes(listingPath) && !page.url().includes("/edit"),
+        { timeout: 20000 }
       )
       .toBe(true);
 
-    // Restore original title for future test runs
-    const hasUpdated = await updatedTitle.isVisible().catch(() => false);
-    if (hasUpdated) {
-      const editAgain = page
-        .getByRole("link", { name: /edit|manage/i })
-        .or(page.locator('a[href*="/edit"]'));
-      if (
-        await editAgain
-          .first()
-          .isVisible()
-          .catch(() => false)
-      ) {
-        await editAgain.first().click();
-        await page.waitForLoadState("domcontentloaded");
-        const tf = page
-          .getByLabel(/title/i)
-          .or(page.locator('input[name="title"]'));
-        if (
-          await tf
-            .first()
-            .isVisible()
-            .catch(() => false)
-        ) {
-          await tf.first().clear();
-          await tf.first().fill("Sunny Mission Room");
-          const sb = page
-            .getByRole("button", { name: /save|update|submit/i })
-            .or(page.locator('button[type="submit"]'));
-          if (
-            await sb
-              .first()
-              .isVisible()
-              .catch(() => false)
-          ) {
-            await sb.first().click();
-            await page.waitForLoadState("domcontentloaded");
-          }
-        }
-      }
-    }
+    await expect(
+      page.locator('[data-testid="listing-detail-header"]')
+    ).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Restore original availability for future test runs.
+    await page.goto(`${listingPath}/edit`);
+    await page.waitForLoadState("domcontentloaded");
+    await expect(openSlotsField.first()).toBeVisible({ timeout: 10000 });
+    await expect(totalSlotsField.first()).toBeVisible({ timeout: 10000 });
+    await totalSlotsField.first().clear();
+    await totalSlotsField.first().fill(String(originalTotalSlots));
+    await openSlotsField.first().clear();
+    await openSlotsField.first().fill(String(originalOpenSlots));
+
+    const restoreResponse = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes(`/api/listings/${listingPath.split("/").pop()}`) &&
+        response.request().method() === "PATCH"
+    );
+    await saveBtn.first().click();
+    expect((await restoreResponse).ok()).toBeTruthy();
+    await expect
+      .poll(
+        () => page.url().includes(listingPath) && !page.url().includes("/edit"),
+        { timeout: 20000 }
+      )
+      .toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a shared public search/list/map payload sanitizer so browser-visible listing payloads use card-safe fields, coarsened coordinates, and opaque public group identifiers.
- Applies the sanitizer across search API, listings API, SSR search initial data, map/list transforms, and load-more/search scenario paths.
- Updates the public payload PII scanner plus focused regression coverage for search/list/map payload boundaries.

## Why
Public search/list/map payloads could expose exact listing coordinates and raw internal grouping/context keys. This PR treats every discovery payload that reaches the browser as public and sanitizes it at the boundary.

## Commit Scope
- This PR branch was created from `origin/main` and contains one commit only.
- It cherry-picks the local fix commit `0ee61acb` as `c1d35830` so the PR does not include the 11 unrelated local-main commits present under `codex/search-ux-fixes`.

## Verification
- `git diff --check origin/main..HEAD`: passed
- `pnpm run typecheck`: passed on the clean PR branch
- Focused P0 Jest suite: passed, 10 suites / 129 tests
- Earlier staged-patch runtime verification also passed:
  - `pnpm run test:e2e:search-release-gate`: 36 passed / 16 skipped
  - Public payload PII scan: `{"ok":true,"scannedFiles":4}`

## Notes
- The original working tree still has unrelated dirty/untracked files; they are not part of this branch or PR.