### PR TITLE
fix(security): block suspended users from deleteMessage/deleteConversation

### DIFF
--- a/src/__tests__/actions/chat.test.ts
+++ b/src/__tests__/actions/chat.test.ts
@@ -30,6 +30,7 @@ jest.mock("@/lib/prisma", () => {
       findUnique: jest.fn(),
       findMany: jest.fn(),
       create: jest.fn(),
+      update: jest.fn(),
       updateMany: jest.fn(),
       count: jest.fn(),
       groupBy: jest.fn(),
@@ -104,6 +105,8 @@ import {
   pollMessages,
   markConversationMessagesAsRead,
   markAllMessagesAsRead,
+  deleteMessage,
+  deleteConversation,
 } from "@/app/actions/chat";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
@@ -1152,6 +1155,142 @@ describe("Chat Actions", () => {
       });
       expect(prisma.conversation.findMany).not.toHaveBeenCalled();
       expect(prisma.message.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteMessage", () => {
+    beforeEach(() => {
+      (prisma.message.findUnique as jest.Mock).mockResolvedValue({
+        senderId: "user-123",
+        deletedAt: null,
+      });
+      (prisma.message.update as jest.Mock).mockResolvedValue({});
+    });
+
+    it("returns error when not authenticated", async () => {
+      (auth as jest.Mock).mockResolvedValue(null);
+
+      const result = await deleteMessage("message-123");
+
+      expect(result).toEqual({
+        success: false,
+        error: "Unauthorized",
+        code: "SESSION_EXPIRED",
+      });
+    });
+
+    it("returns suspended error before reading or deleting the message", async () => {
+      const error = mockCurrentUserSuspended();
+
+      const result = await deleteMessage("message-123");
+
+      expect(result).toEqual({
+        success: false,
+        error,
+        code: "ACCOUNT_SUSPENDED",
+      });
+      expect(prisma.message.findUnique).not.toHaveBeenCalled();
+      expect(prisma.message.update).not.toHaveBeenCalled();
+    });
+
+    it("blocks deletion of a message the user did not send", async () => {
+      (prisma.message.findUnique as jest.Mock).mockResolvedValue({
+        senderId: "other-456",
+        deletedAt: null,
+      });
+
+      const result = await deleteMessage("message-123");
+
+      expect(result).toEqual({
+        success: false,
+        error: "You can only delete your own messages",
+      });
+      expect(prisma.message.update).not.toHaveBeenCalled();
+    });
+
+    it("soft deletes the sender's own message", async () => {
+      const result = await deleteMessage("message-123");
+
+      expect(result).toEqual({ success: true });
+      expect(prisma.message.update).toHaveBeenCalledWith({
+        where: { id: "message-123" },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: "user-123",
+        },
+      });
+    });
+  });
+
+  describe("deleteConversation", () => {
+    beforeEach(() => {
+      (prisma.conversation.findUnique as jest.Mock).mockResolvedValue({
+        deletedAt: null,
+        participants: [{ id: "user-123" }, { id: "other-456" }],
+      });
+      (prisma.conversationDeletion.upsert as jest.Mock).mockResolvedValue({});
+    });
+
+    it("returns error when not authenticated", async () => {
+      (auth as jest.Mock).mockResolvedValue(null);
+
+      const result = await deleteConversation("conv-123");
+
+      expect(result).toEqual({
+        success: false,
+        error: "Unauthorized",
+        code: "SESSION_EXPIRED",
+      });
+    });
+
+    it("returns suspended error before reading or deleting the conversation", async () => {
+      const error = mockCurrentUserSuspended();
+
+      const result = await deleteConversation("conv-123");
+
+      expect(result).toEqual({
+        success: false,
+        error,
+        code: "ACCOUNT_SUSPENDED",
+      });
+      expect(prisma.conversation.findUnique).not.toHaveBeenCalled();
+      expect(prisma.conversationDeletion.upsert).not.toHaveBeenCalled();
+    });
+
+    it("blocks deletion by a non-participant", async () => {
+      (prisma.conversation.findUnique as jest.Mock).mockResolvedValue({
+        deletedAt: null,
+        participants: [{ id: "other-1" }, { id: "other-2" }],
+      });
+
+      const result = await deleteConversation("conv-123");
+
+      expect(result).toEqual({
+        success: false,
+        error: "You are not part of this conversation",
+      });
+      expect(prisma.conversationDeletion.upsert).not.toHaveBeenCalled();
+    });
+
+    it("soft deletes the conversation for the current participant", async () => {
+      const result = await deleteConversation("conv-123");
+
+      expect(result).toEqual({ success: true });
+      expect(prisma.conversationDeletion.upsert).toHaveBeenCalledWith({
+        where: {
+          conversationId_userId: {
+            conversationId: "conv-123",
+            userId: "user-123",
+          },
+        },
+        update: {
+          deletedAt: expect.any(Date),
+        },
+        create: {
+          conversationId: "conv-123",
+          userId: "user-123",
+        },
+      });
     });
   });
 });

--- a/src/app/actions/chat.ts
+++ b/src/app/actions/chat.ts
@@ -719,6 +719,15 @@ export async function deleteMessage(
     return { success: false, error: "Unauthorized", code: "SESSION_EXPIRED" };
   }
 
+  const suspension = await checkSuspension(session.user.id);
+  if (suspension.suspended) {
+    return {
+      success: false,
+      error: suspension.error || "Account suspended",
+      code: "ACCOUNT_SUSPENDED",
+    };
+  }
+
   try {
     // Verify the user is the sender of the message
     const message = await prisma.message.findUnique({
@@ -767,6 +776,15 @@ export async function deleteConversation(
   const session = await auth();
   if (!session?.user?.id) {
     return { success: false, error: "Unauthorized", code: "SESSION_EXPIRED" };
+  }
+
+  const suspension = await checkSuspension(session.user.id);
+  if (suspension.suspended) {
+    return {
+      success: false,
+      error: suspension.error || "Account suspended",
+      code: "ACCOUNT_SUSPENDED",
+    };
   }
 
   try {


### PR DESCRIPTION
## Problem

**P1 security issue.** Suspended users could still mutate messaging state through two server actions in `src/app/actions/chat.ts`:

- `deleteMessage` (soft-delete their own messages)
- `deleteConversation` (hide conversations from their view)

These were the only **2 of 7** mutating actions in the file that never consulted `checkSuspension()`. Every other mutation — `sendMessage`, `markAllMessagesAsRead`, `setTypingStatus`, `markConversationMessagesAsRead` — already short-circuits suspended users. This is the same class of bug as the recent `fix(security): gate all admin read pages on suspended-aware requireAdminAuth`, applied to the messaging mutation layer.

## Fix

Add the existing, fail-closed `checkSuspension(session.user.id)` guard (`src/app/actions/suspension.ts`, already imported) to both actions — immediately after the session check and **before any `prisma` access**, so suspended users are rejected before any DB read or write.

```ts
const suspension = await checkSuspension(session.user.id);
if (suspension.suspended) {
  return { success: false, error: suspension.error || "Account suspended", code: "ACCOUNT_SUSPENDED" };
}
```

Returns `{ success: false, ... }` explicitly to match each function's `success`-based contract (callers check `result.success`) — not the file's `buildSuspendedActionError()` helper, which omits `success`.

## Tests

`deleteMessage`/`deleteConversation` weren't previously imported or tested. Added two `describe` blocks (8 tests) reusing the existing `mockCurrentUserSuspended()` helper:

- **Regression tests:** assert the `ACCOUNT_SUSPENDED` result **and** that no DB mutation ran (`findUnique`/`update`/`upsert` `.not.toHaveBeenCalled()`).
- Baseline coverage: unauthenticated → `SESSION_EXPIRED`, authorization failure (non-sender / non-participant), and the happy path.
- Added the missing `message.update` mock the action genuinely calls.

## Verification

- ✅ `jest src/__tests__/actions/chat.test.ts` — **57/57 pass**
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm lint` — 0 errors

## Risk / rollback

Low risk, additive — introduces one early-return rejection path; no behavior change for active users. No schema/migration/API-surface changes. Fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)