### PR TITLE
fix(security): enforce trusted-address validation on listing PATCH

### DIFF
--- a/src/__tests__/api/listings-host-managed-patch.test.ts
+++ b/src/__tests__/api/listings-host-managed-patch.test.ts
@@ -15,6 +15,33 @@ jest.mock("@/lib/geocoding", () => ({
   geocodeAddress: jest.fn(),
 }));
 
+jest.mock("@/lib/geocoding/address-suggestion-token", () => ({
+  verifyAddressSuggestionToken: jest.fn().mockReturnValue({
+    valid: false,
+    reason: "malformed",
+  }),
+}));
+
+const mockValidateAddressForPublish = jest.fn();
+
+jest.mock("@/lib/geocoding/google-places", () => {
+  class GooglePlacesUnavailableError extends Error {
+    constructor(
+      message: string,
+      public readonly code: "MISSING_KEY" | "TIMEOUT" | "UPSTREAM" | "CAPPED"
+    ) {
+      super(message);
+      this.name = "GooglePlacesUnavailableError";
+    }
+  }
+
+  return {
+    GooglePlacesUnavailableError,
+    validateAddressForPublish: (...args: unknown[]) =>
+      mockValidateAddressForPublish(...args),
+  };
+});
+
 jest.mock("@/lib/listing-language-guard", () => ({
   checkListingLanguageCompliance: jest.fn().mockReturnValue({ allowed: true }),
 }));
@@ -60,6 +87,9 @@ jest.mock("@/lib/env", () => ({
     semanticSearch: false,
     get moderationWriteLocks() {
       return process.env.FEATURE_MODERATION_WRITE_LOCKS === "true";
+    },
+    get googleAddressValidation() {
+      return process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION === "true";
     },
   },
 }));
@@ -118,7 +148,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = "test-key";
 import { PATCH } from "@/app/api/listings/[id]/route";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { geocodeAddress } from "@/lib/geocoding";
+import { verifyAddressSuggestionToken } from "@/lib/geocoding/address-suggestion-token";
 import { syncCanonicalListingInventory } from "@/lib/listings/canonical-inventory";
 import { markListingDirtyInTx } from "@/lib/search/search-doc-dirty";
 import { createClient } from "@supabase/supabase-js";
@@ -228,10 +258,13 @@ function mockTransaction({
 describe("PATCH /api/listings/[id] contact-first availability contract", () => {
   const originalModerationWriteLocks =
     process.env.FEATURE_MODERATION_WRITE_LOCKS;
+  const originalGoogleAddressValidation =
+    process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION;
 
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.FEATURE_MODERATION_WRITE_LOCKS;
+    delete process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION;
     (auth as jest.Mock).mockResolvedValue(ownerSession);
     (prisma.listing.findUnique as jest.Mock).mockResolvedValue(listing);
     (syncCanonicalListingInventory as jest.Mock).mockResolvedValue({
@@ -240,6 +273,13 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
       publishStatus: "PENDING_PROJECTION",
       sourceVersion: BigInt(4),
     });
+    // Default: no valid suggestion token and Google validation disabled, so an
+    // address change is blocked unless a test opts into one of the trusted paths.
+    (verifyAddressSuggestionToken as jest.Mock).mockReturnValue({
+      valid: false,
+      reason: "malformed",
+    });
+    mockValidateAddressForPublish.mockReset();
   });
 
   afterEach(() => {
@@ -247,6 +287,12 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
       delete process.env.FEATURE_MODERATION_WRITE_LOCKS;
     } else {
       process.env.FEATURE_MODERATION_WRITE_LOCKS = originalModerationWriteLocks;
+    }
+    if (originalGoogleAddressValidation === undefined) {
+      delete process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION;
+    } else {
+      process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION =
+        originalGoogleAddressValidation;
     }
   });
 
@@ -533,10 +579,9 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
   });
 
   it("refreshes normalized address and physical unit linkage on address edits", async () => {
-    (geocodeAddress as jest.Mock).mockResolvedValue({
-      status: "ok",
-      lat: 37.781,
-      lng: -122.412,
+    (verifyAddressSuggestionToken as jest.Mock).mockReturnValue({
+      valid: true,
+      coords: { lat: 37.781, lng: -122.412 },
     });
     const { update, locationUpdate, executeRaw } = mockTransaction({
       lockedRows: [
@@ -556,6 +601,7 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
             city: "San Francisco",
             state: "CA",
             zip: "94103",
+            addressSuggestionToken: "valid-token",
           })
         ),
       }),
@@ -602,10 +648,9 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
   });
 
   it("repairs canonical unit linkage when no physical unit exists", async () => {
-    (geocodeAddress as jest.Mock).mockResolvedValue({
-      status: "ok",
-      lat: 37.781,
-      lng: -122.412,
+    (verifyAddressSuggestionToken as jest.Mock).mockReturnValue({
+      valid: true,
+      coords: { lat: 37.781, lng: -122.412 },
     });
     const { update } = mockTransaction({
       lockedRows: [
@@ -625,6 +670,7 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
             city: "San Francisco",
             state: "CA",
             zip: "94103",
+            addressSuggestionToken: "valid-token",
           })
         ),
       }),
@@ -654,6 +700,174 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
       })
     );
     expect(update.mock.calls[0][0].data).not.toHaveProperty("physicalUnitId");
+  });
+
+  describe("trusted-address validation on address edits (P1 bypass guard)", () => {
+    it("blocks an address change that lacks a valid suggestion token when Google validation is disabled (no silent geocode)", async () => {
+      // Default beforeEach: token invalid, FEATURE_GOOGLE_ADDRESS_VALIDATION unset.
+      const { update, locationUpdate, executeRaw } = mockTransaction();
+
+      const response = await PATCH(
+        new Request("http://localhost/api/listings/listing-abc", {
+          method: "PATCH",
+          body: JSON.stringify(
+            validPatchPayload({
+              address: "1 Spoofed Way",
+              city: "San Francisco",
+              state: "CA",
+              zip: "94103",
+            })
+          ),
+        }),
+        { params: Promise.resolve({ id: "listing-abc" }) }
+      );
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("10");
+      // The write transaction must never run for an unverified address change.
+      expect(update).not.toHaveBeenCalled();
+      expect(locationUpdate).not.toHaveBeenCalled();
+      expect(executeRaw).not.toHaveBeenCalled();
+      expect(mockValidateAddressForPublish).not.toHaveBeenCalled();
+    });
+
+    it("accepts an address change backed by a valid suggestion token and persists the token coords", async () => {
+      (verifyAddressSuggestionToken as jest.Mock).mockReturnValue({
+        valid: true,
+        coords: { lat: 40.7128, lng: -74.006 },
+      });
+      const { locationUpdate, executeRaw } = mockTransaction({
+        lockedRows: [
+          lockedListing({
+            normalizedAddress: "123 main st san francisco ca 94102",
+            physicalUnitId: "unit-123",
+          }),
+        ],
+      });
+
+      const response = await PATCH(
+        new Request("http://localhost/api/listings/listing-abc", {
+          method: "PATCH",
+          body: JSON.stringify(
+            validPatchPayload({
+              address: "456 Oak Ave",
+              city: "San Francisco",
+              state: "CA",
+              zip: "94103",
+              addressSuggestionToken: "valid-token",
+            })
+          ),
+        }),
+        { params: Promise.resolve({ id: "listing-abc" }) }
+      );
+
+      expect(response.status).toBe(200);
+      expect(verifyAddressSuggestionToken).toHaveBeenCalledWith("valid-token", {
+        userId: "owner-123",
+        address: "456 Oak Ave",
+        city: "San Francisco",
+        state: "CA",
+        zip: "94103",
+      });
+      // Google validation is never consulted once the token is trusted.
+      expect(mockValidateAddressForPublish).not.toHaveBeenCalled();
+      expect(locationUpdate).toHaveBeenCalled();
+      // Token coords are written to PostGIS via raw SQL.
+      const coordsCall = executeRaw.mock.calls.find((call) =>
+        JSON.stringify(call).includes("ST_SetSRID")
+      );
+      expect(coordsCall).toBeTruthy();
+    });
+
+    it("falls back to Google Address Validation when enabled and the token is absent", async () => {
+      process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION = "true";
+      mockValidateAddressForPublish.mockResolvedValue({
+        address: "456 Oak Ave",
+        city: "San Francisco",
+        state: "CA",
+        zip: "94103",
+        lat: 37.781,
+        lng: -122.412,
+        precision: "PREMISE",
+      });
+      const { update } = mockTransaction({
+        lockedRows: [
+          lockedListing({
+            normalizedAddress: "123 main st san francisco ca 94102",
+            physicalUnitId: "unit-123",
+          }),
+        ],
+      });
+
+      const response = await PATCH(
+        new Request("http://localhost/api/listings/listing-abc", {
+          method: "PATCH",
+          body: JSON.stringify(
+            validPatchPayload({
+              address: "456 Oak Ave",
+              city: "San Francisco",
+              state: "CA",
+              zip: "94103",
+            })
+          ),
+        }),
+        { params: Promise.resolve({ id: "listing-abc" }) }
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockValidateAddressForPublish).toHaveBeenCalledWith({
+        address: "456 Oak Ave",
+        city: "San Francisco",
+        state: "CA",
+        zip: "94103",
+      });
+      expect(update).toHaveBeenCalled();
+    });
+
+    it("rejects an address change that Google cannot verify with 400", async () => {
+      process.env.FEATURE_GOOGLE_ADDRESS_VALIDATION = "true";
+      mockValidateAddressForPublish.mockResolvedValue(null);
+      const { update } = mockTransaction();
+
+      const response = await PATCH(
+        new Request("http://localhost/api/listings/listing-abc", {
+          method: "PATCH",
+          body: JSON.stringify(
+            validPatchPayload({
+              address: "1 Unverifiable Pl",
+              city: "San Francisco",
+              state: "CA",
+              zip: "94103",
+            })
+          ),
+        }),
+        { params: Promise.resolve({ id: "listing-abc" }) }
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        field: "address",
+      });
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it("does not re-validate when the address is unchanged", async () => {
+      const { update } = mockTransaction();
+
+      const response = await PATCH(
+        new Request("http://localhost/api/listings/listing-abc", {
+          method: "PATCH",
+          // validPatchPayload() reuses the stored address (123 Main St ...).
+          body: JSON.stringify(validPatchPayload()),
+        }),
+        { params: Promise.resolve({ id: "listing-abc" }) }
+      );
+
+      expect(response.status).toBe(200);
+      expect(verifyAddressSuggestionToken).not.toHaveBeenCalled();
+      expect(mockValidateAddressForPublish).not.toHaveBeenCalled();
+      expect(update).toHaveBeenCalled();
+    });
   });
 
   it("survives a phase01 canonical-sync skip: PATCH succeeds, physicalUnitId falls back, dirty mark still fires (H2)", async () => {

--- a/src/app/api/listings/[id]/route.ts
+++ b/src/app/api/listings/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
-import { geocodeAddress } from "@/lib/geocoding";
 import { createClient } from "@supabase/supabase-js";
 import bcrypt from "bcryptjs";
 import {
@@ -21,7 +20,6 @@ import { isValidLanguageCode } from "@/lib/languages";
 import { markListingDirtyInTx } from "@/lib/search/search-doc-dirty";
 import { withRateLimit } from "@/lib/with-rate-limit";
 import { captureApiError } from "@/lib/api-error-handler";
-import { isCircuitOpenError } from "@/lib/circuit-breaker";
 import { validateCsrf } from "@/lib/csrf";
 import { logger } from "@/lib/logger";
 import { checkSuspension, checkEmailVerified } from "@/app/actions/suspension";
@@ -31,6 +29,11 @@ import { features } from "@/lib/env";
 import { syncListingEmbedding } from "@/lib/embeddings/sync";
 import { getHostModerationWriteLockResult } from "@/lib/listings/moderation-write-lock";
 import { normalizeAddress } from "@/lib/search/normalize-address";
+import { verifyAddressSuggestionToken } from "@/lib/geocoding/address-suggestion-token";
+import {
+  GooglePlacesUnavailableError,
+  validateAddressForPublish,
+} from "@/lib/geocoding/google-places";
 import { syncCanonicalAvailability } from "@/lib/listings/canonical-sync";
 import {
   syncListingLifecycleProjectionInTx,
@@ -166,6 +169,12 @@ const listingProfilePatchSchema = z
       .nullable()
       .optional(),
     images: z.array(supabaseImageUrlSchema).max(10).optional(),
+    addressSuggestionToken: z
+      .string()
+      .trim()
+      .max(4096, "Address suggestion token is invalid")
+      .optional()
+      .transform((value) => (value && value.length > 0 ? value : undefined)),
   })
   .strict();
 
@@ -854,6 +863,7 @@ export async function PATCH(
         householdGender,
         primaryHomeLanguage,
         images,
+        addressSuggestionToken,
       } = profilePatch;
 
       if (householdLanguages && householdLanguages.length > 0) {
@@ -930,48 +940,80 @@ export async function PATCH(
         zip,
       });
 
+      // Address edits must clear the same trusted-address bar as listing
+      // creation: a server-signed suggestion token (PREMISE precision, bound to
+      // this user + the submitted fields) or Google Address Validation. Never
+      // fall back to best-guess forward geocoding, which would let a direct API
+      // caller point a listing at an unverified address.
       let coords: { lat: number; lng: number } | null = null;
       if (addressChanged && listing.location) {
-        const fullAddress = `${address}, ${city}, ${state} ${zip}`;
-        try {
-          const geoResult = await geocodeAddress(fullAddress);
-          if (geoResult.status === "not_found") {
-            await logger.warn("Geocoding failed for listing update", {
+        const verifiedAddressSuggestion = verifyAddressSuggestionToken(
+          addressSuggestionToken,
+          {
+            userId,
+            address,
+            city,
+            state,
+            zip,
+          }
+        );
+
+        if (verifiedAddressSuggestion.valid) {
+          coords = verifiedAddressSuggestion.coords;
+        } else if (features.googleAddressValidation) {
+          try {
+            const validatedAddress = await validateAddressForPublish({
+              address,
+              city,
+              state,
+              zip,
+            });
+
+            if (!validatedAddress) {
+              const message =
+                "Could not verify this exact address. Please choose a suggested address or check the details and try again.";
+              return NextResponse.json(
+                {
+                  error: message,
+                  field: "address",
+                  fields: { address: message },
+                },
+                { status: 400 }
+              );
+            }
+
+            coords = { lat: validatedAddress.lat, lng: validatedAddress.lng };
+          } catch (validationError) {
+            if (validationError instanceof GooglePlacesUnavailableError) {
+              return NextResponse.json(
+                {
+                  error:
+                    "Address verification temporarily unavailable. Please try again.",
+                },
+                { status: 503, headers: { "Retry-After": "10" } }
+              );
+            }
+
+            throw validationError;
+          }
+        } else {
+          await logger.warn(
+            "Listing update blocked: address validation disabled",
+            {
               route: "/api/listings/[id]",
               method: "PATCH",
               userId: userId.slice(0, 8) + "...",
               city,
               state,
-            });
-            return NextResponse.json(
-              {
-                error:
-                  "Could not find this address. Please check and try again.",
-              },
-              { status: 400 }
-            );
-          }
-          if (geoResult.status === "error") {
-            return NextResponse.json(
-              {
-                error:
-                  "Address verification temporarily unavailable. Please try again.",
-              },
-              { status: 503, headers: { "Retry-After": "10" } }
-            );
-          }
-          coords = { lat: geoResult.lat, lng: geoResult.lng };
-        } catch (geoError) {
-          if (isCircuitOpenError(geoError)) {
-            return NextResponse.json(
-              {
-                error:
-                  "Address verification service temporarily unavailable. Please try again shortly.",
-              },
-              { status: 503, headers: { "Retry-After": "30" } }
-            );
-          }
-          throw geoError;
+            }
+          );
+          return NextResponse.json(
+            {
+              error:
+                "Address verification temporarily unavailable. Please try again.",
+            },
+            { status: 503, headers: { "Retry-After": "10" } }
+          );
         }
       }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,441 +1,86 @@
-# Unified SearchBar — one pill, every surface (2026-06-12)
-
-Full plan: `~/.claude/plans/make-the-search-bar-expressive-sundae.md` (approved).
-
-- **Goal + acceptance criteria:** Home hero bar and search-page header bar are pixel-identical
-  (one shared SearchBar component, 68px pill, Where → What(AI, env-gated) → Budget), with the
-  full interaction treatment (raised active cell, morphing submit, scrim + Esc layering,
-  collapsed-pill segment deep-links, stacked mobile layout). All unit + e2e gates green on a
-  prod build, both semantic-flag states.
-- **Scope:** new `src/components/search/SearchBar/` module; rewrites of DesktopHeaderSearch +
-  MobileSearchOverlay form block; HomeSearchBar replaces SearchForm on HomeClient; lib
-  extractions (map-fly-to, search-dates, price-input); SearchForm.tsx + CompactSearchPill.tsx
-  deleted at the end.
-- **Risks:** URL-sync clobbering typing; auto-submit double-navigation; filter/sort/bounds
-  param survival; search-page collapse/focus regressions; env-gated What field in CI/prod
-  builds. Stable-selector contract in the plan MUST be preserved.
-- **Verification:** pnpm lint/typecheck/test → pnpm build + start → prod-build Playwright gate
-  (home-a11y, homepage, search-a11y, filter-price, search-smoke, p0-filters-mobile) →
-  flag-off build → manual Chrome pass.
-
-## Checklist
-
-- [x] Slice 0: this checklist
-- [x] Slice 1: lib extractions (map-fly-to.ts, search-dates.ts, price-input.ts) + import flips
-- [x] Slice 2: SearchBar module + unit tests (pipeline + chrome states)
-- [x] Slice 3: swap search-page desktop header (scrim, equal-height summary, id unify)
-- [x] Slice 4: swap home (HomeSearchBar, port SearchForm tests as parity oracle)
-- [x] Slice 5: collapsed-summary segment deep-links (openAndFocus + budget) — done in slice 3
-- [x] Slice 6: mobile overlay on stacked SearchBar (+ What field, real form)
-- [x] Slice 7: delete SearchForm.tsx / CompactSearchPill.tsx / shim; grep clean
-- [x] Verification story written below
-
-## Results + verification story (2026-06-12)
-
-**Shipped** (8 commits on codex/fix-search-bar-ui-ux): one shared `SearchBar` module renders
-the search bar on the home hero, the search-page header (expanded + 68px segmented summary
-pill with deep-links + scrim + Esc layering), and the mobile overlay (stacked, `mobile-`
-prefixed ids). Fields unified to Where → What(AI, env-gated) → Budget; one submit pipeline
-(canonical URL, typed-location resolution, bounds preservation, price swap/clamp via live
-refs, single fly-to, recents everywhere); typing guard now on all surfaces.
-SearchForm.tsx + CompactSearchPill.tsx deleted.
-
-**Bugs found & fixed during verification** (each with regression coverage or e2e):
-1. React #418 hydration error on /search — scrim portal rendered during hydration; mount-gated.
-2. Duplicate-submit dedupe ran after cancelling the pending debounced navigation → search
-   swallowed + isSearching stuck (latent SearchForm bug); dedupe now checked first.
-3. Dead-space cell click stole focus from the clicked budget input when the engage-morph
-   shifted layout under reduced motion (all e2e emulate it); handler now no-ops when focus
-   is already inside the cell.
-4. Desktop header collapse never triggered — useScrollHeader watched window.scrollY but
-   /search scrolls an inner panel; hook now also tracks [data-search-results-scroll-region].
-
-**Verification evidence**:
-- `pnpm lint` 0 errors · `pnpm typecheck` clean · `pnpm test` 502 suites / 7843 tests green
-  (102 new SearchBar tests incl. parity fingerprint home-vs-header under both flag states;
-  82-test HomeSearchBar port of the SearchForm behavioral contract).
-- Prod-build e2e (per lessons.md): flag-ON build → home-a11y + homepage + search-a11y +
-  filter-price = 30/30. Flag-OFF build (CI/prod parity, `search-what` absent from SSR) →
-  29/30 + HP-06 passes 3/3 on retry (cold-server flake in the untouched bottom CTA).
-- Manual Chrome pass (desktop + mobile, both pages): idle/engaged/raised-cell states, morph,
-  recents combobox, collapse → summary → segment deep-link → scrim → Esc → focus restore,
-  mobile overlay + collapsed bar, home stacked card.
-
-**Known limitations / follow-ups**:
-- Authenticated e2e projects (search-smoke, Mobile Chrome journeys) fail locally at
-  auth.setup (CredentialsSignin) against a manually started prod server — pre-existing
-  local-env issue (documented in memory); rely on CI for those.
-- Mobile overlay: Escape closes the overlay even while the autocomplete popup is open
-  (no Esc layering there; pre-existing).
-- `InlineFilterStrip.tsx` still has its own validateMoveInDate copy (deliberately untouched).
-- Local `.next` currently holds the flag-OFF build.
-
----
-
-# M1 no-empty-listings bypass fix — (2026-06-11)
-
-## Problem
-
-The "a listing can never be ACTIVE with 0 open slots" rule was enforced in
-`recoverHostManagedListing` and the host availability PATCH, but BOTH `updateListingStatus`
-functions (host: `src/app/actions/listing-status.ts`; admin: `src/app/actions/admin.ts`)
-skipped it — a host could toggle an empty listing back to ACTIVE (ghost listing).
-
-## Fix
-
-- Host action: added the guard after the freshness-recovery check, using the system-wide
-  effective-slots chain `openSlots ?? availableSlots ?? totalSlots` (legacy rows keep their
-  count in availableSlots with openSlots null — a bare `openSlots ?? 0` would have wrongly
-  blocked legacy reactivation). Reuses the existing error code
-  `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS` and message from recoverHostManagedListing.
-- Admin action: locked SELECT now also fetches the slot columns; same chain guard
-  (fail-closed `?? 0`) with code `ACTIVE_REQUIRES_OPEN_SLOTS`. Placed after the
-  moderation-lock check. Guard is ACTIVE-only — pausing/renting an empty listing still works.
-
-## Known remaining gap — CLOSED in follow-up commit
-
-`unsuppressListing` (admin.ts) restored moderation-locked listings to ACTIVE without a slots
-check. Fixed: unsuppress always releases the moderation hold, but an empty listing (same
-effective-slots chain) is restored to PAUSED instead of ACTIVE — rejecting outright would
-deadlock the listing (the host cannot edit a moderation-locked listing to add slots). The
-admin UI (`ListingList.tsx` handleUnsuppress) now mirrors the returned status instead of
-hardcoding ACTIVE. Tests: empty → PAUSED (host-managed + legacy), audit logs PAUSED;
-existing restore-to-ACTIVE tests green via factory slot defaults. Full suite 7816 passed.
-
-## Results + verification story
-
-- 7 new regression tests: host-managed 0-slot reject, legacy effective-slots reject,
-  openSlots=0-authoritative (chain precedence), PAUSED/RENTED still allowed on empty listings
-  (both actions), admin reject + legacy reject + pause-allowed.
-- `pnpm lint` 0 errors; `pnpm typecheck` clean; action/security/integration/component suites
-  175/175; full `pnpm test` 500/500 suites, 7814 passed, 0 failed.
-
----
-
-# H4 unit-projection version-ordering fix — (2026-06-11)
-
-## Problem
-
-`rebuildUnitPublicProjection` guarded its upsert with
-`WHERE stored.source_version <= MAX(isp.source_version)`. Inventory source_versions are
-independent per-inventory counters (each derives from its own Listing.version), so the
-cross-inventory MAX is not a valid ordering token: deleting the highest-versioned inventory
-makes every later rebuild compute a lower MAX, the guard rejects forever, and the unit row is
-frozen with the deleted room's data (count, from_price, representative all stale).
-
-## Fix (`src/lib/projections/unit-projection.ts`)
-
-- Serialize rebuilds per unit with `pg_advisory_xact_lock(hashtext('p2:unitproj:' || unitId))`
-  taken BEFORE the aggregate read (callers lock inventory rows first → acquisition order is
-  rows → unit lock everywhere, no deadlock; lock releases at commit). Each rebuild then
-  aggregates the latest committed state, so the upsert applies unconditionally.
-- Dropped the `WHERE source_version <=` guard and `GREATEST()` from both upsert variants;
-  stored `source_version` is now informational (MAX of current aggregate, may regress).
-- Deliberately did NOT use `acquireXactLock()` — its `SET LOCAL lock_timeout='5s'` would leak
-  into the caller's whole transaction (inline canonical-sync path).
-- Tombstone's own per-inventory guard untouched (same-counter comparison — valid).
-
-## Invariants
-
-1. unit_public_projection is a pure aggregate of current visible ISP rows; per-unit advisory
-   lock makes read-aggregate-write critical sections strictly sequential.
-2. Cross-inventory source_versions are never compared for ordering decisions.
-3. unit source_version may regress on inventory deletion (metadata only); the search read
-   path computes `GREATEST(upp.source_version, MAX(isp.source_version))` per query — unaffected.
-
-## Results + verification story
-
-- 3 new regression tests (unit-projection.test.ts): exact H4 scenario (delete max-version
-  room → unit row regroups to remaining room), not-stuck-in-the-past (subsequent lower-version
-  updates apply), and end-to-end handleTombstone regroup. Renamed the GREATEST test to match
-  the new semantics.
-- `pnpm lint` 0 errors (22 pre-existing warnings, none in touched files); `pnpm typecheck` clean.
-- Projections + outbox + phase02 integration suites (read-path isolation, tombstone fast lane):
-  165/165 green. Full `pnpm test`: 500/500 suites, 7807 passed, 0 failed.
-- No schema change; rollback = revert commit.
-
----
-
-# H3 ghost-update race fix — plan (2026-06-11)
-
-Full plan: /home/surya/.claude/plans/fix-this-h3-ghost-dynamic-snowflake.md
+# P1 Fix: Listing PATCH bypasses create-time trusted-address validation
 
 ## Goal + acceptance criteria
 
-- A moderator PAUSE/BAN (PAUSED/SUPPRESSED/ARCHIVED) can never be overwritten back to a
-  publishable state by a background recompute (outbox INVENTORY_UPSERTED / EMBED_NEEDED
-  handlers, canonical sync).
-- Background handlers never recreate the `inventory_search_projection` row for a hidden inventory.
-- Stale writes are logged no-ops; equal-version idempotent replays still apply; legitimate
-  unpause → re-publish still works.
-- Zero regressions: full lib/projections + lib/outbox + lib/listings suites green, plus
-  daily-maintenance + listings-host-managed-patch (in-flight retention work untouched).
+`PATCH /api/listings/[id]` must enforce the **same** trusted-address validation as
+create (`POST /api/listings`) whenever the address changes. Direct-API address
+changes that only pass Nominatim forward-geocoding (best-guess) must be rejected.
 
-## Checklist
+- Acceptance: a PATCH that changes address WITHOUT a valid `addressSuggestionToken`
+  and with Google Address Validation disabled is **blocked (503)** — never silently
+  geocoded.
+- Acceptance: with a valid server-signed `addressSuggestionToken` matching the
+  submitted fields → 200, coords come from the token (no geocode).
+- Acceptance: with `googleAddressValidation` enabled, an unverifiable address →
+  400; a verified address → 200 with validated coords; upstream outage → 503.
+- Acceptance: address-unchanged PATCH path is unaffected.
 
-- [x] Site 1: `src/lib/projections/inventory-projection.ts` — FOR UPDATE read, hidden-status
-      early skip (isHiddenStatus), CAS-guarded publish_status UPDATEs, `skipReason` in result
-- [x] Tests A1–A8 (inventory-projection.test.ts) + B9 (handlers.test.ts) → suites green
-- [x] Commit 1: 520f95ac
-- [x] Site 2: `src/lib/listings/canonical-inventory.ts` — `EXCLUDED.source_version >= current`
-      guard on ON CONFLICT DO UPDATE, stale-skip branch + warn log + result type
-- [x] Tests C10–C11 (canonical-inventory.test.ts, append-only) + D12–D13 (new guard test file)
-- [x] Commit 2: 70e2ff89 (also carries the in-tree pending H2 emergency-stop gating for this
-      module — entangled in the same file, noted in the commit message)
-- [x] Site 3: `src/lib/projections/semantic.ts` — status-guarded publish + semantic-row retraction
-- [x] Test E14 (semantic.test.ts)
-- [x] Commit 3: 646f49ec
-- [x] Verify: lint, typecheck, full affected suites, then full `pnpm test`
-- [x] Results + verification story below
+## Root cause
 
-## Risks
+- Create path (`src/app/api/listings/route.ts:328-391`): verifies a signed
+  `addressSuggestionToken` (PREMISE precision, user+fields bound) OR calls
+  `validateAddressForPublish` (Google Address Validation); blocks otherwise.
+- PATCH path (`src/app/api/listings/[id]/route.ts:933-976`): on address change only
+  calls `geocodeAddress` (Nominatim forward-geocode), which returns coords for any
+  plausible/fake address — **no trust/precision gate**. The official EditListingForm
+  doesn't even expose address editing, so this is an API-level abuse bypass.
 
-- State-transition/race logic (auth/state domain): guards must fail CLOSED (stay hidden), never open.
-- Working tree has uncommitted homepage + outbox-retention work — edits confined to
-  non-overlapping hunks; do not touch drain.ts/handlers.ts/daily-maintenance.
+## Scope (files/modules)
 
-## Results + verification story
+- `src/app/api/listings/[id]/route.ts`
+  - imports: add `verifyAddressSuggestionToken`, `validateAddressForPublish` +
+    `GooglePlacesUnavailableError`; remove now-unused `geocodeAddress` and
+    `isCircuitOpenError`.
+  - `listingProfilePatchSchema`: add optional `addressSuggestionToken` (mirror create
+    schema: trim, max 4096, empty→undefined).
+  - destructure `addressSuggestionToken`.
+  - replace the `geocodeAddress` block with create-mirroring token → Google
+    validation → block logic, wrapped in `if (addressChanged && listing.location)`.
+- `src/__tests__/api/listings-host-managed-patch.test.ts`
+  - add mocks: `address-suggestion-token` (verify), `google-places`
+    (validateAddressForPublish + GooglePlacesUnavailableError); add
+    `googleAddressValidation` getter to the `@/lib/env` mock.
+  - update the 2 existing address-change tests to pass a valid token.
+  - add security regression tests (bypass blocked; token path; google path; 400).
 
-All three ghost-write sites are guarded; a hidden inventory (PAUSED/SUPPRESSED/ARCHIVED) can
-no longer be flipped back to a publishable state by a background recompute, and the
-tombstone-deleted `inventory_search_projection` row is never recreated by a stale event.
-Guards fail closed (worst case: listing stays hidden, surfaced via
-`cfm.canonical.stale_sync_skipped_count` warn log). No schema changes; rollback = revert commits.
+## Risks (auth/PII/state/DB/cost)
 
-Verification (all on 2026-06-11):
-- `pnpm lint` — 0 errors; 22 pre-existing warnings, none in touched files.
-- `pnpm typecheck` — clean.
-- Targeted suites: inventory-projection (14), handlers (34), lib/listings (33, incl. new
-  canonical-inventory-guard.test.ts on real PGlite SQL), semantic (14) — all green.
-- Adjacency: daily-maintenance + listings-host-managed-patch suites green (no interaction
-  with in-flight retention work).
-- Full `pnpm test`: 500/500 suites, 7804 passed, 0 failed (8 pre-existing skips).
+- Security-critical path; coords persist to PostGIS `Location.coords`. No DB schema
+  change. No PII in logs (only userId-prefix + city/state, matching create).
+- Behavior change: direct-API address edits now require a verified address. The
+  first-party edit form never changed address, so no first-party UX regression.
 
-Found-and-fixed along the way (commit 3a7b96b5): phase08/phase09 schema suites were red
-*before* this task — the in-flight retention work added the phase08 migration to the phase02
-fixture list, so the phase08+ fixture chains applied it twice (non-idempotent ADD CONSTRAINT).
-The phase08 fixture now skips application when `fanout_status` already exists.
+## Verification
 
----
-
-# Homepage HIGH-issue fixes — plan (2026-06-11)
-
-(previous tasks: full-site UI review → superseded by homepage deep review, see tasks/ui-review-homepage-2026-06-10.md; map restyle completed cc203aff..e3d5fdc9)
-
-## Context
-
-Homepage UI review (tasks/ui-review-homepage-2026-06-10.md) found 7 HIGH issues. This plan fixes
-all of them with explicit no-regression guardrails. Demo ~Jun 16 (code freeze mindset): every change
-is small, isolated, and verified visually + by tests before commit.
-
-Exploration verified two corrections to the original findings:
-- **H6**: `src/app/api/messages/route.ts` has NO 404 code path (only 401/403/400/429/500). The observed
-  404 is most likely the dev server's degraded state (same hang that 404'd `/` for fresh sessions).
-  → diagnose first, then a minimal hardening fix.
-- **H7**: `element.scrollIntoView()` correctly scrolls the nearest scrollable ancestor (the custom
-  container) — only the skip link's *native anchor navigation* is broken. Fix is small and contained.
-
-## Goal + acceptance criteria
-
-- All 7 HIGH issues fixed; zero visual/behavioral regression on `/` and `/search` at 320/375/768/1024/1440.
-- Keyboard focus visibly indicated on every hero search input (WCAG 2.4.7).
-- Hero LCP image served optimized (AVIF/WebP via next/image, priority) — no layout shift, identical art direction.
-- Featured grid readable at 768–1023px (no one-word-per-line titles, no "N…/O…" badges).
-- Card titles clamp to 1 line at all widths.
-- Suspense skeleton mirrors the real featured layout (CLS budget e2e stays green).
-- Skip link scrolls the custom container and moves focus to `#main-content`.
-- unreadCount polling: real status confirmed; polling stops on terminal auth status.
-- New regression tests for: input focus-visible, skip-link focus. Existing suites stay green.
-
-## Scope (files)
-
-- src/components/SearchForm.tsx (focus classes only: ~1015, ~1261, ~1300)
-- src/components/LocationSearchInput.tsx (~825; shared with /search header + mobile overlay — verify there)
-- src/app/HomeClient.tsx (hero photo div ~94, CTA polaroid ~752 → next/image)
-- src/app/layout.tsx (font weights audit only — only if a weight is provably unused)
-- src/components/FeaturedListingsClient.tsx (grid spans ~165/225, badges ~251, title link ~283-289)
-- src/app/page.tsx (skeleton ~34-71 → extracted component)
-- NEW src/components/FeaturedListingsSkeleton.tsx
-- src/components/ui/SkipLink.tsx (+ src/components/MainLayout.tsx: tabIndex/outline on `<main>`)
-- src/components/NavbarClient.tsx (polling: terminal-status handling only, ~211-249)
-- tests: extend tests/e2e/journeys/a11y-audit.anon.spec.ts (skip link), new/extended keyboard focus spec
-
-## Risks
-
-- LocationSearchInput is shared with /search (desktop header + mobile overlay) → focus ring appears there
-  too. Mitigation: `focus-visible:` only (keyboard-only; pointer users see zero change) + manual check on /search.
-- Hero CSS-bg → next/image: art direction (`bg-[63%_top]` mobile / `center_right` desktop, opacity-45/100,
-  `::after` SVG mask) must be preserved exactly. Mitigation: keep wrapper div + classes, Image inside with
-  matching object-position; before/after screenshots at all 5 widths.
-- Featured grid span changes alter md layout intentionally — lg+ (1024+) must be pixel-identical.
-- NavbarClient is global chrome → only additive guard (stop polling on 401/403), nothing else.
-- web-vitals-budget.spec.ts (LCP/CLS budgets) is the safety net for H2/H5 — must stay green.
-
-## Fix specs
-
-### 0. Restart dev server (precondition)
-Both :3000/:3010 instances hung during review. Restart `pnpm dev`, confirm `curl localhost:3000/` → 200
-anonymously. Needed for H6 diagnosis and all verification.
-
-### H6 — unreadCount 404: diagnose, then harden (do first, needs fresh server)
-1. Logged-in home, DevTools/network probe: capture REAL status of `/api/messages?view=unreadCount`.
-   - If 200 after restart → environmental (hung dev server); record in results, no route change.
-   - If genuine 4xx/5xx → root-cause in route (auth/jwt callback path) before touching anything.
-2. Hardening (regardless): in src/components/NavbarClient.tsx poll handler, stop polling permanently on
-   401/403 (session terminally invalid; currently backs off and keeps hammering). Keep everything else identical.
-3. No route changes unless step 1 proves a route bug. Existing tests in
-   src/__tests__/api/messages-unread.test.ts pin 200/401/403/500 behavior — keep green.
-
-### H1 — focus-visible rings on search inputs
-Canonical pattern exists: ui/input.tsx → `focus-visible:ring-2 focus-visible:ring-primary/30`.
-- In SearchForm.tsx (search-what ~1015, search-budget-min ~1261, search-budget-max ~1300) and
-  LocationSearchInput.tsx (~825): replace `focus:ring-0` with
-  `focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 rounded-md`.
-  **ring-inset is required**: field wrappers have `overflow-hidden` — an offset ring would clip.
-  Keep `focus:outline-none` and the home variant's `focus:bg-surface-canvas`.
-- Do NOT touch the form-level `focus-within` shadows (lines ~951-952) — they stay as-is.
-- Test: new e2e (extend tests/e2e/search-a11y-keyboard.anon.spec.ts or home spec): Tab into each input
-  on `/`, assert computed box-shadow ≠ 'none'. Manual: /search desktop header + mobile overlay unchanged for mouse.
-
-### H4 — fix line-clamp on card titles (smallest diff first)
-FeaturedListingsClient.tsx ~283-289: move clamp from `<h3>` to the Link; Link becomes
-`line-clamp-1 py-1 hover:underline` (drop `inline-flex min-h-8 items-center`; `line-clamp-*` sets
--webkit-box display; py-1 keeps ~32px tap target: 24px line + 8px). h3 keeps typography classes, drops `line-clamp-1`.
-Verify: long title ("Inner Sunset shared room — UCSF and park nearby") is 1 line + ellipsis at 320/375/768;
-baseline alignment with "2 slots" span unchanged at 1440.
-
-### H3 — featured grid at md
-FeaturedListingsClient.tsx:
-- Card spans (~225): big `md:col-span-12 lg:col-span-6`, small `md:col-span-6 lg:col-span-3`
-  (was md:col-span-6/md:col-span-3). lg+ output identical to today; md becomes 2-up smalls + full-width bigs.
-- Badges (~251): replace `min-w-0 truncate` with `shrink-0` on tag spans (never truncate badge text).
-- Verify at 768: titles ≤2 words/line no more, badges full ("NEW", "OPEN"), meta line shows useful text;
-  1024/1440 unchanged vs before-screenshots.
-
-### H5 — skeleton parity (after H3, mirrors its final classes)
-- Extract real-layout skeleton to NEW src/components/FeaturedListingsSkeleton.tsx (server-safe, no "use client"):
-  - section: same as real section (`py-20 md:py-28` + container) — copy exact classes from
-    FeaturedListingsClient section + `aria-busy="true"`.
-  - header: badge line, h2 block (~2 lines), pills-row placeholder (5 pill shapes), atlas-link placeholder.
-  - grid: `grid grid-cols-1 gap-x-6 gap-y-10 md:grid-cols-12`; items 0 & 5 big
-    (`md:col-span-12 lg:col-span-6`, `h-72 sm:h-80 md:h-[26rem]`), rest small
-    (`md:col-span-6 lg:col-span-3`, `h-64 sm:h-72 md:h-[19rem]`), each + pt-4 title/meta placeholder lines.
-  - keep existing shimmer classes (`animate-shimmer bg-gradient-to-r …`).
-- page.tsx: fallback={<FeaturedListingsSkeleton />}.
-- Verify: throttle/reload `/` (dev has no ISR cache) — no visible jump when skeleton resolves;
-  e2e CLS budget (tests/e2e/performance/web-vitals-budget.spec.ts) green.
-
-### H2 — hero image → next/image (+ font preload audit)
-- HomeClient.tsx ~94: keep `.home-hero-photo` wrapper div + its opacity/`::after` mask classes; replace
-  the CSS background classes (the url + cover + 63%_top / md center_right position utilities) with child
-  `<Image src="/images/home/hero-living-room.png" alt="" fill priority sizes="100vw"
-  className="object-cover object-[63%_top] md:object-[center_right]" />`.
-  (Optimizer serves AVIF/WebP at device widths — config already has formats + sharp ^0.34.5.)
-  `::after` pseudo-element paints above the child image (tree order) — mask preserved; verify mobile curve.
-- HomeClient.tsx ~752 (CTA polaroid): same pattern, `loading="lazy"`, `sizes="(max-width:1024px) 90vw, 33vw"`,
-  wrapper gets `relative overflow-hidden` (keep aspect-[4/3] rounded-2xl).
-- Optional (skip if any visual doubt): downscale source PNG → keep as-is; next/image already cuts wire size.
-- Fonts: diagnose the 2 preloaded-unused woff2 warnings — map the two hashed files to families
-  (network tab vs generated @font-face), grep actual usage of weights (font-medium=500, font-semibold=600,
-  display 600). ONLY remove a weight from layout.tsx config if provably unused; otherwise leave config alone
-  and record findings.
-- Verify: hero art-direction identical at all widths (esp. mobile 63%_top crop + bottom mask curve);
-  network shows AVIF/WebP ≤ ~250KB instead of 1.7MB PNG; LCP budget e2e green; no CLS on hero.
-
-### H7 — skip link works with custom scroll container
-- src/components/ui/SkipLink.tsx → "use client"; add onClick: preventDefault →
-  `document.getElementById(targetId)` → `el.scrollIntoView()` (scrolls the custom container — verified) →
-  `el.focus({ preventScroll: true })`.
-- src/components/MainLayout.tsx `<main id="main-content">`: add `tabIndex={-1}` and `focus:outline-none`
-  (globals.css `:focus-visible:not(input)` would otherwise draw a page-wide outline).
-- Keep href="#main-content" for no-JS semantics.
-- Test: extend tests/e2e/journeys/a11y-audit.anon.spec.ts skip-link test: after Enter,
-  `document.activeElement.id === "main-content"`.
-- Explicitly OUT of scope (pre-existing, separate task): useScrollHeader window.scrollY,
-  Privacy/Terms scroll-spy, InfiniteScroll/LazyImage IntersectionObserver root.
-
-## Execution order (each step: implement → verify → next)
-
-0. Restart dev server → H6 diagnosis (record real status)
-1. H4 title clamp (tiny) → visual check
-2. H3 grid spans + badges → visual check 768/1024/1440
-3. H5 skeleton (mirrors H3 classes) → reload + CLS check
-4. H1 focus rings → keyboard pass home + /search spot-check
-5. H7 skip link → keyboard test
-6. H2 hero next/image + font audit → art-direction screenshots + LCP
-7. H6 hardening (NavbarClient terminal-status) if step 0 confirmed env-only; route fix if not
-8. New/extended tests (H1 focus e2e, H7 skip-link assertion)
-
-## Verification (Definition of Done)
-
-- pnpm lint && pnpm typecheck && pnpm test — green
-- Targeted e2e: journeys/01-discovery-search.spec.ts, performance/web-vitals-budget.spec.ts,
-  search-a11y-keyboard.anon.spec.ts (+ extended), journeys/a11y-audit.anon.spec.ts
-- Browser screenshot pass at 320/375/768/1024/1440 diffed by eye against
-  tasks/.ui-review/homepage-jun10/ "before" shots — only intended changes visible
-- /search regression spot-check: desktop header search, mobile overlay, filters (LocationSearchInput shared)
-- Console: zero errors on `/` (incl. unreadCount), no font-preload warnings if font fix applied
+- `pnpm typecheck`
+- `pnpm test src/__tests__/api/listings-host-managed-patch.test.ts`
+- `pnpm test src/__tests__/api/listings-post.test.ts` (create path unaffected)
+- `pnpm lint` (confirm no orphaned imports)
 
 ## Rollback notes
 
-- Pure FE changes, no DB/migrations. Each fix lands as its own commit → `git revert` per-fix.
-- Hero image fix is the only riskier-looking diff; it's still a 2-block change, revertible independently.
+- Pure code change, reversible by `git revert`. No migration/backfill.
 
-## Results + verification story (2026-06-11)
+## Results + verification story
 
-All 7 HIGH issues closed. Changes uncommitted, ready for review/commit.
+Implemented on branch `fix/listing-patch-address-validation`.
 
-**Environment recovery (step 0)**: dev server was wedged (corrupt webpack cache from a WSL/Docker
-restart event ~20 min before; roomshare-db-1 had exited too). Cleared .next, restarted, started DB
-container. Separately, my own plan file broke the build: Tailwind v4 scans tasks/*.md, picked up a
-class-shaped background-url token from the plan text, and webpack failed on resolving './…' →
-fixed in place + lesson added to tasks/lessons.md.
+- `src/app/api/listings/[id]/route.ts`: PATCH now requires a valid server-signed
+  `addressSuggestionToken` OR Google Address Validation whenever the address
+  changes, mirroring create. Removed the Nominatim `geocodeAddress` fallback and
+  its now-orphaned imports (`geocodeAddress`, `isCircuitOpenError`).
+- `src/__tests__/api/listings-host-managed-patch.test.ts`: added validator mocks +
+  `googleAddressValidation` env getter; updated the 2 address-edit tests to the
+  token path; added a 5-test "P1 bypass guard" describe block.
 
-**H6 — unreadCount "404": closed, NO code change.** With DB healthy: 200 {count:0}. With DB down:
-403 fail-closed ("Unable to verify account status"). The 404 was the wedged dev server. Decided
-against stop-on-403 hardening — a transient DB outage would permanently kill the unread badge until
-reload (regression); existing exponential backoff (max 5 min) already handles both cases.
+Verification (all green):
+- `pnpm typecheck` → EXIT 0
+- `npx jest listings-host-managed-patch.test.ts` → 17 passed (5 new)
+- `npx jest listings-post.test.ts` → 56 passed (create path unaffected)
+- `npx jest listings-idor.test.ts` → 32 passed ([id] route unaffected)
+- `npx eslint` on changed route → 0 errors (pre-existing `LockedListingRow`
+  warning only)
 
-**Fixes landed**:
-- H1 src/components/SearchForm.tsx + LocationSearchInput.tsx — focus-visible:ring-2 ring-inset
-  ring-primary/40 on all 4 inputs (keyboard-only; pointer UX unchanged).
-- H3 FeaturedListingsClient.tsx — big md:col-span-12 lg:col-span-6, small md:col-span-6 lg:col-span-3;
-  badges shrink-0 (never truncate). lg+ unchanged.
-- H4 FeaturedListingsClient.tsx — clamp moved onto the title Link (line-clamp-1 py-1), h3 declassed.
-- H5 NEW src/components/FeaturedListingsSkeleton.tsx mirrors real section; page.tsx fallback swapped.
-- H7 SkipLink.tsx — client onClick: scrollIntoView + focus; MainLayout main gets tabIndex={-1} +
-  focus-visible:outline-none.
-- H2 HomeClient.tsx — hero + CTA polaroid now next/image (fill, priority+sizes=100vw hero / lazy CTA);
-  art direction classes preserved (object-[63%_top] md:object-[center_right], opacity, ::after mask).
-  Hero served via /_next/image (AVIF/WebP, responsive) instead of raw 1.7MB PNG; preload emitted.
-  Font-preload warnings: diagnosed as DEV-ONLY (Next dev appends ?v= to preload hrefs, mismatching
-  @font-face URLs). Prod HTML has no font preloads at all → no config change.
-
-**Verification**:
-- pnpm typecheck ✓, lint 0 errors (none in touched files) ✓, full unit suite ✓ (exit 0).
-- NEW tests/e2e/home-a11y-regression.anon.spec.ts: skip-link (focus lands on #main-content, container
-  scrolls back) + focus-visible rings on all 4 inputs — 2/2 pass.
-- e2e: journeys/01-discovery-search ✓, web-vitals homepage LCP ✓, search-a11y-keyboard 9/9 ✓
-  (incl. the /search LocationSearchInput regression surface).
-- Pre-existing, NOT regressions (proved by stash-and-rerun control on clean main): homepage CLS 0.50
-  (bit-identical 0.5004180081155565 with and without fixes — deterministic pre-existing shift, likely
-  the lazy SearchForm fallback swap; passes CI threshold 0.55) and search-page CLS. Worth a follow-up.
-- Visual (screenshots in tasks/.ui-review/homepage-jun10/after-*.jpeg vs before shots): hero pixel-
-  faithful at 1440/375; 768 featured grid fixed (720px bigs, 348px smalls, full badges, full meta);
-  titles 1 line at every width; terracotta focus ring visible on WHAT input; anonymous homepage 200
-  with AuthCTA rendering (closes the unverified item from the review).
-- Note: Playwright-MCP browser had a stuck 200% page zoom (WSLg restart artifact) — verification used
-  a dedicated chromium launch with --force-device-scale-factor=1; e2e runner unaffected.
-
-**Follow-up (user request, 2026-06-11)**: mobile hero photo was nearly invisible (pre-existing design:
-photo at opacity-45 under a 0.97→0.84 wash). Changed in HomeClient.tsx: photo now full opacity at all
-breakpoints; mobile wash re-curved (0.97 → 0.92 @40% → 0.7 @58% → 0.22 @80% → 0.05 @100%) so the
-headline/subhead/chips zone stays readable while the photo shows at near-full strength below the search
-card. Desktop gradient untouched. Verified at 320/375/640 (screenshots hero-fix-*.jpeg).
-
-**Follow-up 2 (user request, 2026-06-11)**: mobile hero composition — content hugged the navbar with all
-viewport slack pooling at the bottom. HomeClient.tsx: hero inner column is now a mobile flex column with
-two aria-hidden spacers distributing tall-viewport slack (capped max-h-14 breath above the search card,
-flex-[4] photo reveal below it; both md:hidden, collapse to zero on short phones). globals.css:
-.home-hero-frame mobile padding-top clamp raised (1rem→2.25rem) for navbar breathing room; md override
-unchanged. Verified 412x860, 375x812, 360x700, 320x568 + 768 sanity (balance2-*.jpeg).
+Behavior: a direct-API address change without a verified token and with Google
+validation disabled now returns 503 (blocked) instead of silently geocoding. The
+first-party EditListingForm never edits the address, so no UX regression.


### PR DESCRIPTION
## Problem (P1)

`PATCH /api/listings/[id]` bypassed the create-time trusted-address validation. On an address change it only ran best-guess Nominatim forward-geocoding (`geocodeAddress`), which returns coordinates for any plausible-looking address.

`POST /api/listings` gates address acceptance behind either:
- a **server-signed `addressSuggestionToken`** (PREMISE precision, bound to the user + exact submitted fields), or
- **Google Address Validation** (`validateAddressForPublish`),

and blocks otherwise. PATCH did neither, so a direct API caller could create a listing with a verified address and then repoint it to an arbitrary unverified address.

Evidence: create validation path (`src/app/api/listings/route.ts:328`) vs. PATCH geocode-only path (`src/app/api/listings/[id]/route.ts:933`, pre-fix).

## Fix

`PATCH` now mirrors create **exactly** when the address changes (`if (addressChanged)`):
1. Verify `addressSuggestionToken` → use token coords.
2. Else, if Google Address Validation is enabled → `validateAddressForPublish` (**400** if unverifiable, **503** with `Retry-After` on upstream outage).
3. Else → **block (503)** — no silent geocoding fallback.

Removed the Nominatim fallback and its now-orphaned imports (`geocodeAddress`, `isCircuitOpenError`). Added optional `addressSuggestionToken` to `listingProfilePatchSchema` (mirrors the create schema).

## UX impact

None for first-party flows. The official `EditListingForm` does not expose address editing — it re-sends the stored address, so `addressChanged` is `false` and validation is skipped. This closes an **API-level abuse bypass** only.

> Follow-up note: if address editing is ever added to the edit form, it must wire up `AddressAutocompleteInput` and send the `addressSuggestionToken`, exactly like `CreateListingForm`.

## Tests

- Migrated the 2 existing address-edit tests onto the trusted-token path.
- Added a 5-test **"P1 bypass guard"** block: bypass blocked (503, **no** DB write), valid-token path persists token coords (and skips Google), Google fallback path, 400 on unverifiable, and unchanged-address skips validation.

## Verification

- `pnpm typecheck` → clean
- `listings-host-managed-patch` → 17 passed (5 new)
- `listings-post` (create path) → 56 passed
- `listings-idor` ([id] route) → 32 passed
- eslint on the route → 0 errors

## Risk / rollback

Pure code change, no DB migration/backfill. Reversible via `git revert`. No PII in logs (userId prefix + city/state only, matching create).

🤖 Generated with [Claude Code](https://claude.com/claude-code)