### PR TITLE
fix(db): preserve transaction client binding

### DIFF
--- a/src/__tests__/lib/db/with-actor.test.ts
+++ b/src/__tests__/lib/db/with-actor.test.ts
@@ -32,6 +32,28 @@ function makeMockClient(throwInTx?: unknown) {
 }
 
 describe("withActor — unit (mock client)", () => {
+  it("preserves the client binding when invoking $transaction", async () => {
+    const stubTx = {
+      $executeRaw: jest.fn().mockResolvedValue(0),
+    };
+    const client = {
+      bindingProbe: "expected-this",
+      $transaction: jest.fn(function (
+        this: { bindingProbe: string },
+        fn: (tx: typeof stubTx) => Promise<unknown>
+      ) {
+        if (this.bindingProbe !== "expected-this") {
+          throw new Error("$transaction lost client binding");
+        }
+        return fn(stubTx);
+      }),
+    };
+
+    await expect(
+      withActor(hostActor(), async () => "ok", { client: client as never })
+    ).resolves.toBe("ok");
+  });
+
   it("re-throws non-object errors (e.g. strings) without wrapping", async () => {
     // Covers isModerationLockedError's early-return false branch (line 27):
     // `!error || typeof error !== "object"` → return false → error is re-thrown as-is.

--- a/src/__tests__/lib/search-alerts-telemetry.test.ts
+++ b/src/__tests__/lib/search-alerts-telemetry.test.ts
@@ -76,6 +76,9 @@ import {
 } from "@/lib/search-alerts";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const FUTURE_MOVE_IN_DATE = new Date(Date.now() + 30 * ONE_DAY_MS)
+  .toISOString()
+  .slice(0, 10);
 const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
 
 describe("search-alerts telemetry routing", () => {
@@ -176,7 +179,7 @@ describe("search-alerts telemetry routing", () => {
       {
         ...baseSavedSearch,
         filters: {
-          startDate: "2026-06-01",
+          startDate: FUTURE_MOVE_IN_DATE,
           minBudget: 500,
           maxBudget: 1500,
           where: "Brooklyn",
@@ -228,7 +231,7 @@ describe("search-alerts telemetry routing", () => {
       {
         ...baseSavedSearch,
         filters: {
-          moveInDate: "2026-06-01",
+          moveInDate: FUTURE_MOVE_IN_DATE,
           minPrice: 500,
           maxPrice: 1500,
           city: "New York",
@@ -286,7 +289,7 @@ describe("search-alerts telemetry routing", () => {
         ...baseSavedSearch,
         alertFrequency: "INSTANT" as const,
         filters: {
-          startDate: "2026-06-01",
+          startDate: FUTURE_MOVE_IN_DATE,
           minBudget: 500,
           maxBudget: 1500,
           city: "New York",
@@ -318,7 +321,7 @@ describe("search-alerts telemetry routing", () => {
         ...baseSavedSearch,
         alertFrequency: "INSTANT" as const,
         filters: {
-          moveInDate: "2026-06-01",
+          moveInDate: FUTURE_MOVE_IN_DATE,
           minPrice: 500,
           maxPrice: 1500,
           city: "New York",

--- a/src/lib/db/with-actor.ts
+++ b/src/lib/db/with-actor.ts
@@ -81,7 +81,7 @@ export async function withActor<T>(
   }
 ): Promise<T> {
   const client = options?.client ?? prisma;
-  const transaction = client.$transaction as <R>(
+  const transaction = client.$transaction.bind(client) as <R>(
     fn: (tx: TransactionClient) => Promise<R>,
     options?: Record<string, unknown>
   ) => Promise<R>;


### PR DESCRIPTION
## Summary
- Bind the transaction host before invoking `withActor()` transactions so Prisma keeps its required client context.
- Add a regression test that fails when `$transaction` loses its `this` binding.

## Why
Staging outbox projection drain was retrying every `GEOCODE_NEEDED` event with `Cannot read properties of undefined (reading '_engineConfig')`. The root cause was `withActor()` storing `client.$transaction` as an unbound function before calling it.

## Verification
- `pnpm test -- src/__tests__/lib/db/with-actor.test.ts --runInBand`
- `pnpm test -- src/__tests__/lib/outbox/drain.test.ts --runInBand`
- `pnpm typecheck`
- Staging validation after fix: 9 geocode events completed, 7 inventory projection events completed, 0 retries/DLQ, 7 staged listings published.

## Notes
Unrelated local artifacts in the worktree were not included in this PR. Staging DB migration-history drift remains a separate approval-gated follow-up.