### PR TITLE
test: stabilize search smoke seed contract

### DIFF
--- a/scripts/seed-e2e.js
+++ b/scripts/seed-e2e.js
@@ -389,6 +389,11 @@ async function upsertListingWithLocation(ownerId, seed) {
       availableSlots: seed.availableSlots || 1,
       openSlots: seed.openSlots ?? seed.availableSlots ?? 1,
       moveInDate: new Date(seed.moveInDate),
+      status: seed.status ?? 'ACTIVE',
+      statusReason: seed.statusReason ?? null,
+      lastConfirmedAt: seed.lastConfirmedAt
+        ? new Date(seed.lastConfirmedAt)
+        : new Date(),
       images: seed.images || DEFAULT_IMAGES,
       createdAt: new Date(seed.createdAt),
       location: {
@@ -423,6 +428,11 @@ async function upsertListingWithLocation(ownerId, seed) {
       availableSlots: seed.availableSlots || 1,
       openSlots: seed.openSlots ?? seed.availableSlots ?? 1,
       moveInDate: new Date(seed.moveInDate),
+      status: seed.status ?? 'ACTIVE',
+      statusReason: seed.statusReason ?? null,
+      lastConfirmedAt: seed.lastConfirmedAt
+        ? new Date(seed.lastConfirmedAt)
+        : new Date(),
       images: seed.images || DEFAULT_IMAGES,
       createdAt: new Date(seed.createdAt),
       location: {
@@ -1372,10 +1382,42 @@ async function main() {
         SELECT COUNT(*)::int AS count FROM listing_search_docs
       `;
       console.log(`  ✓ listing_search_docs backfilled: ${countResult[0].count} rows`);
+
+      const missionContract = await prisma.$queryRaw`
+        SELECT
+          listing_search_docs.status,
+          listing_search_docs.search_tsv @@ plainto_tsquery('english', 'Mission') AS "missionMatches",
+          (
+            "lastConfirmedAt" IS NULL
+            OR "lastConfirmedAt" > NOW() - INTERVAL '21 days'
+          ) AS "freshnessMatches"
+        FROM listing_search_docs
+        JOIN "Listing" ON "Listing".id = listing_search_docs.id
+        WHERE listing_search_docs.id = 'e2e-sf-1-sunny-mission-room'
+        LIMIT 1
+      `;
+      const missionRow = missionContract[0];
+      if (
+        !missionRow ||
+        missionRow.status !== 'ACTIVE' ||
+        missionRow.missionMatches !== true ||
+        missionRow.freshnessMatches !== true
+      ) {
+        throw new Error(
+          [
+            'E2E seed search contract failed: Sunny Mission Room must be ACTIVE, fresh, and match Mission',
+            `(got status=${missionRow?.status ?? 'missing'}, missionMatches=${missionRow?.missionMatches ?? 'missing'}, freshnessMatches=${missionRow?.freshnessMatches ?? 'missing'})`,
+          ].join(' ')
+        );
+      }
+      console.log('  ✓ Search smoke contract verified: Mission finds Sunny Mission Room');
     } else {
       console.log('  ⚠ listing_search_docs table does not exist — skipping backfill (run prisma migrate deploy first)');
     }
   } catch (err) {
+    if (err.message?.startsWith('E2E seed search contract failed:')) {
+      throw err;
+    }
     console.error('  ⚠ listing_search_docs backfill failed:', err.message);
     // Non-fatal: tests may still partially work without it
   }

--- a/tests/e2e/hydration-console.anon.spec.ts
+++ b/tests/e2e/hydration-console.anon.spec.ts
@@ -41,6 +41,10 @@ function expectNoHydrationFailures(failures: string[]) {
   expect(failures).toEqual([]);
 }
 
+function visibleForm(page: Page, testId: "login-form") {
+  return page.locator(`[data-testid="${testId}"]:visible`).first();
+}
+
 test.describe("Hydration console guard", () => {
   test("login renders without React hydration mismatch errors", async ({
     page,
@@ -48,14 +52,17 @@ test.describe("Hydration console guard", () => {
     const failures = captureHydrationFailures(page);
 
     await page.goto("/login");
-    const loginForm = page.getByTestId("login-form");
+    const loginForm = visibleForm(page, "login-form");
     await expect(loginForm).toBeAttached();
+    await expect(loginForm).toHaveAttribute("data-hydrated", "true", {
+      timeout: 15_000,
+    });
     await expect(loginForm).toHaveAttribute("method", "post");
     await expect(loginForm).toHaveAttribute(
       "data-turnstile-enabled",
       /^(true|false)$/
     );
-    await expect(page.locator('input[name="password"]')).toHaveAttribute(
+    await expect(loginForm.locator('input[name="password"]')).toHaveAttribute(
       "name",
       "password"
     );

--- a/tests/e2e/search-p0-smoke.anon.spec.ts
+++ b/tests/e2e/search-p0-smoke.anon.spec.ts
@@ -102,7 +102,7 @@ test.describe("Search P0 Smoke Suite", () => {
 
   // S02: Text query shows matching results
   test("S02: text query shows matching results", async ({ page }) => {
-    await page.goto(`/search?q=Mission&${boundsQS}`);
+    await page.goto(`/search?what=Mission&${boundsQS}`);
 
     const container = searchResultsContainer(page);
     const cards = container.locator('[data-testid="listing-card"]');
@@ -111,12 +111,12 @@ test.describe("Search P0 Smoke Suite", () => {
     const count = await cards.count();
     expect(count).toBeGreaterThanOrEqual(1);
 
-    // At least one card should contain the query text "Mission"
+    // Seed contract: Mission text search must expose the public Mission fixture.
     const allCardTexts = await cards.allTextContents();
-    const hasMission = allCardTexts.some((text) =>
-      text.toLowerCase().includes("mission")
+    const hasSunnyMissionRoom = allCardTexts.some((text) =>
+      text.toLowerCase().includes("sunny mission room")
     );
-    expect(hasMission).toBe(true);
+    expect(hasSunnyMissionRoom).toBe(true);
   });
 
   // S03: Price filter narrows results


### PR DESCRIPTION
## Summary
- reset deterministic SF seed listings back to active, fresh public-searchable state on each E2E seed run
- add a fail-fast Mission search seed contract check for Sunny Mission Room
- update S02 to use the current text-search param (`what=Mission`) and assert the exact fixture

## Verification
- `node scripts/seed-e2e.js`
- `node --check scripts/seed-e2e.js`
- `pnpm playwright test tests/e2e/search-p0-smoke.anon.spec.ts --grep="S02" --project=chromium-anon`
- `pnpm playwright test tests/e2e/search-p0-smoke.anon.spec.ts --project=chromium-anon`
- `pnpm typecheck`
- `pnpm playwright test tests/e2e/hydration-console.anon.spec.ts --project=chromium-anon`
- `git diff --check`