### PR TITLE
test: keep host-managed fixtures fresh

### DIFF
--- a/src/__tests__/api/messages-pagination.test.ts
+++ b/src/__tests__/api/messages-pagination.test.ts
@@ -93,6 +93,9 @@ import { GET, POST } from "@/app/api/messages/route";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 // Helper to create mock request using native Request
 function createMockRequest(
   url: string,
@@ -508,7 +511,7 @@ describe("Messages Pagination (P1-03)", () => {
           moveInDate: new Date("2026-05-01T00:00:00.000Z"),
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
         },
       });
     });

--- a/src/__tests__/api/messages.test.ts
+++ b/src/__tests__/api/messages.test.ts
@@ -90,6 +90,9 @@ import { auth } from "@/auth";
 import { checkEmailVerified } from "@/app/actions/suspension";
 import { withRateLimit } from "@/lib/with-rate-limit";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 describe("Messages API", () => {
   const mockSession = {
     user: { id: "user-123", name: "Test User", email: "test@example.com" },
@@ -381,7 +384,7 @@ describe("Messages API", () => {
           moveInDate: new Date("2026-05-01T00:00:00.000Z"),
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
         },
       });
       (prisma.blockedUser.findFirst as jest.Mock).mockResolvedValueOnce({
@@ -412,7 +415,7 @@ describe("Messages API", () => {
           moveInDate: new Date("2026-05-01T00:00:00.000Z"),
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
         },
       });
       (prisma.blockedUser.findFirst as jest.Mock).mockResolvedValueOnce({
@@ -449,7 +452,7 @@ describe("Messages API", () => {
           moveInDate: new Date("2026-05-01T00:00:00.000Z"),
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
           owner: { isSuspended: true },
         },
       });
@@ -483,7 +486,7 @@ describe("Messages API", () => {
           moveInDate: new Date("2026-05-01T00:00:00.000Z"),
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
         },
       };
       const mockMessage = {
@@ -545,7 +548,7 @@ describe("Messages API", () => {
           moveInDate: new Date("2026-05-01T00:00:00.000Z"),
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
         },
       });
       (prisma.message.create as jest.Mock).mockResolvedValue({

--- a/src/__tests__/api/payments-checkout-route.test.ts
+++ b/src/__tests__/api/payments-checkout-route.test.ts
@@ -105,6 +105,9 @@ const mockedFeatures = features as {
   disablePayments: boolean;
 };
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 describe("POST /api/payments/checkout", () => {
   const originalNodeEnv = process.env.NODE_ENV;
 
@@ -143,7 +146,7 @@ describe("POST /api/payments/checkout", () => {
       moveInDate: new Date("2026-05-01T00:00:00.000Z"),
       availableUntil: null,
       minStayMonths: 1,
-      lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+      lastConfirmedAt: freshLastConfirmedAt(),
     });
     mockEvaluateMessageStartPaywall.mockResolvedValue({
       summary: {

--- a/src/__tests__/lib/contact/phone-reveal.test.ts
+++ b/src/__tests__/lib/contact/phone-reveal.test.ts
@@ -31,6 +31,9 @@ import {
   revealHostPhoneForListing,
 } from "@/lib/contact/phone-reveal";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 function buildClient() {
   const client = {
     listing: {
@@ -77,7 +80,7 @@ const activeListing = {
   moveInDate: new Date("2026-05-01T00:00:00.000Z"),
   availableUntil: null,
   minStayMonths: 1,
-  lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+  lastConfirmedAt: freshLastConfirmedAt(),
   owner: {
     isSuspended: false,
   },

--- a/src/__tests__/lib/geocoding/public-autocomplete.test.ts
+++ b/src/__tests__/lib/geocoding/public-autocomplete.test.ts
@@ -22,6 +22,9 @@ import {
   tokenizePublicAutocompleteText,
 } from "@/lib/geocoding/public-autocomplete";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 describe("public autocomplete", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -83,7 +86,7 @@ describe("public autocomplete", () => {
         moveInDate: new Date("2026-05-01T00:00:00.000Z"),
         availableUntil: null,
         minStayMonths: 1,
-        lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+        lastConfirmedAt: freshLastConfirmedAt(),
         status: "ACTIVE",
         statusReason: null,
         needsMigrationReview: false,
@@ -110,7 +113,7 @@ describe("public autocomplete", () => {
         moveInDate: new Date("2026-05-01T00:00:00.000Z"),
         availableUntil: null,
         minStayMonths: 1,
-        lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+        lastConfirmedAt: freshLastConfirmedAt(),
         status: "ACTIVE",
         statusReason: null,
         needsMigrationReview: false,
@@ -128,7 +131,7 @@ describe("public autocomplete", () => {
         moveInDate: new Date("2026-05-01T00:00:00.000Z"),
         availableUntil: null,
         minStayMonths: 1,
-        lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+        lastConfirmedAt: freshLastConfirmedAt(),
         status: "ACTIVE",
         statusReason: null,
         needsMigrationReview: false,
@@ -164,7 +167,7 @@ describe("public autocomplete", () => {
         moveInDate: new Date("2026-05-01T00:00:00.000Z"),
         availableUntil: null,
         minStayMonths: 1,
-        lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+        lastConfirmedAt: freshLastConfirmedAt(),
         status: "ACTIVE",
         statusReason: null,
         needsMigrationReview: true,

--- a/src/__tests__/lib/messaging/listing-contactable.test.ts
+++ b/src/__tests__/lib/messaging/listing-contactable.test.ts
@@ -6,6 +6,9 @@ import {
   LISTING_NOT_FOUND_MESSAGE,
 } from "@/lib/messaging/listing-contactable";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 const contactableListing = {
   status: "ACTIVE" as const,
   availabilitySource: "HOST_MANAGED" as const,
@@ -15,7 +18,7 @@ const contactableListing = {
   moveInDate: new Date("2026-05-01T00:00:00.000Z"),
   availableUntil: null,
   minStayMonths: 1,
-  lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+  lastConfirmedAt: freshLastConfirmedAt(),
   statusReason: null,
   needsMigrationReview: false,
 };

--- a/src/__tests__/lib/search-alerts-telemetry.test.ts
+++ b/src/__tests__/lib/search-alerts-telemetry.test.ts
@@ -75,6 +75,9 @@ import {
   triggerInstantAlerts,
 } from "@/lib/search-alerts";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 describe("search-alerts telemetry routing", () => {
   const mockUser = {
     id: "user-123",
@@ -129,7 +132,7 @@ describe("search-alerts telemetry routing", () => {
         moveInDate: new Date("2026-05-01T00:00:00.000Z"),
         availableUntil: null,
         minStayMonths: 1,
-        lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+        lastConfirmedAt: freshLastConfirmedAt(),
       },
     ]);
     (prisma.listing.findUnique as jest.Mock).mockResolvedValue({
@@ -146,7 +149,7 @@ describe("search-alerts telemetry routing", () => {
       moveInDate: new Date("2026-05-01T00:00:00.000Z"),
       availableUntil: null,
       minStayMonths: 1,
-      lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+      lastConfirmedAt: freshLastConfirmedAt(),
     });
     (prisma.alertSubscription.upsert as jest.Mock).mockResolvedValue({
       id: "subscription-123",

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -355,6 +355,9 @@ const BOUNDS = {
   maxLng: -122.35,
 };
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 function makeListingData(overrides: Partial<ListingData> = {}): ListingData {
   const listing = {
     id: "listing-1",
@@ -508,7 +511,7 @@ function setupDefaultMocks({
         moveInDate: new Date("2026-05-01T00:00:00.000Z"),
         availableUntil: null,
         minStayMonths: 1,
-        lastConfirmedAt: new Date("2026-04-20T00:00:00.000Z"),
+        lastConfirmedAt: freshLastConfirmedAt(),
       }));
     }
   );

--- a/src/__tests__/lib/search/unbounded-browse-protection.test.ts
+++ b/src/__tests__/lib/search/unbounded-browse-protection.test.ts
@@ -50,6 +50,9 @@ import {
 
 const mockExecuteRawUnsafe = prisma.$executeRawUnsafe as jest.Mock;
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
+
 // Helper to create mock listing data
 function createMockSearchDocRow(id: string, overrides = {}) {
   return {
@@ -64,7 +67,7 @@ function createMockSearchDocRow(id: string, overrides = {}) {
     openSlots: 2,
     availableUntil: null,
     minStayMonths: 1,
-    lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+    lastConfirmedAt: freshLastConfirmedAt(),
     status: "ACTIVE",
     statusReason: null,
     needsMigrationReview: false,
@@ -226,7 +229,7 @@ describe("Unbounded Browse Protection", () => {
           openSlots: 2,
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
           status: "ACTIVE",
           statusReason: null,
           needsMigrationReview: false,
@@ -278,7 +281,7 @@ describe("Unbounded Browse Protection", () => {
           openSlots: 2,
           availableUntil: null,
           minStayMonths: 1,
-          lastConfirmedAt: new Date("2026-04-20T12:00:00.000Z"),
+          lastConfirmedAt: freshLastConfirmedAt(),
           status: "ACTIVE",
           statusReason: null,
           needsMigrationReview: false,


### PR DESCRIPTION
## What changed
- Replaced stale fixed `lastConfirmedAt: 2026-04-20` host-managed test fixtures with fresh relative timestamps in API, messaging, search, phone reveal, and public autocomplete tests.
- Kept explicit stale/unavailable test cases intact.

## Why it is safe
- Test-only change. No production code, schema, dependency, or runtime behavior changes.
- Root cause: on May 18, 2026 the fixed April 20 fixtures are beyond the 21-day freshness threshold, so availability gates/filtering run before the behavior under test.
- This fixes the Unit Tests and API & Action Tests blockers currently affecting PR #127.

## Verification
- `CI=true pnpm test -- src/__tests__/api/messages.test.ts src/__tests__/api/messages-pagination.test.ts src/__tests__/api/payments-checkout-route.test.ts --runInBand`
- `CI=true pnpm test -- src/__tests__/lib/search/search-v2-service.test.ts src/__tests__/lib/search/unbounded-browse-protection.test.ts src/__tests__/lib/search-alerts-telemetry.test.ts --runInBand`
- `CI=true pnpm test -- src/__tests__/lib/messaging/listing-contactable.test.ts --runInBand`
- `CI=true pnpm test -- src/__tests__/lib/contact/phone-reveal.test.ts src/__tests__/lib/geocoding/public-autocomplete.test.ts --runInBand`
- `CI=true NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=8192" pnpm jest --ci --maxWorkers=2 --coverage --testPathPatterns="src/__tests__/lib/" --testPathPatterns="src/__tests__/hooks/" --testPathIgnorePatterns="filter-regression|test-utils"`
- `CI=true NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=8192" pnpm jest --ci --maxWorkers=2 --testPathPatterns="src/__tests__/api/" --testPathIgnorePatterns="facets"`
- `CI=true NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=8192" pnpm jest --ci --maxWorkers=1 --testPathPatterns="src/__tests__/api/search/facets/"`
- `CI=true NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=8192" pnpm jest --ci --maxWorkers=2 --testPathPatterns="src/__tests__/actions/"`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

## Risks / rollback
- Low risk: fixture-only freshness changes. Roll back by reverting this commit if needed.

## Related files
- `src/__tests__/api/messages*.test.ts`
- `src/__tests__/api/payments-checkout-route.test.ts`
- `src/__tests__/lib/**` affected host-managed availability tests