### PR TITLE
Fix preview web-vitals origin cleanliness

### DIFF
--- a/src/__tests__/api/web-vitals.test.ts
+++ b/src/__tests__/api/web-vitals.test.ts
@@ -1,0 +1,114 @@
+const mockCheckMetricsRateLimit = jest
+  .fn()
+  .mockResolvedValue({ success: true });
+const mockGetClientIP = jest.fn().mockReturnValue("127.0.0.1");
+const mockLoggerSyncError = jest.fn();
+const mockCaptureException = jest.fn();
+
+jest.mock("@/lib/rate-limit-redis", () => ({
+  checkMetricsRateLimit: (...args: unknown[]) =>
+    mockCheckMetricsRateLimit(...args),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  getClientIP: (...args: unknown[]) => mockGetClientIP(...args),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    sync: {
+      error: (...args: unknown[]) => mockLoggerSyncError(...args),
+    },
+  },
+  sanitizeErrorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+jest.mock(
+  "@sentry/nextjs",
+  () => ({
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+  }),
+  { virtual: true }
+);
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (
+      data: unknown,
+      init?: { status?: number; headers?: Record<string, string> }
+    ) => {
+      const status = init?.status ?? 200;
+      return new Response(JSON.stringify(data), {
+        status,
+        headers: {
+          "content-type": "application/json",
+          ...(init?.headers ?? {}),
+        },
+      });
+    },
+  },
+}));
+
+import { POST } from "@/app/api/web-vitals/route";
+
+const VALID_PAYLOAD = {
+  id: "vital-123",
+  name: "LCP",
+  value: 1200,
+  rating: "good",
+  delta: 1200,
+  navigationType: "navigate",
+  pathname: "/search",
+  timestamp: 1780552000000,
+};
+
+function makeRequest(origin: string): Request {
+  return new Request(`${origin}/api/web-vitals`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin,
+    },
+    body: JSON.stringify(VALID_PAYLOAD),
+  });
+}
+
+describe("POST /api/web-vitals", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ALLOWED_ORIGINS;
+    delete process.env.ALLOWED_HOSTS;
+    process.env.VERCEL_URL = "roomshare-random.vercel.app";
+    (process.env as any).NODE_ENV = "production";
+    mockCheckMetricsRateLimit.mockResolvedValue({ success: true });
+    mockGetClientIP.mockReturnValue("127.0.0.1");
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("accepts valid same-origin metrics from the exact Vercel deployment URL", async () => {
+    const response = await POST(
+      makeRequest("https://roomshare-random.vercel.app")
+    );
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(response.status).toBe(200);
+    expect(mockCheckMetricsRateLimit).toHaveBeenCalledWith("127.0.0.1");
+  });
+
+  it("rejects metrics from unknown Vercel preview origins", async () => {
+    const response = await POST(
+      makeRequest("https://other-preview.vercel.app")
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(response.status).toBe(403);
+    expect(mockCheckMetricsRateLimit).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/origin-guard.test.ts
+++ b/src/__tests__/lib/origin-guard.test.ts
@@ -9,6 +9,7 @@ describe("origin-guard", () => {
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...ORIGINAL_ENV };
+    delete process.env.VERCEL_URL;
   });
 
   afterAll(() => {
@@ -40,6 +41,19 @@ describe("origin-guard", () => {
       const { getAllowedOrigins } = await import("@/lib/origin-guard");
       expect(getAllowedOrigins()).toEqual([]);
     });
+
+    it("adds the exact Vercel deployment origin when VERCEL_URL is set", async () => {
+      process.env.ALLOWED_ORIGINS = "https://example.com";
+      process.env.VERCEL_URL = "roomshare-random.vercel.app";
+      (process.env as any).NODE_ENV = "production";
+
+      const { getAllowedOrigins } = await import("@/lib/origin-guard");
+
+      expect(getAllowedOrigins()).toEqual([
+        "https://example.com",
+        "https://roomshare-random.vercel.app",
+      ]);
+    });
   });
 
   describe("isOriginAllowed", () => {
@@ -63,6 +77,19 @@ describe("origin-guard", () => {
       const { isOriginAllowed } = await import("@/lib/origin-guard");
       expect(isOriginAllowed(null)).toBe(false);
     });
+
+    it("allows only the exact Vercel deployment origin from VERCEL_URL", async () => {
+      delete process.env.ALLOWED_ORIGINS;
+      process.env.VERCEL_URL = "roomshare-random.vercel.app";
+      (process.env as any).NODE_ENV = "production";
+
+      const { isOriginAllowed } = await import("@/lib/origin-guard");
+
+      expect(isOriginAllowed("https://roomshare-random.vercel.app")).toBe(
+        true
+      );
+      expect(isOriginAllowed("https://other-preview.vercel.app")).toBe(false);
+    });
   });
 
   describe("getAllowedHosts", () => {
@@ -71,6 +98,19 @@ describe("origin-guard", () => {
       (process.env as any).NODE_ENV = "production";
       const { getAllowedHosts } = await import("@/lib/origin-guard");
       expect(getAllowedHosts()).toEqual(["example.com", "api.example.com"]);
+    });
+
+    it("adds the exact Vercel deployment host when VERCEL_URL is set", async () => {
+      process.env.ALLOWED_HOSTS = "example.com";
+      process.env.VERCEL_URL = "roomshare-random.vercel.app";
+      (process.env as any).NODE_ENV = "production";
+
+      const { getAllowedHosts } = await import("@/lib/origin-guard");
+
+      expect(getAllowedHosts()).toEqual([
+        "example.com",
+        "roomshare-random.vercel.app",
+      ]);
     });
   });
 
@@ -102,6 +142,18 @@ describe("origin-guard", () => {
       (process.env as any).NODE_ENV = "development";
       const { isHostAllowed } = await import("@/lib/origin-guard");
       expect(isHostAllowed("localhost")).toBe(true);
+    });
+
+    it("allows only the exact Vercel deployment host from VERCEL_URL", async () => {
+      delete process.env.ALLOWED_HOSTS;
+      process.env.VERCEL_URL = "roomshare-random.vercel.app";
+      (process.env as any).NODE_ENV = "production";
+
+      const { isHostAllowed } = await import("@/lib/origin-guard");
+
+      expect(isHostAllowed("roomshare-random.vercel.app")).toBe(true);
+      expect(isHostAllowed("roomshare-random.vercel.app:443")).toBe(true);
+      expect(isHostAllowed("other-preview.vercel.app")).toBe(false);
     });
   });
 });

--- a/src/lib/origin-guard.ts
+++ b/src/lib/origin-guard.ts
@@ -3,12 +3,25 @@
  * Used by: chat, agent, metrics routes.
  */
 
+function getVercelDeploymentHost(): string | null {
+  const rawUrl = process.env.VERCEL_URL?.trim();
+  if (!rawUrl) return null;
+
+  const withoutProtocol = rawUrl.replace(/^https?:\/\//i, "");
+  const host = withoutProtocol.split("/")[0]?.trim();
+  return host || null;
+}
+
 export function getAllowedOrigins(): string[] {
   const origins = process.env.ALLOWED_ORIGINS || "";
   const parsed = origins
     .split(",")
     .map((o) => o.trim())
     .filter(Boolean);
+  const vercelHost = getVercelDeploymentHost();
+  if (vercelHost) {
+    parsed.push(`https://${vercelHost}`);
+  }
   if (process.env.NODE_ENV === "development") {
     parsed.push("http://localhost:3000");
   }
@@ -21,6 +34,10 @@ export function getAllowedHosts(): string[] {
     .split(",")
     .map((h) => h.trim())
     .filter(Boolean);
+  const vercelHost = getVercelDeploymentHost();
+  if (vercelHost) {
+    parsed.push(vercelHost);
+  }
   if (process.env.NODE_ENV === "development") {
     parsed.push("localhost:3000", "localhost");
   }


### PR DESCRIPTION
## Summary
- Allow the exact current Vercel deployment host/origin from `VERCEL_URL` in the origin guard.
- Keep explicit `ALLOWED_ORIGINS` and `ALLOWED_HOSTS` behavior unchanged.
- Do not add wildcard Vercel domains or change map/search behavior.
- Add regression coverage for `/api/web-vitals` accepting the exact same-origin preview URL while rejecting unknown preview origins.

## Verification
- `pnpm test -- src/__tests__/lib/origin-guard.test.ts --runInBand` ✅
- `pnpm test -- src/__tests__/api/web-vitals.test.ts --runInBand` ✅
- `pnpm typecheck` ✅
- Vercel GitHub preview for commit `8456747` reached `READY` ✅
- `/api/health/live` returned `200` with version `8456747` ✅

## Preview env status
The branch-scoped staging Preview env values still need to be entered manually in Vercel for `codex/fix-preview-web-vitals-cleanliness` before final staging sign-off. The Vercel CLI can list the existing `Preview (staging)` env names, but `vercel env pull --git-branch=staging` returned empty values for encrypted variables in this auth context, so I did not have real secret values to copy.

Current runtime evidence: `/api/health/ready` on the fresh PR preview returns `500`; Vercel runtime logs show `DATABASE_URL is not configured`. I removed the blank branch-scoped env entries that were created during the attempted copy so they do not mask the real configuration.

## Map/search note
The earlier `MAP_QUERY_FAILED` came from unsupported smoke input using `bounds=`. The supported verification URL is `/api/search/v2?what=Mission&minLat=37.570&maxLat=37.980&minLng=-122.638&maxLng=-122.201`.