### PR TITLE
fix: stabilize vercel production build config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '20'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -35,8 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -67,8 +63,6 @@ jobs:
         run: |
           bash .github/scripts/install-pgvector.sh
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -90,8 +84,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -114,8 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -132,8 +122,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -155,8 +143,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -180,8 +166,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -201,8 +185,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -217,8 +199,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -236,8 +216,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: '20'
         cache: 'pnpm'
 
     - name: Install dependencies

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,12 +20,10 @@ jobs:
     - uses: actions/checkout@v6
 
     - uses: pnpm/action-setup@v6
-      with:
-        version: 10
 
     - uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'pnpm'
 
     - name: Install dependencies

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 concurrency:
   group: lighthouse-${{ github.ref }}
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '20'
 
 concurrency:
   group: lighthouse-${{ github.ref }}

--- a/.github/workflows/playwright-search-release-gate.yml
+++ b/.github/workflows/playwright-search-release-gate.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 jobs:
   search-release-gate:
@@ -73,8 +73,6 @@ jobs:
           bash .github/scripts/install-pgvector.sh
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/playwright-search-release-gate.yml
+++ b/.github/workflows/playwright-search-release-gate.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: "22"
+  NODE_VERSION: "20"
 
 jobs:
   search-release-gate:

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   smoke:
@@ -57,8 +57,6 @@ jobs:
           bash .github/scripts/install-pgvector.sh
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '20'
 
 jobs:
   smoke:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -91,10 +91,7 @@ jobs:
       - name: Install pgvector extension in PostgreSQL
         run: |
           bash .github/scripts/install-pgvector.sh
-
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:
@@ -180,8 +177,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '20'
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '20'
 
 jobs:
   stability-e2e:

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   stability-e2e:
@@ -66,8 +66,6 @@ jobs:
           bash .github/scripts/install-pgvector.sh
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/next.config.ts
+++ b/next.config.ts
@@ -278,12 +278,17 @@ const nextConfig: NextConfig = {
 
 let exportedConfig = nextConfig;
 
-// Only wrap with Sentry when credentials are available (skip in CI E2E runs)
+// Only wrap with Sentry when the build plugin is explicitly enabled.
+// Runtime Sentry capture remains controlled by SENTRY_DSN in sentry.*.config.ts.
+const isSentryBuildPluginEnabled =
+  process.env.SENTRY_ENABLE_BUILD_PLUGIN === "1";
 const hasSentryCredentials = !!(
-  process.env.SENTRY_ORG && process.env.SENTRY_PROJECT
+  process.env.SENTRY_ORG &&
+  process.env.SENTRY_PROJECT &&
+  process.env.SENTRY_AUTH_TOKEN
 );
 
-if (isSentryEnabled && hasSentryCredentials) {
+if (isSentryBuildPluginEnabled && hasSentryCredentials) {
   const { withSentryConfig } = require("@sentry/nextjs");
 
   exportedConfig = withSentryConfig(nextConfig, {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "sideEffects": false,
+  "packageManager": "pnpm@10.27.0",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "postinstall": "prisma generate",
     "dev": "node scripts/run-dev.js",


### PR DESCRIPTION
## Summary
- Pin Vercel production runtime selection with engines.node: 22.x.
- Pin package manager selection with packageManager: pnpm@10.27.0.
- Gate Sentry build-time wrapping behind SENTRY_ENABLE_BUILD_PLUGIN=1 plus org/project/auth token, while leaving runtime Sentry behavior controlled by SENTRY_DSN.
- Update GitHub Actions pnpm setup to read the pnpm version from packageManager instead of also passing version: 10; CI Node runtime is otherwise unchanged.

## Verification
- Local pnpm typecheck passed.
- Local pnpm build passed.
- Production-like local build with Sentry env present and SENTRY_ENABLE_BUILD_PLUGIN unset passed.
- Vercel preview is READY for eb4e653: dpl_BwMtHjELziSwW8BKpmZH42fNs4xN.
- Vercel build logs show Node 22.x selected from package.json and pnpm 10.27.0 selected from packageManager.
- Preview /api/health/live returns 200 with version eb4e653.
- GitHub checks are green, including CI, Vercel, search gates, Lighthouse, stability, and all Playwright shards.

## Known follow-up
- Preview /api/health/ready still returns 500 due to runtime dependency/config health, not the Vercel build crash. Logs show missing Redis config and database reachability errors in preview. This should be fixed before declaring the release fully runtime-ready.
