### PR TITLE
fix(security): gate all admin read pages on suspended-aware requireAdminAuth

### DIFF
--- a/src/__tests__/app/admin/admin-suspended-guard.test.tsx
+++ b/src/__tests__/app/admin/admin-suspended-guard.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Regression guard: every /admin read page must gate access through the
+ * suspended-aware requireAdminAuth() helper, not a raw isAdmin check.
+ *
+ * Before this fix, several pages did their own
+ * `prisma.user.findUnique({ select: { isAdmin: true } })` (or trusted the stale
+ * JWT `session.user.isAdmin`) and never checked `isSuspended`, so a suspended
+ * admin could still load admin views. These tests drive the real
+ * requireAdminAuth() against a suspended admin and assert the page redirects to
+ * "/". A page that skips the helper would never see the suspended flag and would
+ * fall through instead of redirecting — failing this test.
+ */
+import "@testing-library/jest-dom";
+
+const mockRedirect = jest.fn((destination: string) => {
+  throw new Error(`REDIRECT:${destination}`);
+});
+
+jest.mock("next/navigation", () => ({
+  redirect: (destination: string) => mockRedirect(destination),
+}));
+
+jest.mock("@/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+  },
+}));
+
+// Client child components are never rendered (the guard redirects first), but
+// their modules load when the page modules import them — stub to keep load clean.
+jest.mock("@/app/admin/users/UserList", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/app/admin/listings/ListingList", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/app/admin/verifications/VerificationList", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import AdminDashboard from "@/app/admin/page";
+import AdminUsersPage from "@/app/admin/users/page";
+import AdminListingsPage from "@/app/admin/listings/page";
+import AuditLogPage from "@/app/admin/audit/page";
+import VerificationsPage from "@/app/admin/verifications/page";
+import AdminBookingsRedirectPage from "@/app/admin/bookings/page";
+import AdminBookingDetailRedirectPage from "@/app/admin/bookings/[id]/page";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+type AdminPageComponent = (props: {
+  searchParams: Promise<Record<string, string>>;
+}) => Promise<unknown>;
+
+const adminPages: Array<{ name: string; Page: AdminPageComponent }> = [
+  { name: "/admin (dashboard)", Page: AdminDashboard as unknown as AdminPageComponent },
+  { name: "/admin/users", Page: AdminUsersPage as unknown as AdminPageComponent },
+  { name: "/admin/listings", Page: AdminListingsPage as unknown as AdminPageComponent },
+  { name: "/admin/audit", Page: AuditLogPage as unknown as AdminPageComponent },
+  { name: "/admin/verifications", Page: VerificationsPage as unknown as AdminPageComponent },
+  { name: "/admin/bookings", Page: AdminBookingsRedirectPage as unknown as AdminPageComponent },
+  {
+    name: "/admin/bookings/[id]",
+    Page: AdminBookingDetailRedirectPage as unknown as AdminPageComponent,
+  },
+];
+
+describe("admin read pages gate on suspended status", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as jest.Mock).mockResolvedValue({ user: { id: "admin-1" } });
+  });
+
+  describe.each(adminPages)("$name", ({ Page }) => {
+    it("redirects a suspended admin to /", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        isAdmin: true,
+        isSuspended: true,
+      });
+
+      await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+        "REDIRECT:/"
+      );
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+    });
+
+    it("redirects a logged-out visitor to login", async () => {
+      (auth as jest.Mock).mockResolvedValue(null);
+
+      await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+        /^REDIRECT:\/login/
+      );
+    });
+
+    it("redirects a non-admin user to /", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        isAdmin: false,
+        isSuspended: false,
+      });
+
+      await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+        "REDIRECT:/"
+      );
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+    });
+  });
+});

--- a/src/__tests__/app/admin/admin-suspended-guard.test.tsx
+++ b/src/__tests__/app/admin/admin-suspended-guard.test.tsx
@@ -80,6 +80,9 @@ describe("admin read pages gate on suspended status", () => {
 
   describe.each(adminPages)("$name", ({ Page }) => {
     it("redirects a suspended admin to /", async () => {
+      (auth as jest.Mock).mockResolvedValue({
+        user: { id: "admin-1", isAdmin: true },
+      });
       (prisma.user.findUnique as jest.Mock).mockResolvedValue({
         isAdmin: true,
         isSuspended: true,
@@ -87,6 +90,16 @@ describe("admin read pages gate on suspended status", () => {
 
       await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow(
         "REDIRECT:/"
+      );
+      expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
+      expect(prisma.user.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "admin-1" },
+          select: expect.objectContaining({
+            isAdmin: true,
+            isSuspended: true,
+          }),
+        })
       );
       expect(mockRedirect).toHaveBeenCalledTimes(1);
       expect(mockRedirect).toHaveBeenCalledWith("/");

--- a/src/__tests__/phase09/cutover-retire-booking.test.ts
+++ b/src/__tests__/phase09/cutover-retire-booking.test.ts
@@ -73,6 +73,13 @@ describe("Phase 09 booking retirement", () => {
     (auth as jest.Mock).mockResolvedValue({
       user: { id: "admin-1", isAdmin: true },
     });
+    // The stub now gates via requireAdminAuth(), which re-reads the admin's
+    // isAdmin/isSuspended from the DB rather than trusting the JWT.
+    const { prisma } = await import("@/lib/prisma");
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      isAdmin: true,
+      isSuspended: false,
+    });
     const page = await import("@/app/admin/bookings/page");
 
     await expect(page.default()).rejects.toThrow("NEXT_REDIRECT:/admin");

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/prisma";
 import { getAuditLogs } from "@/lib/audit";
+import { requireAdminAuth } from "@/lib/admin-auth";
 import {
   Shield,
   User,
@@ -109,19 +108,11 @@ interface PageProps {
 }
 
 export default async function AuditLogPage({ searchParams }: PageProps) {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin/audit");
   }
-
-  // Check if user is admin
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { isAdmin: true },
-  });
-
-  if (!user?.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 

--- a/src/app/admin/bookings/[id]/page.tsx
+++ b/src/app/admin/bookings/[id]/page.tsx
@@ -1,5 +1,5 @@
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { requireAdminAuth } from "@/lib/admin-auth";
 
 export const metadata = {
   title: "Admin | RoomShare",
@@ -7,13 +7,11 @@ export const metadata = {
 };
 
 export default async function AdminBookingDetailRedirectPage() {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin");
   }
-
-  if (!session.user.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -1,5 +1,5 @@
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { requireAdminAuth } from "@/lib/admin-auth";
 
 export const metadata = {
   title: "Admin | RoomShare",
@@ -7,13 +7,11 @@ export const metadata = {
 };
 
 export default async function AdminBookingsRedirectPage() {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin");
   }
-
-  if (!session.user.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 

--- a/src/app/admin/listings/page.tsx
+++ b/src/app/admin/listings/page.tsx
@@ -1,6 +1,6 @@
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { requireAdminAuth } from "@/lib/admin-auth";
 import type { ListingStatus, Prisma } from "@prisma/client";
 import Link from "next/link";
 import { ArrowLeft, Home } from "lucide-react";
@@ -33,19 +33,11 @@ function parseStatus(value: string | undefined): ListingStatusFilter {
 export default async function AdminListingsPage({
   searchParams,
 }: AdminListingsPageProps) {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin/listings");
   }
-
-  // Check if user is admin
-  const currentUser = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { isAdmin: true },
-  });
-
-  if (!currentUser?.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { requireAdminAuth } from "@/lib/admin-auth";
 import Link from "next/link";
 import {
   Users,
@@ -50,19 +50,11 @@ async function getAdminStats() {
 }
 
 export default async function AdminDashboard() {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin");
   }
-
-  // Check if user is admin
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { isAdmin: true },
-  });
-
-  if (!user?.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,6 +1,6 @@
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { requireAdminAuth } from "@/lib/admin-auth";
 import type { Prisma } from "@prisma/client";
 import Link from "next/link";
 import { ArrowLeft, Users } from "lucide-react";
@@ -33,19 +33,11 @@ function parseFilter(value: string | undefined): UserFilter {
 export default async function AdminUsersPage({
   searchParams,
 }: AdminUsersPageProps) {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin/users");
   }
-
-  // Check if user is admin
-  const currentUser = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { isAdmin: true },
-  });
-
-  if (!currentUser?.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 
@@ -124,7 +116,7 @@ export default async function AdminUsersPage({
         <UserList
           initialUsers={users}
           totalUsers={totalUsers}
-          currentUserId={session.user.id}
+          currentUserId={adminCheck.userId}
           searchQuery={searchQuery}
           currentFilter={currentFilter}
           currentPage={currentPage}

--- a/src/app/admin/verifications/page.tsx
+++ b/src/app/admin/verifications/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
-import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import VerificationList from "./VerificationList";
+import { requireAdminAuth } from "@/lib/admin-auth";
 import Link from "next/link";
 import { ArrowLeft, ShieldCheck } from "lucide-react";
 
@@ -13,19 +13,11 @@ export const metadata: Metadata = {
 };
 
 export default async function VerificationsPage() {
-  const session = await auth();
-
-  if (!session?.user?.id) {
+  const adminCheck = await requireAdminAuth();
+  if (adminCheck.code === "SESSION_EXPIRED") {
     redirect("/login?callbackUrl=/admin/verifications");
   }
-
-  // Check if user is admin
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { isAdmin: true },
-  });
-
-  if (!user?.isAdmin) {
+  if (!adminCheck.isAdmin) {
     redirect("/");
   }
 


### PR DESCRIPTION
## P1 Security: suspended admins could still access admin read pages

### Problem
`requireAdminAuth()` (`src/lib/admin-auth.ts`) already does a fresh DB lookup of `isAdmin` **and** `isSuspended` — but **7 admin pages bypassed it** with their own gate:

- **5 pages** did `prisma.user.findUnique({ select: { isAdmin: true } })` — never read `isSuspended`.
- **2 bookings stubs** trusted the **stale JWT** `session.user.isAdmin`.

A suspended admin sailed straight through all of them. There is no `admin/layout.tsx` gate, so each page was independently exposed.

### Fix
Route every page through the suspended-aware helper, matching the pattern already used in `reports/page.tsx`:

```ts
const adminCheck = await requireAdminAuth();
if (adminCheck.code === "SESSION_EXPIRED") redirect("/login?callbackUrl=/admin/…");
if (!adminCheck.isAdmin) redirect("/");   // covers NOT_ADMIN and ACCOUNT_SUSPENDED
```

Pages fixed: admin dashboard, `users`, `listings`, `audit`, `verifications`, and both `bookings` redirect stubs. Now-unused `auth`/`prisma`/`session` imports removed; `users` reads the admin id from `adminCheck.userId`.

> Note: gate is `!adminCheck.isAdmin`, not `adminCheck.error` — `error: string` includes the falsy `""`, so truthiness doesn't narrow the discriminated union (would leave `userId` as `string | null`). `isAdmin` is the clean discriminant.

### Tests
- **New** `src/__tests__/app/admin/admin-suspended-guard.test.tsx` — drives the **real** `requireAdminAuth()` across all 7 pages (21 tests: suspended → `/`, logged-out → `/login`, non-admin → `/`). A page that skips the helper never sees the suspended flag and fails to redirect — exactly this bug.
- **Updated** `cutover-retire-booking.test.ts` — the `/admin/bookings` test relied on the old stale-JWT path; now seeds a DB user since the stub re-reads admin status from the DB.

### Verification
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm lint` — 0 errors (pre-existing warnings only, none in touched files)
- ✅ Tests — new suite + `AdminListPages` + cutover + admin actions: **109 passed**

### Out of scope / follow-up
A centralized `admin/layout.tsx` calling `requireAdminAuth()` would prevent recurrence, but Next.js renders layouts and pages in parallel (a layout redirect can't reliably stop a page's own data fetching), so it can't be the sole guard. Per-page checks match the current repo convention. Worth filing as a hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)