### PR TITLE
fix(listings): persist bookingMode on canonical Listing

### DIFF
--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -31,7 +31,16 @@ ALTER TABLE "Listing"
 UPDATE "Listing" AS listing
 SET "booking_mode" = 'WHOLE_UNIT'
 FROM "listing_inventories" AS inventory
-WHERE inventory.unit_id = listing."physical_unit_id"
+WHERE inventory.id = listing.id
+  AND inventory.inventory_key = ('listing:' || listing.id)
+  AND inventory.lifecycle_status = 'ACTIVE'
+  AND inventory.publish_status IN (
+    'PENDING_GEOCODE',
+    'PENDING_PROJECTION',
+    'PENDING_EMBEDDING',
+    'PUBLISHED',
+    'STALE_PUBLISHED'
+  )
   AND inventory.room_category = 'ENTIRE_PLACE'
   AND listing."booking_mode" <> 'WHOLE_UNIT';
 
@@ -43,7 +52,16 @@ WHERE listing."roomType" = 'Entire Place'
   AND NOT EXISTS (
     SELECT 1
     FROM "listing_inventories" AS inventory
-    WHERE inventory.unit_id = listing."physical_unit_id"
+    WHERE inventory.id = listing.id
+      AND inventory.inventory_key = ('listing:' || listing.id)
+      AND inventory.lifecycle_status = 'ACTIVE'
+      AND inventory.publish_status IN (
+        'PENDING_GEOCODE',
+        'PENDING_PROJECTION',
+        'PENDING_EMBEDDING',
+        'PUBLISHED',
+        'STALE_PUBLISHED'
+      )
   );
 
 WITH reconciled_search_docs AS (

--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -13,14 +13,24 @@
 --
 -- Data-safety:
 --   * ADD COLUMN with a constant DEFAULT is metadata-only on PG 11+ (no table rewrite/long lock).
---   * Backfill UPDATE touches only roomType='Entire Place' rows.
+--   * Backfill first preserves existing canonical inventory rows that already represent
+--     whole-unit listings, including divergent rows where roomType is not 'Entire Place'.
+--   * Legacy roomType fallback only fills rows without a stronger inventory signal.
 --   * CHECK added NOT VALID then VALIDATE to avoid a blocking scan on large tables.
 
 ALTER TABLE "Listing"
   ADD COLUMN IF NOT EXISTS "booking_mode" TEXT NOT NULL DEFAULT 'SHARED';
 
--- Backfill existing rows from roomType so current data stays consistent with the
--- derive-from-roomType behavior that was in effect while the column was absent.
+-- Backfill from existing canonical inventory first; this preserves divergent rows
+-- created while bookingMode was accepted but not stored on Listing.
+UPDATE "Listing" AS listing
+SET "booking_mode" = 'WHOLE_UNIT'
+FROM "listing_inventories" AS inventory
+WHERE inventory.listing_id = listing.id
+  AND inventory.room_category = 'ENTIRE_PLACE'
+  AND listing."booking_mode" <> 'WHOLE_UNIT';
+
+-- Fall back to legacy derive-from-roomType behavior for rows without an inventory signal.
 UPDATE "Listing"
 SET "booking_mode" = 'WHOLE_UNIT'
 WHERE "roomType" = 'Entire Place'

--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -66,11 +66,21 @@ WHERE listing."roomType" = 'Entire Place'
 
 WITH reconciled_search_docs AS (
   UPDATE listing_search_docs AS doc
-  SET booking_mode = listing."booking_mode",
+  SET booking_mode = listing.effective_booking_mode,
       doc_updated_at = NOW()
-  FROM "Listing" AS listing
+  FROM (
+    SELECT
+      listing.id,
+      CASE
+        WHEN listing."booking_mode" = 'WHOLE_UNIT'
+          OR listing."roomType" = 'Entire Place'
+        THEN 'WHOLE_UNIT'
+        ELSE COALESCE(listing."booking_mode", 'SHARED')
+      END AS effective_booking_mode
+    FROM "Listing" AS listing
+  ) AS listing
   WHERE doc.id = listing.id
-    AND doc.booking_mode IS DISTINCT FROM listing."booking_mode"
+    AND doc.booking_mode IS DISTINCT FROM listing.effective_booking_mode
   RETURNING doc.id
 )
 INSERT INTO listing_search_doc_dirty (listing_id, reason, marked_at)

--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -26,7 +26,7 @@ ALTER TABLE "Listing"
 UPDATE "Listing" AS listing
 SET "booking_mode" = 'WHOLE_UNIT'
 FROM "listing_inventories" AS inventory
-WHERE inventory.listing_id = listing.id
+WHERE inventory.unit_id = listing."physical_unit_id"
   AND inventory.room_category = 'ENTIRE_PLACE'
   AND listing."booking_mode" <> 'WHOLE_UNIT';
 

--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -8,6 +8,9 @@
 -- choice persists and may legitimately diverge from roomType.
 --
 -- Rollback (reversible):
+--   DELETE FROM listing_search_doc_dirty WHERE reason = 'booking_mode_backfill';
+--   Regenerate listing_search_docs from the pre-rollback projection, or restore prior
+--   search docs from backup if preserving stale booking_mode values is required.
 --   ALTER TABLE "Listing" DROP CONSTRAINT "Listing_bookingMode_check";
 --   ALTER TABLE "Listing" DROP COLUMN "booking_mode";
 --
@@ -16,6 +19,8 @@
 --   * Backfill first preserves existing canonical inventory rows that already represent
 --     whole-unit listings, including divergent rows where roomType is not 'Entire Place'.
 --   * Legacy roomType fallback only fills rows without a stronger inventory signal.
+--   * Existing search docs are reconciled and marked dirty so stale booking_mode filters
+--     are repaired immediately and by the durable backstop.
 --   * CHECK added NOT VALID then VALIDATE to avoid a blocking scan on large tables.
 
 ALTER TABLE "Listing"
@@ -35,6 +40,22 @@ UPDATE "Listing"
 SET "booking_mode" = 'WHOLE_UNIT'
 WHERE "roomType" = 'Entire Place'
   AND "booking_mode" <> 'WHOLE_UNIT';
+
+WITH reconciled_search_docs AS (
+  UPDATE listing_search_docs AS doc
+  SET booking_mode = listing."booking_mode",
+      doc_updated_at = NOW()
+  FROM "Listing" AS listing
+  WHERE doc.id = listing.id
+    AND doc.booking_mode IS DISTINCT FROM listing."booking_mode"
+  RETURNING doc.id
+)
+INSERT INTO listing_search_doc_dirty (listing_id, reason, marked_at)
+SELECT id, 'booking_mode_backfill', NOW()
+FROM reconciled_search_docs
+ON CONFLICT (listing_id) DO UPDATE SET
+  reason = EXCLUDED.reason,
+  marked_at = EXCLUDED.marked_at;
 
 ALTER TABLE "Listing"
   ADD CONSTRAINT "Listing_bookingMode_check"

--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -36,10 +36,15 @@ WHERE inventory.unit_id = listing."physical_unit_id"
   AND listing."booking_mode" <> 'WHOLE_UNIT';
 
 -- Fall back to legacy derive-from-roomType behavior for rows without an inventory signal.
-UPDATE "Listing"
+UPDATE "Listing" AS listing
 SET "booking_mode" = 'WHOLE_UNIT'
-WHERE "roomType" = 'Entire Place'
-  AND "booking_mode" <> 'WHOLE_UNIT';
+WHERE listing."roomType" = 'Entire Place'
+  AND listing."booking_mode" <> 'WHOLE_UNIT'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "listing_inventories" AS inventory
+    WHERE inventory.unit_id = listing."physical_unit_id"
+  );
 
 WITH reconciled_search_docs AS (
   UPDATE listing_search_docs AS doc

--- a/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
+++ b/prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql
@@ -1,0 +1,33 @@
+-- Re-introduce canonical booking_mode on Listing.
+--
+-- Phase-09 (20260509000000_phase09_cutover_retire_booking) dropped Listing.booking_mode
+-- as part of retiring the legacy Booking model, but nothing replaced it as the durable
+-- source of truth. The listing-create API still accepts `bookingMode`, so a host's
+-- WHOLE_UNIT/SHARED choice was silently lost and every read path re-derived it from
+-- roomType (or hardcoded 'SHARED'). This restores a first-class, durable column so the
+-- choice persists and may legitimately diverge from roomType.
+--
+-- Rollback (reversible):
+--   ALTER TABLE "Listing" DROP CONSTRAINT "Listing_bookingMode_check";
+--   ALTER TABLE "Listing" DROP COLUMN "booking_mode";
+--
+-- Data-safety:
+--   * ADD COLUMN with a constant DEFAULT is metadata-only on PG 11+ (no table rewrite/long lock).
+--   * Backfill UPDATE touches only roomType='Entire Place' rows.
+--   * CHECK added NOT VALID then VALIDATE to avoid a blocking scan on large tables.
+
+ALTER TABLE "Listing"
+  ADD COLUMN IF NOT EXISTS "booking_mode" TEXT NOT NULL DEFAULT 'SHARED';
+
+-- Backfill existing rows from roomType so current data stays consistent with the
+-- derive-from-roomType behavior that was in effect while the column was absent.
+UPDATE "Listing"
+SET "booking_mode" = 'WHOLE_UNIT'
+WHERE "roomType" = 'Entire Place'
+  AND "booking_mode" <> 'WHOLE_UNIT';
+
+ALTER TABLE "Listing"
+  ADD CONSTRAINT "Listing_bookingMode_check"
+  CHECK ("booking_mode" IN ('SHARED', 'WHOLE_UNIT')) NOT VALID;
+
+ALTER TABLE "Listing" VALIDATE CONSTRAINT "Listing_bookingMode_check";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Listing {
   houseRules              String[]
   leaseDuration           String?
   roomType                String?
+  bookingMode             String                    @default("SHARED") @map("booking_mode")
   normalizedAddress       String?
   physicalUnitId          String?                   @map("physical_unit_id")
   householdLanguages      String[]                  @default([]) @map("household_languages")

--- a/scripts/cfm/backfill-canonical-inventory.ts
+++ b/scripts/cfm/backfill-canonical-inventory.ts
@@ -12,6 +12,7 @@ type ListingRow = {
   ownerId: string;
   price: string;
   roomType: string | null;
+  bookingMode: string;
   totalSlots: number;
   availableSlots: number;
   openSlots: number | null;
@@ -130,6 +131,7 @@ function canonicalize(row: ListingRow): {
 function roomCategory(
   row: ListingRow
 ): "ENTIRE_PLACE" | "PRIVATE_ROOM" | "SHARED_ROOM" {
+  if (row.bookingMode === "WHOLE_UNIT") return "ENTIRE_PLACE";
   if (row.roomType === "Entire Place") return "ENTIRE_PLACE";
   if (row.roomType === "Shared Room") return "SHARED_ROOM";
   return "PRIVATE_ROOM";
@@ -163,6 +165,7 @@ async function fetchPendingRows(
       l."ownerId" AS "ownerId",
       l.price::TEXT AS price,
       l."roomType" AS "roomType",
+      l."booking_mode" AS "bookingMode",
       l."totalSlots" AS "totalSlots",
       l."availableSlots" AS "availableSlots",
       l."openSlots" AS "openSlots",

--- a/scripts/seed-demo.js
+++ b/scripts/seed-demo.js
@@ -18,6 +18,10 @@ const prisma = new PrismaClient();
 const DRY_RUN = process.argv.includes('--dry-run');
 const DEMO_PASSWORD = 'RoomshareDemo2026!';
 
+function deriveBookingMode(roomType) {
+  return roomType === 'Entire Place' ? 'WHOLE_UNIT' : 'SHARED';
+}
+
 // ---------------------------------------------------------------------------
 // Demo user definitions
 // ---------------------------------------------------------------------------
@@ -473,6 +477,7 @@ async function tableExists(tableName) {
 // upsertListingWithLocation — mirrors seed-e2e.js exactly
 // ---------------------------------------------------------------------------
 async function upsertListingWithLocation(ownerId, seed) {
+  const bookingMode = seed.bookingMode || deriveBookingMode(seed.roomType);
   const listing = await prisma.listing.upsert({
     where: { id: seed.id },
     update: {
@@ -481,6 +486,7 @@ async function upsertListingWithLocation(ownerId, seed) {
       description: seed.description,
       price: seed.price,
       roomType: seed.roomType,
+      bookingMode,
       amenities: seed.amenities || ['Wifi', 'Furnished', 'Kitchen'],
       houseRules: seed.houseRules || [],
       householdLanguages: ['en'],
@@ -518,6 +524,7 @@ async function upsertListingWithLocation(ownerId, seed) {
       description: seed.description,
       price: seed.price,
       roomType: seed.roomType,
+      bookingMode,
       amenities: seed.amenities || ['Wifi', 'Furnished', 'Kitchen'],
       houseRules: seed.houseRules || [],
       householdLanguages: ['en'],
@@ -912,7 +919,7 @@ async function main() {
         INSERT INTO listing_search_docs (
           id, owner_id, title, description, price, images,
           amenities, house_rules, household_languages, primary_home_language,
-          lease_duration, room_type, move_in_date, total_slots, available_slots,
+          lease_duration, room_type, booking_mode, move_in_date, total_slots, available_slots,
           view_count, status, listing_created_at,
           address, city, state, zip, location_geog, lat, lng,
           avg_rating, review_count, recommended_score,
@@ -923,7 +930,12 @@ async function main() {
         SELECT
           l.id, l."ownerId", l.title, l.description, l.price, l.images,
           l.amenities, l."houseRules", l."household_languages", l."primary_home_language",
-          l."leaseDuration", l."roomType", l."moveInDate", l."totalSlots", l."availableSlots",
+          l."leaseDuration", l."roomType",
+          CASE
+            WHEN l."booking_mode" = 'WHOLE_UNIT' OR l."roomType" = 'Entire Place' THEN 'WHOLE_UNIT'
+            ELSE COALESCE(l."booking_mode", 'SHARED')
+          END,
+          l."moveInDate", l."totalSlots", l."availableSlots",
           l."viewCount", l.status::text, l."createdAt",
           loc.address, loc.city, loc.state, loc.zip,
           loc.coords, ST_Y(loc.coords::geometry), ST_X(loc.coords::geometry),
@@ -949,6 +961,7 @@ async function main() {
           primary_home_language = EXCLUDED.primary_home_language,
           lease_duration = EXCLUDED.lease_duration,
           room_type = EXCLUDED.room_type,
+          booking_mode = EXCLUDED.booking_mode,
           move_in_date = EXCLUDED.move_in_date,
           total_slots = EXCLUDED.total_slots,
           available_slots = EXCLUDED.available_slots,

--- a/scripts/seed-e2e.js
+++ b/scripts/seed-e2e.js
@@ -26,6 +26,10 @@ const DEFAULT_PROFILE_BIO =
   'E2E verified Roomshare test profile with enough detail for create flows.';
 const SF_PRIMARY_USER_LISTING_COUNT = 5;
 
+function deriveBookingMode(roomType) {
+  return roomType === 'Entire Place' ? 'WHOLE_UNIT' : 'SHARED';
+}
+
 function slugifyFixtureId(value) {
   return value
     .toLowerCase()
@@ -373,6 +377,7 @@ const CROSS_OWNER_SEEDS = [
 ];
 
 async function upsertListingWithLocation(ownerId, seed) {
+  const bookingMode = seed.bookingMode || deriveBookingMode(seed.roomType);
   const listing = await prisma.listing.upsert({
     where: { id: seed.id },
     update: {
@@ -381,6 +386,7 @@ async function upsertListingWithLocation(ownerId, seed) {
       description: seed.description,
       price: seed.price,
       roomType: seed.roomType,
+      bookingMode,
       amenities: seed.amenities || ['Wifi', 'Furnished', 'Kitchen'],
       houseRules: seed.houseRules || ['No Smoking', 'Quiet Hours 10pm-8am'],
       householdLanguages: ['en'],
@@ -420,6 +426,7 @@ async function upsertListingWithLocation(ownerId, seed) {
       description: seed.description,
       price: seed.price,
       roomType: seed.roomType,
+      bookingMode,
       amenities: seed.amenities || ['Wifi', 'Furnished', 'Kitchen'],
       houseRules: seed.houseRules || ['No Smoking', 'Quiet Hours 10pm-8am'],
       householdLanguages: ['en'],
@@ -924,6 +931,7 @@ async function main() {
   const reviewerMoveInDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
   const reviewerAvailableUntil = new Date(Date.now() + 180 * 24 * 60 * 60 * 1000);
   const reviewerImages = ['https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?w=600'];
+  const reviewerBookingMode = deriveBookingMode(REVIEWER_LISTING.roomType);
 
   const existingReviewerListing = await prisma.listing.findFirst({
     where: { title: REVIEWER_LISTING.title, ownerId: reviewer.id },
@@ -941,6 +949,7 @@ async function main() {
         description: REVIEWER_LISTING.description,
         price: REVIEWER_LISTING.price,
         roomType: REVIEWER_LISTING.roomType,
+        bookingMode: reviewerBookingMode,
         amenities: ['WiFi', 'Furnished', 'Laundry'],
         houseRules: ['No Pets'],
         householdLanguages: ['en'],
@@ -978,6 +987,7 @@ async function main() {
       description: REVIEWER_LISTING.description,
       price: REVIEWER_LISTING.price,
       roomType: REVIEWER_LISTING.roomType,
+      bookingMode: reviewerBookingMode,
       amenities: ['WiFi', 'Furnished', 'Laundry'],
       houseRules: ['No Pets'],
       householdLanguages: ['en'],
@@ -1313,7 +1323,7 @@ async function main() {
         INSERT INTO listing_search_docs (
           id, owner_id, title, description, price, images,
           amenities, house_rules, household_languages, primary_home_language,
-          lease_duration, room_type, move_in_date, total_slots, available_slots,
+          lease_duration, room_type, booking_mode, move_in_date, total_slots, available_slots,
           view_count, status, listing_created_at,
           address, city, state, zip, location_geog, lat, lng,
           avg_rating, review_count, recommended_score,
@@ -1324,7 +1334,12 @@ async function main() {
         SELECT
           l.id, l."ownerId", l.title, l.description, l.price, l.images,
           l.amenities, l."houseRules", l."household_languages", l."primary_home_language",
-          l."leaseDuration", l."roomType", l."moveInDate", l."totalSlots", l."availableSlots",
+          l."leaseDuration", l."roomType",
+          CASE
+            WHEN l."booking_mode" = 'WHOLE_UNIT' OR l."roomType" = 'Entire Place' THEN 'WHOLE_UNIT'
+            ELSE COALESCE(l."booking_mode", 'SHARED')
+          END,
+          l."moveInDate", l."totalSlots", l."availableSlots",
           l."viewCount", l.status::text, l."createdAt",
           loc.address, loc.city, loc.state, loc.zip,
           loc.coords, ST_Y(loc.coords::geometry), ST_X(loc.coords::geometry),
@@ -1353,6 +1368,7 @@ async function main() {
           primary_home_language = EXCLUDED.primary_home_language,
           lease_duration = EXCLUDED.lease_duration,
           room_type = EXCLUDED.room_type,
+          booking_mode = EXCLUDED.booking_mode,
           move_in_date = EXCLUDED.move_in_date,
           total_slots = EXCLUDED.total_slots,
           available_slots = EXCLUDED.available_slots,

--- a/scripts/seed-listings.js
+++ b/scripts/seed-listings.js
@@ -169,6 +169,11 @@ const leaseDurations = ["Month-to-month", "3 months", "6 months", "12 months"];
 const genderPrefs = ["NO_PREFERENCE", "MALE_ONLY", "FEMALE_ONLY"];
 // CHECK constraint: householdGender IN ('ALL_MALE','ALL_FEMALE','MIXED')
 const householdGenders = ["MIXED", "ALL_MALE", "ALL_FEMALE"];
+
+function deriveBookingMode(roomType) {
+    return roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED";
+}
+
 async function main() {
     // Get the user ID for the owner
     const user = await prisma.user.findFirst({
@@ -186,6 +191,7 @@ async function main() {
         const listing = listings[i];
         const amenitySet = amenities[i % amenities.length];
         const ruleSet = houseRules[i % houseRules.length];
+        const roomType = roomTypes[i % roomTypes.length];
 
         try {
             const created = await prisma.listing.create({
@@ -204,7 +210,8 @@ async function main() {
                     genderPreference: genderPrefs[i % genderPrefs.length],
                     householdGender: householdGenders[i % householdGenders.length],
                     leaseDuration: leaseDurations[i % leaseDurations.length],
-                    roomType: roomTypes[i % roomTypes.length],
+                    roomType,
+                    bookingMode: deriveBookingMode(roomType),
                     totalSlots: 2,
                     availableSlots: 1,
                     status: "ACTIVE",

--- a/scripts/seed-staging.js
+++ b/scripts/seed-staging.js
@@ -423,6 +423,10 @@ function daysFromNow(days) {
   return date;
 }
 
+function deriveBookingMode(roomType) {
+  return roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED";
+}
+
 function buildListingData(seed, ownerId) {
   const moveInDate = daysFromNow(seed.status === "ACTIVE" ? 14 : 30);
   const availableUntil = daysFromNow(180);
@@ -438,6 +442,7 @@ function buildListingData(seed, ownerId) {
     houseRules: seed.houseRules,
     leaseDuration: seed.leaseDuration,
     roomType: seed.roomType,
+    bookingMode: seed.bookingMode || deriveBookingMode(seed.roomType),
     normalizedAddress:
       `${seed.address}, ${seed.city}, ${seed.state} ${seed.zip}`
         .toLowerCase()

--- a/scripts/seed-test-listings.js
+++ b/scripts/seed-test-listings.js
@@ -9,6 +9,10 @@ const { PrismaClient } = require('@prisma/client');
 
 const prisma = new PrismaClient();
 
+function deriveBookingMode(roomType) {
+  return roomType === 'Entire Place' ? 'WHOLE_UNIT' : 'SHARED';
+}
+
 // ============================================================
 // LANGUAGE CODES (ISO 639-1) - matching src/lib/languages.ts
 // ============================================================
@@ -1046,6 +1050,7 @@ async function main() {
       const amenities = test.amenities || ['WiFi'];
       const houseRules = test.houseRules || ['No Smoking'];
       const price = 1000 + Math.floor(Math.random() * 1500);
+      const roomType = test.roomType !== undefined ? test.roomType : 'Private Room';
 
       const listing = await prisma.listing.create({
         data: {
@@ -1062,7 +1067,8 @@ async function main() {
           genderPreference: test.genderPreference !== undefined ? test.genderPreference : 'NO_PREFERENCE',
           householdGender: test.householdGender !== undefined ? test.householdGender : 'MIXED',
           leaseDuration: test.leaseDuration !== undefined ? test.leaseDuration : 'Flexible',
-          roomType: test.roomType !== undefined ? test.roomType : 'Private Room',
+          roomType,
+          bookingMode: deriveBookingMode(roomType),
           totalSlots: 2,
           availableSlots: 1,
           status: 'ACTIVE',

--- a/src/__tests__/api/listings-idor.test.ts
+++ b/src/__tests__/api/listings-idor.test.ts
@@ -350,6 +350,63 @@ describe("Listings API IDOR Protection", () => {
       expect(updateMock).toHaveBeenCalled();
     });
 
+    // P1 regression: bookingMode must persist on profile edit, and must not be
+    // clobbered when a (flag-off) client omits it from the payload.
+    function mockOwnerPatchTransaction() {
+      (auth as jest.Mock).mockResolvedValue(ownerSession);
+      (prisma.listing.findUnique as jest.Mock).mockResolvedValue(mockListing);
+      const updateMock = jest
+        .fn()
+        .mockResolvedValue({ ...mockListing, title: "Updated Title" });
+      (prisma.$transaction as jest.Mock).mockImplementation(
+        async (callback) => {
+          const tx = {
+            $queryRaw: jest.fn().mockResolvedValue([makeLockedListing()]),
+            listing: {
+              findUnique: jest.fn().mockResolvedValue(makeLockedListing()),
+              update: updateMock,
+            },
+            location: { update: jest.fn() },
+            $executeRaw: jest.fn(),
+          };
+          return callback(tx);
+        }
+      );
+      return updateMock;
+    }
+
+    it("persists bookingMode on profile PATCH when provided", async () => {
+      const updateMock = mockOwnerPatchTransaction();
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({ ...validPatchPayload, bookingMode: "WHOLE_UNIT" }),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateMock.mock.calls[0][0].data).toMatchObject({
+        bookingMode: "WHOLE_UNIT",
+      });
+    });
+
+    it("does not clobber bookingMode when omitted from profile PATCH", async () => {
+      const updateMock = mockOwnerPatchTransaction();
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify(validPatchPayload),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateMock.mock.calls[0][0].data).not.toHaveProperty("bookingMode");
+    });
+
     it("returns 409 for legacy inventory writes against HOST_MANAGED listings", async () => {
       (auth as jest.Mock).mockResolvedValue(ownerSession);
       (prisma.listing.findUnique as jest.Mock).mockResolvedValue(mockListing);

--- a/src/__tests__/api/listings-idor.test.ts
+++ b/src/__tests__/api/listings-idor.test.ts
@@ -509,6 +509,30 @@ describe("Listings API IDOR Protection", () => {
       });
     });
 
+    it("repairs existing Entire Place listings with SHARED bookingMode when bookingMode is omitted", async () => {
+      const updateMock = mockOwnerPatchTransaction({
+        roomType: "Entire Place",
+        bookingMode: "SHARED",
+      });
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          ...validPatchPayload,
+          title: "Updated Entire Place Title",
+          roomType: "Entire Place",
+        }),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateMock.mock.calls[0][0].data).toMatchObject({
+        bookingMode: "WHOLE_UNIT",
+      });
+    });
+
     it("does not clobber bookingMode when omitted from profile PATCH", async () => {
       const updateMock = mockOwnerPatchTransaction();
       const request = new Request("http://localhost/api/listings/listing-abc", {

--- a/src/__tests__/api/listings-idor.test.ts
+++ b/src/__tests__/api/listings-idor.test.ts
@@ -163,6 +163,7 @@ import {
   getFuturePeakReservedLoad,
   syncFutureInventoryTotalSlots,
 } from "@/lib/availability";
+import { features } from "@/lib/env";
 
 function makeAvailabilitySnapshot(
   overrides: Partial<{
@@ -192,6 +193,7 @@ function makeLockedListing(
     ownerId: string;
     totalSlots: number;
     availableSlots: number;
+    roomType: string | null;
     bookingMode: string;
     availabilitySource: "LEGACY_BOOKING" | "HOST_MANAGED";
     moveInDate: Date | null;
@@ -210,6 +212,7 @@ function makeLockedListing(
     openSlots: 2,
     totalSlots: 2,
     availableSlots: 2,
+    roomType: null,
     bookingMode: "SHARED",
     availabilitySource: "LEGACY_BOOKING" as const,
     moveInDate: new Date("2026-05-01T00:00:00.000Z"),
@@ -220,6 +223,11 @@ function makeLockedListing(
 }
 
 describe("Listings API IDOR Protection", () => {
+  const originalWholeUnitModeDescriptor = Object.getOwnPropertyDescriptor(
+    features,
+    "wholeUnitMode"
+  );
+
   const ownerSession = {
     user: { id: "owner-123", email: "owner@example.com", isSuspended: false },
     authTime: Math.floor(Date.now() / 1000),
@@ -273,10 +281,24 @@ describe("Listings API IDOR Protection", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(features, "wholeUnitMode", {
+      configurable: true,
+      get: () => false,
+    });
     (prisma.user.findUnique as jest.Mock).mockResolvedValue({ password: null });
     (getAvailability as jest.Mock).mockResolvedValue(makeAvailabilitySnapshot());
     (getFuturePeakReservedLoad as jest.Mock).mockResolvedValue(0);
     (syncFutureInventoryTotalSlots as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    if (originalWholeUnitModeDescriptor) {
+      Object.defineProperty(
+        features,
+        "wholeUnitMode",
+        originalWholeUnitModeDescriptor
+      );
+    }
   });
 
   describe("PATCH /api/listings/[id]", () => {
@@ -292,6 +314,7 @@ describe("Listings API IDOR Protection", () => {
           description: "Hacked description",
           price: "1",
           totalSlots: "1",
+          bookingMode: "WHOLE_UNIT",
         }),
       });
 
@@ -352,18 +375,21 @@ describe("Listings API IDOR Protection", () => {
 
     // P1 regression: bookingMode must persist on profile edit, and must not be
     // clobbered when a (flag-off) client omits it from the payload.
-    function mockOwnerPatchTransaction() {
+    function mockOwnerPatchTransaction(
+      lockedOverrides: Parameters<typeof makeLockedListing>[0] = {}
+    ) {
       (auth as jest.Mock).mockResolvedValue(ownerSession);
       (prisma.listing.findUnique as jest.Mock).mockResolvedValue(mockListing);
+      const lockedListing = makeLockedListing(lockedOverrides);
       const updateMock = jest
         .fn()
         .mockResolvedValue({ ...mockListing, title: "Updated Title" });
       (prisma.$transaction as jest.Mock).mockImplementation(
         async (callback) => {
           const tx = {
-            $queryRaw: jest.fn().mockResolvedValue([makeLockedListing()]),
+            $queryRaw: jest.fn().mockResolvedValue([lockedListing]),
             listing: {
-              findUnique: jest.fn().mockResolvedValue(makeLockedListing()),
+              findUnique: jest.fn().mockResolvedValue(lockedListing),
               update: updateMock,
             },
             location: { update: jest.fn() },
@@ -375,11 +401,102 @@ describe("Listings API IDOR Protection", () => {
       return updateMock;
     }
 
-    it("persists bookingMode on profile PATCH when provided", async () => {
+    it("persists bookingMode on profile PATCH when provided and wholeUnitMode is enabled", async () => {
+      Object.defineProperty(features, "wholeUnitMode", {
+        configurable: true,
+        get: () => true,
+      });
       const updateMock = mockOwnerPatchTransaction();
       const request = new Request("http://localhost/api/listings/listing-abc", {
         method: "PATCH",
         body: JSON.stringify({ ...validPatchPayload, bookingMode: "WHOLE_UNIT" }),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateMock.mock.calls[0][0].data).toMatchObject({
+        bookingMode: "WHOLE_UNIT",
+      });
+    });
+
+    it("derives SHARED when wholeUnitMode is disabled and non-entire roomType posts WHOLE_UNIT", async () => {
+      const updateMock = mockOwnerPatchTransaction({ roomType: "Private Room" });
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          ...validPatchPayload,
+          roomType: "Private Room",
+          bookingMode: "WHOLE_UNIT",
+        }),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateMock.mock.calls[0][0].data).toMatchObject({
+        bookingMode: "SHARED",
+      });
+    });
+
+    it("derives WHOLE_UNIT when wholeUnitMode is disabled and Entire Place posts SHARED", async () => {
+      const updateMock = mockOwnerPatchTransaction({ roomType: "Private Room" });
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          ...validPatchPayload,
+          roomType: "Entire Place",
+          bookingMode: "SHARED",
+        }),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateMock.mock.calls[0][0].data).toMatchObject({
+        bookingMode: "WHOLE_UNIT",
+      });
+    });
+
+    it("rejects enabled wholeUnitMode Entire Place PATCH with SHARED bookingMode", async () => {
+      Object.defineProperty(features, "wholeUnitMode", {
+        configurable: true,
+        get: () => true,
+      });
+      const updateMock = mockOwnerPatchTransaction({ roomType: "Private Room" });
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          ...validPatchPayload,
+          roomType: "Entire Place",
+          bookingMode: "SHARED",
+        }),
+      });
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: "listing-abc" }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.fields).toHaveProperty("bookingMode");
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it("sets WHOLE_UNIT when roomType changes to Entire Place and bookingMode is omitted", async () => {
+      const updateMock = mockOwnerPatchTransaction({ roomType: "Private Room" });
+      const request = new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          ...validPatchPayload,
+          roomType: "Entire Place",
+        }),
       });
 
       const response = await PATCH(request, {

--- a/src/__tests__/api/listings-post.test.ts
+++ b/src/__tests__/api/listings-post.test.ts
@@ -182,6 +182,7 @@ import { triggerInstantAlerts } from "@/lib/search-alerts";
 import { markListingDirtyInTx } from "@/lib/search/search-doc-dirty";
 import { syncCanonicalListingInventory } from "@/lib/listings/canonical-inventory";
 import { calculateProfileCompletion } from "@/lib/profile-completion";
+import { features } from "@/lib/env";
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -262,9 +263,17 @@ function mockSuccessfulTransaction() {
 
 describe("POST /api/listings — extended edge cases", () => {
   const originalGooglePlacesApiKey = process.env.GOOGLE_PLACES_API_KEY;
+  const originalWholeUnitModeDescriptor = Object.getOwnPropertyDescriptor(
+    features,
+    "wholeUnitMode"
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(features, "wholeUnitMode", {
+      configurable: true,
+      get: () => false,
+    });
     process.env.GOOGLE_PLACES_API_KEY = "test-google-key";
     (geocodeAddress as jest.Mock).mockReset();
     (verifyAddressSuggestionToken as jest.Mock).mockReset();
@@ -307,6 +316,13 @@ describe("POST /api/listings — extended edge cases", () => {
   });
 
   afterAll(() => {
+    if (originalWholeUnitModeDescriptor) {
+      Object.defineProperty(
+        features,
+        "wholeUnitMode",
+        originalWholeUnitModeDescriptor
+      );
+    }
     if (originalGooglePlacesApiKey === undefined) {
       delete process.env.GOOGLE_PLACES_API_KEY;
     } else {
@@ -558,12 +574,33 @@ describe("POST /api/listings — extended edge cases", () => {
     }
 
     it("persists bookingMode WHOLE_UNIT even when roomType diverges", async () => {
+      Object.defineProperty(features, "wholeUnitMode", {
+        configurable: true,
+        get: () => true,
+      });
       const { create } = mockCapturingTransaction();
       const response = await POST(
         makeRequest({
           ...validBody,
           roomType: "Private Room",
           bookingMode: "WHOLE_UNIT",
+        })
+      );
+      expect(response.status).toBe(201);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ bookingMode: "WHOLE_UNIT" }),
+        })
+      );
+    });
+
+    it("derives WHOLE_UNIT from Entire Place when wholeUnitMode is disabled even if SHARED is posted", async () => {
+      const { create } = mockCapturingTransaction();
+      const response = await POST(
+        makeRequest({
+          ...validBody,
+          roomType: "Entire Place",
+          bookingMode: "SHARED",
         })
       );
       expect(response.status).toBe(201);

--- a/src/__tests__/api/listings-post.test.ts
+++ b/src/__tests__/api/listings-post.test.ts
@@ -574,13 +574,28 @@ describe("POST /api/listings — extended edge cases", () => {
       );
     });
 
-    it("defaults bookingMode to SHARED when omitted", async () => {
+    it("defaults omitted bookingMode to SHARED for non-entire-place roomType", async () => {
       const { create } = mockCapturingTransaction();
-      const response = await POST(makeRequest(validBody));
+      const response = await POST(
+        makeRequest({ ...validBody, roomType: "Private Room" })
+      );
       expect(response.status).toBe(201);
       expect(create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ bookingMode: "SHARED" }),
+        })
+      );
+    });
+
+    it("defaults omitted bookingMode to WHOLE_UNIT for Entire Place roomType", async () => {
+      const { create } = mockCapturingTransaction();
+      const response = await POST(
+        makeRequest({ ...validBody, roomType: "Entire Place" })
+      );
+      expect(response.status).toBe(201);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ bookingMode: "WHOLE_UNIT" }),
         })
       );
     });

--- a/src/__tests__/api/listings-post.test.ts
+++ b/src/__tests__/api/listings-post.test.ts
@@ -534,6 +534,66 @@ describe("POST /api/listings — extended edge cases", () => {
   });
 
   // =========================================================================
+  // bookingMode persistence (P1 regression)
+  // =========================================================================
+  // Regression: bookingMode was accepted + validated but omitted from
+  // listingCreateData, so a host's WHOLE_UNIT choice never reached the
+  // canonical Listing row (the column had been dropped in the phase-09 cutover).
+  describe("bookingMode persistence (P1 regression)", () => {
+    function mockCapturingTransaction() {
+      const create = jest.fn().mockResolvedValue(mockListing);
+      (prisma.$transaction as jest.Mock).mockImplementation(async (callback) => {
+        const tx = {
+          listing: { create },
+          location: { create: jest.fn().mockResolvedValue({ id: "loc-123" }) },
+          $executeRaw: jest.fn().mockResolvedValue(1),
+          $queryRaw: jest
+            .fn()
+            .mockResolvedValueOnce([{ count: 0 }])
+            .mockResolvedValue([]),
+        };
+        return callback(tx);
+      });
+      return { create };
+    }
+
+    it("persists bookingMode WHOLE_UNIT even when roomType diverges", async () => {
+      const { create } = mockCapturingTransaction();
+      const response = await POST(
+        makeRequest({
+          ...validBody,
+          roomType: "Private Room",
+          bookingMode: "WHOLE_UNIT",
+        })
+      );
+      expect(response.status).toBe(201);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ bookingMode: "WHOLE_UNIT" }),
+        })
+      );
+    });
+
+    it("defaults bookingMode to SHARED when omitted", async () => {
+      const { create } = mockCapturingTransaction();
+      const response = await POST(makeRequest(validBody));
+      expect(response.status).toBe(201);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ bookingMode: "SHARED" }),
+        })
+      );
+    });
+
+    it('rejects filter-only bookingMode "any"', async () => {
+      const response = await POST(
+        makeRequest({ ...validBody, bookingMode: "any" })
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  // =========================================================================
   // 3. Image validation
   // =========================================================================
 

--- a/src/__tests__/api/listings-post.test.ts
+++ b/src/__tests__/api/listings-post.test.ts
@@ -594,6 +594,25 @@ describe("POST /api/listings — extended edge cases", () => {
       );
     });
 
+    it("rejects enabled wholeUnitMode Entire Place listings with SHARED bookingMode", async () => {
+      Object.defineProperty(features, "wholeUnitMode", {
+        configurable: true,
+        get: () => true,
+      });
+      const response = await POST(
+        makeRequest({
+          ...validBody,
+          roomType: "Entire Place",
+          bookingMode: "SHARED",
+        })
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.fields).toHaveProperty("bookingMode");
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
     it("derives WHOLE_UNIT from Entire Place when wholeUnitMode is disabled even if SHARED is posted", async () => {
       const { create } = mockCapturingTransaction();
       const response = await POST(

--- a/src/__tests__/components/CreateListingForm.test.tsx
+++ b/src/__tests__/components/CreateListingForm.test.tsx
@@ -478,6 +478,20 @@ describe("CreateListingForm", () => {
       });
     });
 
+    it("omits bookingMode from the POST body when whole-unit mode is disabled", async () => {
+      render(<CreateListingForm enableWholeUnitMode={false} />);
+      await addImageAndSubmit();
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(JSON.parse(options.body as string)).not.toHaveProperty(
+        "bookingMode"
+      );
+    });
+
     it("includes X-Idempotency-Key header", async () => {
       render(<CreateListingForm />);
       await addImageAndSubmit();

--- a/src/__tests__/lib/data.test.ts
+++ b/src/__tests__/lib/data.test.ts
@@ -1512,3 +1512,71 @@ describe("slotThreshold parameterization", () => {
     });
   });
 });
+
+describe("legacy bookingMode SQL filters", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses effective whole-unit semantics for map listings", async () => {
+    mockQueryWithTimeout.mockResolvedValue([]);
+
+    await getMapListings({
+      bookingMode: "WHOLE_UNIT",
+      bounds: { minLat: 30, maxLat: 40, minLng: -120, maxLng: -110 },
+    });
+
+    const sql = mockQueryWithTimeout.mock.calls[0][0] as string;
+
+    expect(sql).toContain(
+      `(l."booking_mode" = 'WHOLE_UNIT' OR l."roomType" = 'Entire Place')`
+    );
+  });
+
+  it("uses effective shared semantics for map listings", async () => {
+    mockQueryWithTimeout.mockResolvedValue([]);
+
+    await getMapListings({
+      bookingMode: "SHARED",
+      bounds: { minLat: 30, maxLat: 40, minLng: -120, maxLng: -110 },
+    });
+
+    const sql = mockQueryWithTimeout.mock.calls[0][0] as string;
+
+    expect(sql).toContain(
+      `(l."booking_mode" = 'SHARED' AND (l."roomType" IS NULL OR l."roomType" <> 'Entire Place'))`
+    );
+  });
+
+  it("uses effective whole-unit semantics for paginated listings", async () => {
+    mockQueryWithTimeout.mockResolvedValue([{ total: BigInt(0) }]);
+
+    await getListingsPaginated({
+      bookingMode: "WHOLE_UNIT",
+      bounds: { minLat: 30, maxLat: 40, minLng: -120, maxLng: -110 },
+    });
+
+    for (const call of mockQueryWithTimeout.mock.calls) {
+      const sql = call[0] as string;
+      expect(sql).toContain(
+        `(l."booking_mode" = 'WHOLE_UNIT' OR l."roomType" = 'Entire Place')`
+      );
+    }
+  });
+
+  it("uses effective shared semantics for paginated listings", async () => {
+    mockQueryWithTimeout.mockResolvedValue([{ total: BigInt(0) }]);
+
+    await getListingsPaginated({
+      bookingMode: "SHARED",
+      bounds: { minLat: 30, maxLat: 40, minLng: -120, maxLng: -110 },
+    });
+
+    for (const call of mockQueryWithTimeout.mock.calls) {
+      const sql = call[0] as string;
+      expect(sql).toContain(
+        `(l."booking_mode" = 'SHARED' AND (l."roomType" IS NULL OR l."roomType" <> 'Entire Place'))`
+      );
+    }
+  });
+});

--- a/src/__tests__/lib/search/search-doc-sync.test.ts
+++ b/src/__tests__/lib/search/search-doc-sync.test.ts
@@ -186,9 +186,41 @@ describe("getProjectionDivergenceReason", () => {
     ).toBe("version_skew");
   });
 
-  it("exports SEARCH_DOC_PROJECTION_VERSION as projection contract version 2", () => {
+  it("exports SEARCH_DOC_PROJECTION_VERSION as projection contract version 3", () => {
     expect(Number.isInteger(SEARCH_DOC_PROJECTION_VERSION)).toBe(true);
-    expect(SEARCH_DOC_PROJECTION_VERSION).toBe(2);
+    expect(SEARCH_DOC_PROJECTION_VERSION).toBe(3);
+  });
+
+  it("projects WHOLE_UNIT for Entire Place even when the snapshot bookingMode is SHARED", async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeProjectableListingSnapshot({
+        roomType: "Entire Place",
+        bookingMode: "SHARED",
+      }),
+    ]);
+    mockExecuteRaw.mockResolvedValueOnce(1);
+
+    const result = await projectSearchDocument("listing-1");
+
+    expect(result.writeApplied).toBe(true);
+    const executeArgs = mockExecuteRaw.mock.calls[0].slice(1);
+    expect(executeArgs).toContain("WHOLE_UNIT");
+    expect(executeArgs).not.toContain("SHARED");
+  });
+
+  it("projects explicit WHOLE_UNIT for non-entire room types", async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      makeProjectableListingSnapshot({
+        roomType: "Private Room",
+        bookingMode: "WHOLE_UNIT",
+      }),
+    ]);
+    mockExecuteRaw.mockResolvedValueOnce(1);
+
+    const result = await projectSearchDocument("listing-1");
+
+    expect(result.writeApplied).toBe(true);
+    expect(mockExecuteRaw.mock.calls[0].slice(1)).toContain("WHOLE_UNIT");
   });
 
   it("suppresses stale cron writes when a newer doc version already won the race", async () => {

--- a/src/__tests__/lib/search/search-doc-sync.test.ts
+++ b/src/__tests__/lib/search/search-doc-sync.test.ts
@@ -186,9 +186,9 @@ describe("getProjectionDivergenceReason", () => {
     ).toBe("version_skew");
   });
 
-  it("exports SEARCH_DOC_PROJECTION_VERSION as an integer >= 1", () => {
+  it("exports SEARCH_DOC_PROJECTION_VERSION as projection contract version 2", () => {
     expect(Number.isInteger(SEARCH_DOC_PROJECTION_VERSION)).toBe(true);
-    expect(SEARCH_DOC_PROJECTION_VERSION).toBeGreaterThanOrEqual(1);
+    expect(SEARCH_DOC_PROJECTION_VERSION).toBe(2);
   });
 
   it("suppresses stale cron writes when a newer doc version already won the race", async () => {

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -32,4 +32,27 @@ describe("listing booking mode migration", () => {
     expect(roomTypeFallbackIndex).toBeGreaterThan(-1);
     expect(inventoryBackfillIndex).toBeLessThan(roomTypeFallbackIndex);
   });
+
+  it("reconciles search docs after Listing backfills and marks dirty rows", () => {
+    expect(migrationSql).toContain("WITH reconciled_search_docs AS");
+    expect(migrationSql).toMatch(
+      /UPDATE\s+listing_search_docs\s+AS\s+doc[\s\S]*SET\s+booking_mode\s*=\s*listing\."booking_mode"[\s\S]*doc_updated_at\s*=\s*NOW\(\)[\s\S]*doc\.booking_mode\s+IS\s+DISTINCT\s+FROM\s+listing\."booking_mode"/
+    );
+    expect(migrationSql).toMatch(
+      /INSERT\s+INTO\s+listing_search_doc_dirty\s+\(listing_id,\s+reason,\s+marked_at\)[\s\S]*'booking_mode_backfill'[\s\S]*ON\s+CONFLICT\s+\(listing_id\)\s+DO\s+UPDATE\s+SET[\s\S]*reason\s*=\s*EXCLUDED\.reason[\s\S]*marked_at\s*=\s*EXCLUDED\.marked_at/
+    );
+
+    const inventoryBackfillIndex = migrationSql.indexOf(
+      'FROM "listing_inventories" AS inventory'
+    );
+    const roomTypeFallbackIndex = migrationSql.indexOf(
+      `WHERE "roomType" = 'Entire Place'`
+    );
+    const reconciliationIndex = migrationSql.indexOf(
+      "WITH reconciled_search_docs AS"
+    );
+
+    expect(reconciliationIndex).toBeGreaterThan(inventoryBackfillIndex);
+    expect(reconciliationIndex).toBeGreaterThan(roomTypeFallbackIndex);
+  });
 });

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  "prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql"
+);
+
+describe("listing booking mode migration", () => {
+  let migrationSql: string;
+
+  beforeAll(() => {
+    migrationSql = fs.readFileSync(MIGRATION_PATH, "utf-8");
+  });
+
+  it("backfills whole-unit mode from canonical inventory before roomType fallback", () => {
+    expect(migrationSql).toMatch(
+      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.listing_id\s*=\s*listing\.id[\s\S]*inventory\.room_category\s*=\s*'ENTIRE_PLACE'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'/
+    );
+    expect(migrationSql).toMatch(
+      /UPDATE\s+"Listing"[\s\S]*SET\s+"booking_mode"\s*=\s*'WHOLE_UNIT'[\s\S]*WHERE\s+"roomType"\s*=\s*'Entire Place'/
+    );
+
+    const inventoryBackfillIndex = migrationSql.indexOf(
+      'FROM "listing_inventories" AS inventory'
+    );
+    const roomTypeFallbackIndex = migrationSql.indexOf(
+      'WHERE "roomType" = \'Entire Place\''
+    );
+
+    expect(inventoryBackfillIndex).toBeGreaterThan(-1);
+    expect(roomTypeFallbackIndex).toBeGreaterThan(-1);
+    expect(inventoryBackfillIndex).toBeLessThan(roomTypeFallbackIndex);
+  });
+});

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -15,7 +15,7 @@ describe("listing booking mode migration", () => {
 
   it("backfills whole-unit mode from canonical inventory before roomType fallback", () => {
     expect(migrationSql).toMatch(
-      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.listing_id\s*=\s*listing\.id[\s\S]*inventory\.room_category\s*=\s*'ENTIRE_PLACE'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'/
+      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.unit_id\s*=\s*listing\."physical_unit_id"[\s\S]*inventory\.room_category\s*=\s*'ENTIRE_PLACE'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'/
     );
     expect(migrationSql).toMatch(
       /UPDATE\s+"Listing"[\s\S]*SET\s+"booking_mode"\s*=\s*'WHOLE_UNIT'[\s\S]*WHERE\s+"roomType"\s*=\s*'Entire Place'/

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -15,10 +15,13 @@ describe("listing booking mode migration", () => {
 
   it("backfills whole-unit mode from canonical inventory before roomType fallback", () => {
     expect(migrationSql).toMatch(
-      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.unit_id\s*=\s*listing\."physical_unit_id"[\s\S]*inventory\.room_category\s*=\s*'ENTIRE_PLACE'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'/
+      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.id\s*=\s*listing\.id[\s\S]*inventory\.inventory_key\s*=\s*\('listing:'\s*\|\|\s*listing\.id\)[\s\S]*inventory\.lifecycle_status\s*=\s*'ACTIVE'[\s\S]*inventory\.publish_status\s+IN\s*\([\s\S]*'PENDING_GEOCODE'[\s\S]*'PENDING_PROJECTION'[\s\S]*'PENDING_EMBEDDING'[\s\S]*'PUBLISHED'[\s\S]*'STALE_PUBLISHED'[\s\S]*\)[\s\S]*inventory\.room_category\s*=\s*'ENTIRE_PLACE'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'/
     );
     expect(migrationSql).toMatch(
-      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*SET\s+"booking_mode"\s*=\s*'WHOLE_UNIT'[\s\S]*WHERE\s+listing\."roomType"\s*=\s*'Entire Place'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'[\s\S]*NOT\s+EXISTS\s*\([\s\S]*SELECT\s+1[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.unit_id\s*=\s*listing\."physical_unit_id"[\s\S]*\)/
+      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*SET\s+"booking_mode"\s*=\s*'WHOLE_UNIT'[\s\S]*WHERE\s+listing\."roomType"\s*=\s*'Entire Place'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'[\s\S]*NOT\s+EXISTS\s*\([\s\S]*SELECT\s+1[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.id\s*=\s*listing\.id[\s\S]*inventory\.inventory_key\s*=\s*\('listing:'\s*\|\|\s*listing\.id\)[\s\S]*inventory\.lifecycle_status\s*=\s*'ACTIVE'[\s\S]*inventory\.publish_status\s+IN\s*\([\s\S]*'PENDING_GEOCODE'[\s\S]*'PENDING_PROJECTION'[\s\S]*'PENDING_EMBEDDING'[\s\S]*'PUBLISHED'[\s\S]*'STALE_PUBLISHED'[\s\S]*\)[\s\S]*\)/
+    );
+    expect(migrationSql).not.toContain(
+      'inventory.unit_id = listing."physical_unit_id"'
     );
 
     const inventoryBackfillIndex = migrationSql.indexOf(

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -39,7 +39,13 @@ describe("listing booking mode migration", () => {
   it("reconciles search docs after Listing backfills and marks dirty rows", () => {
     expect(migrationSql).toContain("WITH reconciled_search_docs AS");
     expect(migrationSql).toMatch(
-      /UPDATE\s+listing_search_docs\s+AS\s+doc[\s\S]*SET\s+booking_mode\s*=\s*listing\."booking_mode"[\s\S]*doc_updated_at\s*=\s*NOW\(\)[\s\S]*doc\.booking_mode\s+IS\s+DISTINCT\s+FROM\s+listing\."booking_mode"/
+      /CASE\s+WHEN\s+listing\."booking_mode"\s*=\s*'WHOLE_UNIT'\s+OR\s+listing\."roomType"\s*=\s*'Entire Place'\s+THEN\s+'WHOLE_UNIT'\s+ELSE\s+COALESCE\(listing\."booking_mode",\s*'SHARED'\)\s+END\s+AS\s+effective_booking_mode/
+    );
+    expect(migrationSql).toMatch(
+      /UPDATE\s+listing_search_docs\s+AS\s+doc[\s\S]*SET\s+booking_mode\s*=\s*listing\.effective_booking_mode[\s\S]*doc_updated_at\s*=\s*NOW\(\)[\s\S]*doc\.booking_mode\s+IS\s+DISTINCT\s+FROM\s+listing\.effective_booking_mode/
+    );
+    expect(migrationSql).not.toMatch(
+      /SET\s+booking_mode\s*=\s*listing\."booking_mode"[\s\S]*doc\.booking_mode\s+IS\s+DISTINCT\s+FROM\s+listing\."booking_mode"/
     );
     expect(migrationSql).toMatch(
       /INSERT\s+INTO\s+listing_search_doc_dirty\s+\(listing_id,\s+reason,\s+marked_at\)[\s\S]*'booking_mode_backfill'[\s\S]*ON\s+CONFLICT\s+\(listing_id\)\s+DO\s+UPDATE\s+SET[\s\S]*reason\s*=\s*EXCLUDED\.reason[\s\S]*marked_at\s*=\s*EXCLUDED\.marked_at/

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -18,14 +18,14 @@ describe("listing booking mode migration", () => {
       /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.unit_id\s*=\s*listing\."physical_unit_id"[\s\S]*inventory\.room_category\s*=\s*'ENTIRE_PLACE'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'/
     );
     expect(migrationSql).toMatch(
-      /UPDATE\s+"Listing"[\s\S]*SET\s+"booking_mode"\s*=\s*'WHOLE_UNIT'[\s\S]*WHERE\s+"roomType"\s*=\s*'Entire Place'/
+      /UPDATE\s+"Listing"\s+AS\s+listing[\s\S]*SET\s+"booking_mode"\s*=\s*'WHOLE_UNIT'[\s\S]*WHERE\s+listing\."roomType"\s*=\s*'Entire Place'[\s\S]*listing\."booking_mode"\s*<>\s*'WHOLE_UNIT'[\s\S]*NOT\s+EXISTS\s*\([\s\S]*SELECT\s+1[\s\S]*FROM\s+"listing_inventories"\s+AS\s+inventory[\s\S]*inventory\.unit_id\s*=\s*listing\."physical_unit_id"[\s\S]*\)/
     );
 
     const inventoryBackfillIndex = migrationSql.indexOf(
       'FROM "listing_inventories" AS inventory'
     );
     const roomTypeFallbackIndex = migrationSql.indexOf(
-      `WHERE "roomType" = 'Entire Place'`
+      `WHERE listing."roomType" = 'Entire Place'`
     );
 
     expect(inventoryBackfillIndex).toBeGreaterThan(-1);
@@ -46,7 +46,7 @@ describe("listing booking mode migration", () => {
       'FROM "listing_inventories" AS inventory'
     );
     const roomTypeFallbackIndex = migrationSql.indexOf(
-      `WHERE "roomType" = 'Entire Place'`
+      `WHERE listing."roomType" = 'Entire Place'`
     );
     const reconciliationIndex = migrationSql.indexOf(
       "WITH reconciled_search_docs AS"

--- a/src/__tests__/schema/listing-booking-mode-migration.test.ts
+++ b/src/__tests__/schema/listing-booking-mode-migration.test.ts
@@ -25,7 +25,7 @@ describe("listing booking mode migration", () => {
       'FROM "listing_inventories" AS inventory'
     );
     const roomTypeFallbackIndex = migrationSql.indexOf(
-      'WHERE "roomType" = \'Entire Place\''
+      `WHERE "roomType" = 'Entire Place'`
     );
 
     expect(inventoryBackfillIndex).toBeGreaterThan(-1);

--- a/src/__tests__/scripts/backfill-canonical-inventory-booking-mode.test.ts
+++ b/src/__tests__/scripts/backfill-canonical-inventory-booking-mode.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("scripts/cfm/backfill-canonical-inventory booking mode mapping", () => {
+  const script = readFileSync(
+    join(process.cwd(), "scripts/cfm/backfill-canonical-inventory.ts"),
+    "utf8"
+  );
+
+  it("selects Listing.bookingMode for canonical inventory backfills", () => {
+    expect(script).toContain("bookingMode: string;");
+    expect(script).toContain('l."booking_mode" AS "bookingMode"');
+  });
+
+  it("prioritizes WHOLE_UNIT booking mode before roomType fallback", () => {
+    expect(script).toMatch(
+      /if \(row\.bookingMode === "WHOLE_UNIT"\) return "ENTIRE_PLACE";\s*if \(row\.roomType === "Entire Place"\)/
+    );
+  });
+});

--- a/src/__tests__/scripts/backfill-search-docs-booking-mode.test.ts
+++ b/src/__tests__/scripts/backfill-search-docs-booking-mode.test.ts
@@ -10,6 +10,8 @@ describe("src/scripts/backfill-search-docs booking mode projection", () => {
   it("selects Listing.bookingMode for search-doc backfills", () => {
     expect(script).toContain("bookingMode: string;");
     expect(script).toContain('l."booking_mode" as "bookingMode"');
+    expect(script).toContain("function resolveSearchBookingMode");
+    expect(script).toContain('listing.roomType === "Entire Place"');
   });
 
   it("upserts booking_mode into listing_search_docs", () => {
@@ -17,7 +19,7 @@ describe("src/scripts/backfill-search-docs booking mode projection", () => {
       /lease_duration,\s*room_type,\s*booking_mode,\s*move_in_date/
     );
     expect(script).toMatch(
-      /\$\{listing\.leaseDuration\},\s*\$\{listing\.roomType\},\s*\$\{listing\.bookingMode\},\s*\$\{listing\.moveInDate\}/
+      /\$\{listing\.leaseDuration\},\s*\$\{listing\.roomType\},\s*\$\{searchBookingMode\},\s*\$\{listing\.moveInDate\}/
     );
     expect(script).toContain("booking_mode = EXCLUDED.booking_mode");
   });

--- a/src/__tests__/scripts/backfill-search-docs-booking-mode.test.ts
+++ b/src/__tests__/scripts/backfill-search-docs-booking-mode.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("src/scripts/backfill-search-docs booking mode projection", () => {
+  const script = readFileSync(
+    join(process.cwd(), "src/scripts/backfill-search-docs.ts"),
+    "utf8"
+  );
+
+  it("selects Listing.bookingMode for search-doc backfills", () => {
+    expect(script).toContain("bookingMode: string;");
+    expect(script).toContain('l."booking_mode" as "bookingMode"');
+  });
+
+  it("upserts booking_mode into listing_search_docs", () => {
+    expect(script).toMatch(
+      /lease_duration,\s*room_type,\s*booking_mode,\s*move_in_date/
+    );
+    expect(script).toMatch(
+      /\$\{listing\.leaseDuration\},\s*\$\{listing\.roomType\},\s*\$\{listing\.bookingMode\},\s*\$\{listing\.moveInDate\}/
+    );
+    expect(script).toContain("booking_mode = EXCLUDED.booking_mode");
+  });
+});

--- a/src/__tests__/scripts/seed-booking-mode.test.ts
+++ b/src/__tests__/scripts/seed-booking-mode.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const seedScriptPaths = [
+  "scripts/seed-e2e.js",
+  "scripts/seed-demo.js",
+  "scripts/seed-staging.js",
+  "scripts/seed-listings.js",
+  "scripts/seed-test-listings.js",
+];
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("seed bookingMode derivation", () => {
+  it.each(seedScriptPaths)("%s derives bookingMode for direct Listing writes", (path) => {
+    const script = readRepoFile(path);
+
+    expect(script).toContain("function deriveBookingMode");
+    expect(script).toContain("bookingMode");
+    expect(script).toContain("deriveBookingMode(");
+  });
+
+  it("test helper derives bookingMode for direct Listing fixture writes", () => {
+    const route = readRepoFile("src/app/api/test-helpers/route.ts");
+
+    expect(route).toContain("function deriveBookingMode");
+    expect(route).toContain("bookingMode: deriveBookingMode(roomType)");
+  });
+
+  it.each(["scripts/seed-e2e.js", "scripts/seed-demo.js"])(
+    "%s writes effective booking_mode in raw search-doc SQL",
+    (path) => {
+      const script = readRepoFile(path);
+
+      expect(script).toMatch(
+        /lease_duration,\s*room_type,\s*booking_mode,\s*move_in_date/
+      );
+      expect(script).toContain(
+        'l."booking_mode" = \'WHOLE_UNIT\' OR l."roomType" = \'Entire Place\''
+      );
+      expect(script).toContain("ELSE COALESCE(l.\"booking_mode\", 'SHARED')");
+      expect(script).toContain("booking_mode = EXCLUDED.booking_mode");
+    }
+  );
+});

--- a/src/app/api/listings/[id]/route.ts
+++ b/src/app/api/listings/[id]/route.ts
@@ -48,6 +48,14 @@ import {
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const SESSION_FRESHNESS_SECONDS = 5 * 60;
+const WHOLE_UNIT_ROOM_TYPE_BOOKING_MODE_ERROR =
+  "Entire place listings must use whole-unit booking mode";
+
+function deriveBookingModeForRoomType(
+  roomType: string | null | undefined
+): "SHARED" | "WHOLE_UNIT" {
+  return roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED";
+}
 
 // Extract storage path from Supabase public URL
 function extractStoragePath(publicUrl: string): string | null {
@@ -847,6 +855,10 @@ export async function PATCH(
       }
 
       const profilePatch: ListingProfilePatch = parsed.data;
+      const bookingModeProvided = Object.prototype.hasOwnProperty.call(
+        rawBody,
+        "bookingMode"
+      );
       const {
         expectedVersion,
         title,
@@ -1079,6 +1091,8 @@ export async function PATCH(
               freshnessReminderSentAt: true,
               freshnessWarningSentAt: true,
               autoPausedAt: true,
+              roomType: true,
+              bookingMode: true,
             },
           });
 
@@ -1111,6 +1125,49 @@ export async function PATCH(
             } as const;
           }
 
+          const nextRoomType =
+            roomType === undefined ? lockedListing.roomType : roomType;
+          const roomTypeChangedToEntirePlace =
+            roomType === "Entire Place" &&
+            lockedListing.roomType !== "Entire Place";
+          const submittedBookingMode =
+            bookingMode === "SHARED" || bookingMode === "WHOLE_UNIT"
+              ? bookingMode
+              : undefined;
+          let resolvedBookingModePatch:
+            | ReturnType<typeof deriveBookingModeForRoomType>
+            | undefined;
+
+          if (features.wholeUnitMode) {
+            if (
+              nextRoomType === "Entire Place" &&
+              submittedBookingMode === "SHARED"
+            ) {
+              return {
+                ok: false,
+                error: WHOLE_UNIT_ROOM_TYPE_BOOKING_MODE_ERROR,
+                code: "INVALID_BOOKING_MODE",
+                field: "bookingMode",
+                fields: {
+                  bookingMode: WHOLE_UNIT_ROOM_TYPE_BOOKING_MODE_ERROR,
+                },
+                httpStatus: 400,
+              } as const;
+            }
+
+            if (bookingModeProvided) {
+              resolvedBookingModePatch =
+                submittedBookingMode ?? deriveBookingModeForRoomType(nextRoomType);
+            } else if (roomTypeChangedToEntirePlace) {
+              resolvedBookingModePatch = "WHOLE_UNIT";
+            }
+          } else if (bookingModeProvided) {
+            resolvedBookingModePatch =
+              deriveBookingModeForRoomType(nextRoomType);
+          } else if (roomTypeChangedToEntirePlace) {
+            resolvedBookingModePatch = "WHOLE_UNIT";
+          }
+
           const updatedListing = await tx.listing.update({
             where: { id },
             data: {
@@ -1131,8 +1188,8 @@ export async function PATCH(
               }),
               leaseDuration: leaseDuration || null,
               roomType: roomType || null,
-              ...(bookingMode !== undefined && {
-                bookingMode: bookingMode || "SHARED",
+              ...(resolvedBookingModePatch !== undefined && {
+                bookingMode: resolvedBookingModePatch,
               }),
               ...(addressChanged && {
                 normalizedAddress: nextNormalizedAddress,
@@ -1186,6 +1243,12 @@ export async function PATCH(
               code: profilePatchResult.code,
               ...("lockReason" in profilePatchResult
                 ? { lockReason: profilePatchResult.lockReason }
+                : {}),
+              ...("field" in profilePatchResult
+                ? { field: profilePatchResult.field }
+                : {}),
+              ...("fields" in profilePatchResult
+                ? { fields: profilePatchResult.fields }
                 : {}),
             },
             { status: profilePatchResult.httpStatus }

--- a/src/app/api/listings/[id]/route.ts
+++ b/src/app/api/listings/[id]/route.ts
@@ -12,6 +12,7 @@ import {
   NO_HTML_MSG,
   listingLeaseDurationSchema,
   listingRoomTypeSchema,
+  listingBookingModeSchema,
   listingGenderPreferenceSchema,
   listingHouseholdGenderSchema,
 } from "@/lib/schemas";
@@ -154,6 +155,7 @@ const listingProfilePatchSchema = z
     zip: z.string().trim().min(1).max(20),
     leaseDuration: listingLeaseDurationSchema,
     roomType: listingRoomTypeSchema,
+    bookingMode: listingBookingModeSchema,
     householdLanguages: z
       .array(z.string().trim().toLowerCase().transform(sanitizeUnicode))
       .max(20)
@@ -849,6 +851,7 @@ export async function PATCH(
         zip,
         leaseDuration,
         roomType,
+        bookingMode,
         householdLanguages,
         genderPreference,
         householdGender,
@@ -1086,6 +1089,9 @@ export async function PATCH(
               }),
               leaseDuration: leaseDuration || null,
               roomType: roomType || null,
+              ...(bookingMode !== undefined && {
+                bookingMode: bookingMode || "SHARED",
+              }),
               ...(addressChanged && {
                 normalizedAddress: nextNormalizedAddress,
               }),

--- a/src/app/api/listings/[id]/route.ts
+++ b/src/app/api/listings/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
-import { geocodeAddress } from "@/lib/geocoding";
 import { createClient } from "@supabase/supabase-js";
 import bcrypt from "bcryptjs";
 import {
@@ -22,7 +21,6 @@ import { isValidLanguageCode } from "@/lib/languages";
 import { markListingDirtyInTx } from "@/lib/search/search-doc-dirty";
 import { withRateLimit } from "@/lib/with-rate-limit";
 import { captureApiError } from "@/lib/api-error-handler";
-import { isCircuitOpenError } from "@/lib/circuit-breaker";
 import { validateCsrf } from "@/lib/csrf";
 import { logger } from "@/lib/logger";
 import { checkSuspension, checkEmailVerified } from "@/app/actions/suspension";
@@ -32,6 +30,11 @@ import { features } from "@/lib/env";
 import { syncListingEmbedding } from "@/lib/embeddings/sync";
 import { getHostModerationWriteLockResult } from "@/lib/listings/moderation-write-lock";
 import { normalizeAddress } from "@/lib/search/normalize-address";
+import { verifyAddressSuggestionToken } from "@/lib/geocoding/address-suggestion-token";
+import {
+  GooglePlacesUnavailableError,
+  validateAddressForPublish,
+} from "@/lib/geocoding/google-places";
 import { syncCanonicalAvailability } from "@/lib/listings/canonical-sync";
 import {
   syncListingLifecycleProjectionInTx,
@@ -168,6 +171,12 @@ const listingProfilePatchSchema = z
       .nullable()
       .optional(),
     images: z.array(supabaseImageUrlSchema).max(10).optional(),
+    addressSuggestionToken: z
+      .string()
+      .trim()
+      .max(4096, "Address suggestion token is invalid")
+      .optional()
+      .transform((value) => (value && value.length > 0 ? value : undefined)),
   })
   .strict();
 
@@ -857,6 +866,7 @@ export async function PATCH(
         householdGender,
         primaryHomeLanguage,
         images,
+        addressSuggestionToken,
       } = profilePatch;
 
       if (householdLanguages && householdLanguages.length > 0) {
@@ -933,48 +943,80 @@ export async function PATCH(
         zip,
       });
 
+      // Address edits must clear the same trusted-address bar as listing
+      // creation: a server-signed suggestion token (PREMISE precision, bound to
+      // this user + the submitted fields) or Google Address Validation. Never
+      // fall back to best-guess forward geocoding, which would let a direct API
+      // caller point a listing at an unverified address.
       let coords: { lat: number; lng: number } | null = null;
       if (addressChanged && listing.location) {
-        const fullAddress = `${address}, ${city}, ${state} ${zip}`;
-        try {
-          const geoResult = await geocodeAddress(fullAddress);
-          if (geoResult.status === "not_found") {
-            await logger.warn("Geocoding failed for listing update", {
+        const verifiedAddressSuggestion = verifyAddressSuggestionToken(
+          addressSuggestionToken,
+          {
+            userId,
+            address,
+            city,
+            state,
+            zip,
+          }
+        );
+
+        if (verifiedAddressSuggestion.valid) {
+          coords = verifiedAddressSuggestion.coords;
+        } else if (features.googleAddressValidation) {
+          try {
+            const validatedAddress = await validateAddressForPublish({
+              address,
+              city,
+              state,
+              zip,
+            });
+
+            if (!validatedAddress) {
+              const message =
+                "Could not verify this exact address. Please choose a suggested address or check the details and try again.";
+              return NextResponse.json(
+                {
+                  error: message,
+                  field: "address",
+                  fields: { address: message },
+                },
+                { status: 400 }
+              );
+            }
+
+            coords = { lat: validatedAddress.lat, lng: validatedAddress.lng };
+          } catch (validationError) {
+            if (validationError instanceof GooglePlacesUnavailableError) {
+              return NextResponse.json(
+                {
+                  error:
+                    "Address verification temporarily unavailable. Please try again.",
+                },
+                { status: 503, headers: { "Retry-After": "10" } }
+              );
+            }
+
+            throw validationError;
+          }
+        } else {
+          await logger.warn(
+            "Listing update blocked: address validation disabled",
+            {
               route: "/api/listings/[id]",
               method: "PATCH",
               userId: userId.slice(0, 8) + "...",
               city,
               state,
-            });
-            return NextResponse.json(
-              {
-                error:
-                  "Could not find this address. Please check and try again.",
-              },
-              { status: 400 }
-            );
-          }
-          if (geoResult.status === "error") {
-            return NextResponse.json(
-              {
-                error:
-                  "Address verification temporarily unavailable. Please try again.",
-              },
-              { status: 503, headers: { "Retry-After": "10" } }
-            );
-          }
-          coords = { lat: geoResult.lat, lng: geoResult.lng };
-        } catch (geoError) {
-          if (isCircuitOpenError(geoError)) {
-            return NextResponse.json(
-              {
-                error:
-                  "Address verification service temporarily unavailable. Please try again shortly.",
-              },
-              { status: 503, headers: { "Retry-After": "30" } }
-            );
-          }
-          throw geoError;
+            }
+          );
+          return NextResponse.json(
+            {
+              error:
+                "Address verification temporarily unavailable. Please try again.",
+            },
+            { status: 503, headers: { "Retry-After": "10" } }
+          );
         }
       }
 

--- a/src/app/api/listings/[id]/route.ts
+++ b/src/app/api/listings/[id]/route.ts
@@ -1127,9 +1127,6 @@ export async function PATCH(
 
           const nextRoomType =
             roomType === undefined ? lockedListing.roomType : roomType;
-          const roomTypeChangedToEntirePlace =
-            roomType === "Entire Place" &&
-            lockedListing.roomType !== "Entire Place";
           const submittedBookingMode =
             bookingMode === "SHARED" || bookingMode === "WHOLE_UNIT"
               ? bookingMode
@@ -1155,17 +1152,17 @@ export async function PATCH(
               } as const;
             }
 
-            if (bookingModeProvided) {
+            if (nextRoomType === "Entire Place") {
+              resolvedBookingModePatch = "WHOLE_UNIT";
+            } else if (bookingModeProvided) {
               resolvedBookingModePatch =
                 submittedBookingMode ?? deriveBookingModeForRoomType(nextRoomType);
-            } else if (roomTypeChangedToEntirePlace) {
-              resolvedBookingModePatch = "WHOLE_UNIT";
             }
+          } else if (nextRoomType === "Entire Place") {
+            resolvedBookingModePatch = "WHOLE_UNIT";
           } else if (bookingModeProvided) {
             resolvedBookingModePatch =
               deriveBookingModeForRoomType(nextRoomType);
-          } else if (roomTypeChangedToEntirePlace) {
-            resolvedBookingModePatch = "WHOLE_UNIT";
           }
 
           const updatedListing = await tx.listing.update({

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -63,6 +63,9 @@ class ListingCollisionRateLimitedError extends Error {
   }
 }
 
+const WHOLE_UNIT_ROOM_TYPE_BOOKING_MODE_ERROR =
+  "Entire place listings must use whole-unit booking mode";
+
 export async function GET(request: Request) {
   // Use Redis-backed limiter for high-volume read path consistency.
   const rateLimitResponse = await withRateLimitRedis(request, {
@@ -419,6 +422,22 @@ export async function POST(request: Request) {
     const resolvedBookingMode = features.wholeUnitMode
       ? (bookingMode ?? derivedBookingMode)
       : derivedBookingMode;
+    if (
+      features.wholeUnitMode &&
+      roomType === "Entire Place" &&
+      bookingMode === "SHARED"
+    ) {
+      return NextResponse.json(
+        {
+          error: WHOLE_UNIT_ROOM_TYPE_BOOKING_MODE_ERROR,
+          field: "bookingMode",
+          fields: {
+            bookingMode: WHOLE_UNIT_ROOM_TYPE_BOOKING_MODE_ERROR,
+          },
+        },
+        { status: 400 }
+      );
+    }
 
     // Build listing create data from validated fields
     const listingCreateData = {

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -431,6 +431,7 @@ export async function POST(request: Request) {
       primaryHomeLanguage: primaryHomeLanguage || null,
       leaseDuration: leaseDuration || null,
       roomType: roomType || null,
+      bookingMode: bookingMode || "SHARED",
       totalSlots,
       availableSlots: totalSlots,
       openSlots: totalSlots,
@@ -528,7 +529,8 @@ export async function POST(request: Request) {
             `;
 
       await syncCanonicalAvailability(tx, {
-        listing: { ...listing, bookingMode },
+        // Created row now carries booking_mode, so no transient override needed.
+        listing,
         address: { address, city, state, zip },
         actor: { role: "host", id: userId },
         trustedCoordinates: coords,

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -414,8 +414,11 @@ export async function POST(request: Request) {
     });
     const listingMoveInDate = new Date(`${moveInDate}T00:00:00.000Z`);
     const listingConfirmedAt = new Date();
-    const resolvedBookingMode =
-      bookingMode ?? (roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED");
+    const derivedBookingMode =
+      roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED";
+    const resolvedBookingMode = features.wholeUnitMode
+      ? (bookingMode ?? derivedBookingMode)
+      : derivedBookingMode;
 
     // Build listing create data from validated fields
     const listingCreateData = {

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -414,6 +414,8 @@ export async function POST(request: Request) {
     });
     const listingMoveInDate = new Date(`${moveInDate}T00:00:00.000Z`);
     const listingConfirmedAt = new Date();
+    const resolvedBookingMode =
+      bookingMode ?? (roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED");
 
     // Build listing create data from validated fields
     const listingCreateData = {
@@ -431,7 +433,7 @@ export async function POST(request: Request) {
       primaryHomeLanguage: primaryHomeLanguage || null,
       leaseDuration: leaseDuration || null,
       roomType: roomType || null,
-      bookingMode: bookingMode || "SHARED",
+      bookingMode: resolvedBookingMode,
       totalSlots,
       availableSlots: totalSlots,
       openSlots: totalSlots,

--- a/src/app/api/test-helpers/route.ts
+++ b/src/app/api/test-helpers/route.ts
@@ -54,6 +54,10 @@ function toNumberParam(value: unknown, fallback: number): number {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function deriveBookingMode(roomType: string | null | undefined): "WHOLE_UNIT" | "SHARED" {
+  return roomType === "Entire Place" ? "WHOLE_UNIT" : "SHARED";
+}
+
 async function setListingCoords(listingId: string, lng: number, lat: number) {
   await prisma.$executeRaw`
     UPDATE "Location"
@@ -564,6 +568,7 @@ export async function POST(request: NextRequest) {
               description,
               price,
               roomType,
+              bookingMode: deriveBookingMode(roomType),
               amenities: ["Wifi", "Kitchen"],
               houseRules: ["No Smoking"],
               householdLanguages: ["en"],

--- a/src/app/listings/[id]/edit/EditListingForm.tsx
+++ b/src/app/listings/[id]/edit/EditListingForm.tsx
@@ -386,6 +386,7 @@ function HostManagedEditListingForm({
         zip: listing.location?.zip || "",
         leaseDuration: listing.leaseDuration,
         roomType: listing.roomType,
+        bookingMode: listing.bookingMode,
         householdLanguages: listing.householdLanguages,
         genderPreference: listing.genderPreference,
         householdGender: listing.householdGender,

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -361,7 +361,7 @@ export default async function ListingPage({ params, searchParams }: PageProps) {
           availableSlots: resolvedAvailability.effectiveAvailableSlots,
           version: listing.version,
           availabilitySource: resolvedAvailability.availabilitySource,
-          bookingMode: "SHARED",
+          bookingMode: listing.bookingMode,
           status: listing.status,
           statusReason: listing.statusReason,
           viewCount: listing.viewCount,

--- a/src/app/listings/create/CreateListingForm.tsx
+++ b/src/app/listings/create/CreateListingForm.tsx
@@ -591,7 +591,7 @@ export default function CreateListingForm({
       roomType: roomType || undefined,
       genderPreference: genderPreference || undefined,
       householdGender: householdGender || undefined,
-      bookingMode: enableWholeUnitMode ? bookingMode : "SHARED",
+      ...(enableWholeUnitMode ? { bookingMode } : {}),
     };
 
     // Client-side Zod pre-validation (optimistic — server validates as defense-in-depth)

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -213,12 +213,12 @@ function applyLegacyBookingModeFilter(
   }
 
   if (bookingMode === "WHOLE_UNIT") {
-    conditions.push(`LOWER(l."roomType") = LOWER('Entire Place')`);
+    conditions.push(`l."booking_mode" = 'WHOLE_UNIT'`);
     return;
   }
 
   if (bookingMode === "SHARED") {
-    conditions.push(`COALESCE(LOWER(l."roomType"), '') <> LOWER('Entire Place')`);
+    conditions.push(`l."booking_mode" = 'SHARED'`);
   }
 }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -213,12 +213,16 @@ function applyLegacyBookingModeFilter(
   }
 
   if (bookingMode === "WHOLE_UNIT") {
-    conditions.push(`l."booking_mode" = 'WHOLE_UNIT'`);
+    conditions.push(
+      `(l."booking_mode" = 'WHOLE_UNIT' OR l."roomType" = 'Entire Place')`
+    );
     return;
   }
 
   if (bookingMode === "SHARED") {
-    conditions.push(`l."booking_mode" = 'SHARED'`);
+    conditions.push(
+      `(l."booking_mode" = 'SHARED' AND (l."roomType" IS NULL OR l."roomType" <> 'Entire Place'))`
+    );
   }
 }
 

--- a/src/lib/listings/canonical-lifecycle.ts
+++ b/src/lib/listings/canonical-lifecycle.ts
@@ -104,6 +104,7 @@ export async function syncListingLifecycleProjectionInTx(
       physicalUnitId: true,
       price: true,
       roomType: true,
+      bookingMode: true,
       totalSlots: true,
       availableSlots: true,
       openSlots: true,

--- a/src/lib/listings/public-detail.ts
+++ b/src/lib/listings/public-detail.ts
@@ -30,6 +30,7 @@ export const publicListingDetailSelect = {
   version: true,
   genderPreference: true,
   householdGender: true,
+  bookingMode: true,
   owner: {
     select: {
       id: true,

--- a/src/lib/search/search-doc-sync.ts
+++ b/src/lib/search/search-doc-sync.ts
@@ -40,7 +40,7 @@ export type CasSuppressionReason =
  * this against `listing_search_docs.projection_version` to detect shape drift
  * even when the underlying listing.updatedAt has not moved.
  */
-export const SEARCH_DOC_PROJECTION_VERSION = 1;
+export const SEARCH_DOC_PROJECTION_VERSION = 2;
 
 interface ListingSearchSnapshot {
   id: string;

--- a/src/lib/search/search-doc-sync.ts
+++ b/src/lib/search/search-doc-sync.ts
@@ -128,10 +128,7 @@ async function fetchListingSearchSnapshot(
       l."statusReason" as "statusReason",
       l."viewCount" as "viewCount",
       l.status::text as status,
-      CASE
-        WHEN l."roomType" = 'Entire Place' THEN 'WHOLE_UNIT'
-        ELSE 'SHARED'
-      END as "bookingMode",
+      l."booking_mode" as "bookingMode",
       l."createdAt" as "createdAt",
       l."updatedAt" as "updatedAt",
       l."version" as "version",

--- a/src/lib/search/search-doc-sync.ts
+++ b/src/lib/search/search-doc-sync.ts
@@ -40,7 +40,7 @@ export type CasSuppressionReason =
  * this against `listing_search_docs.projection_version` to detect shape drift
  * even when the underlying listing.updatedAt has not moved.
  */
-export const SEARCH_DOC_PROJECTION_VERSION = 2;
+export const SEARCH_DOC_PROJECTION_VERSION = 3;
 
 interface ListingSearchSnapshot {
   id: string;
@@ -192,6 +192,16 @@ function canProjectSearchDocument(listing: ListingSearchSnapshot): boolean {
   );
 }
 
+function resolveSearchBookingMode(
+  listing: Pick<ListingSearchSnapshot, "bookingMode" | "roomType">
+): string {
+  if (listing.bookingMode === "WHOLE_UNIT" || listing.roomType === "Entire Place") {
+    return "WHOLE_UNIT";
+  }
+
+  return listing.bookingMode || "SHARED";
+}
+
 function classifyCasSuppressionReason(
   listing: Pick<
     ListingSearchSnapshot,
@@ -242,6 +252,7 @@ async function writeSearchDocument(
   const householdLanguagesLower = listing.householdLanguages.map((language) =>
     language.toLowerCase()
   );
+  const searchBookingMode = resolveSearchBookingMode(listing);
 
   const rowsAffected = await prisma.$executeRaw`
     INSERT INTO listing_search_docs (
@@ -265,7 +276,7 @@ async function writeSearchDocument(
       ${listing.lat}, ${listing.lng},
       ${listing.avgRating}, ${listing.reviewCount}, ${recommendedScore},
       ${amenitiesLower}, ${houseRulesLower}, ${householdLanguagesLower},
-      ${listing.bookingMode},
+      ${searchBookingMode},
       ${SEARCH_DOC_PROJECTION_VERSION}, ${listing.version},
       NOW(), NOW()
     )

--- a/src/scripts/backfill-search-docs.ts
+++ b/src/scripts/backfill-search-docs.ts
@@ -189,6 +189,16 @@ function computeRecommendedScore(
   return ratingScore + viewScore + reviewScore + freshnessBoost;
 }
 
+function resolveSearchBookingMode(
+  listing: Pick<ListingWithData, "bookingMode" | "roomType">
+): string {
+  if (listing.bookingMode === "WHOLE_UNIT" || listing.roomType === "Entire Place") {
+    return "WHOLE_UNIT";
+  }
+
+  return listing.bookingMode || "SHARED";
+}
+
 /**
  * Upsert a batch of search docs
  */
@@ -217,6 +227,7 @@ async function upsertSearchDocsBatch(
     const householdLanguagesLower = listing.householdLanguages.map((l) =>
       l.toLowerCase()
     );
+    const searchBookingMode = resolveSearchBookingMode(listing);
 
     // Use raw SQL for upsert with geography type
     await prisma.$executeRaw`
@@ -233,7 +244,7 @@ async function upsertSearchDocsBatch(
       ) VALUES (
         ${listing.id}, ${listing.ownerId}, ${listing.title}, ${listing.description}, ${listing.price}, ${listing.images},
         ${listing.amenities}, ${listing.houseRules}, ${listing.householdLanguages}, ${listing.primaryHomeLanguage},
-        ${listing.leaseDuration}, ${listing.roomType}, ${listing.bookingMode}, ${listing.moveInDate}, ${listing.totalSlots}, ${listing.availableSlots},
+        ${listing.leaseDuration}, ${listing.roomType}, ${searchBookingMode}, ${listing.moveInDate}, ${listing.totalSlots}, ${listing.availableSlots},
         ${listing.viewCount}, ${listing.status}, ${listing.createdAt},
         ${listing.address}, ${listing.city}, ${listing.state}, ${listing.zip},
         ST_SetSRID(ST_MakePoint(${listing.lng}, ${listing.lat}), 4326)::geography,

--- a/src/scripts/backfill-search-docs.ts
+++ b/src/scripts/backfill-search-docs.ts
@@ -60,6 +60,7 @@ interface ListingWithData {
   primaryHomeLanguage: string | null;
   leaseDuration: string | null;
   roomType: string | null;
+  bookingMode: string;
   moveInDate: Date | null;
   totalSlots: number;
   availableSlots: number;
@@ -102,6 +103,7 @@ async function fetchListingsWithData(
       l."primary_home_language" as "primaryHomeLanguage",
       l."leaseDuration" as "leaseDuration",
       l."roomType" as "roomType",
+      l."booking_mode" as "bookingMode",
       l."moveInDate" as "moveInDate",
       l."totalSlots" as "totalSlots",
       l."availableSlots" as "availableSlots",
@@ -221,7 +223,7 @@ async function upsertSearchDocsBatch(
       INSERT INTO listing_search_docs (
         id, owner_id, title, description, price, images,
         amenities, house_rules, household_languages, primary_home_language,
-        lease_duration, room_type, move_in_date, total_slots, available_slots,
+        lease_duration, room_type, booking_mode, move_in_date, total_slots, available_slots,
         view_count, status, listing_created_at,
         address, city, state, zip, location_geog, lat, lng,
         avg_rating, review_count, recommended_score,
@@ -231,7 +233,7 @@ async function upsertSearchDocsBatch(
       ) VALUES (
         ${listing.id}, ${listing.ownerId}, ${listing.title}, ${listing.description}, ${listing.price}, ${listing.images},
         ${listing.amenities}, ${listing.houseRules}, ${listing.householdLanguages}, ${listing.primaryHomeLanguage},
-        ${listing.leaseDuration}, ${listing.roomType}, ${listing.moveInDate}, ${listing.totalSlots}, ${listing.availableSlots},
+        ${listing.leaseDuration}, ${listing.roomType}, ${listing.bookingMode}, ${listing.moveInDate}, ${listing.totalSlots}, ${listing.availableSlots},
         ${listing.viewCount}, ${listing.status}, ${listing.createdAt},
         ${listing.address}, ${listing.city}, ${listing.state}, ${listing.zip},
         ST_SetSRID(ST_MakePoint(${listing.lng}, ${listing.lat}), 4326)::geography,
@@ -253,6 +255,7 @@ async function upsertSearchDocsBatch(
         primary_home_language = EXCLUDED.primary_home_language,
         lease_duration = EXCLUDED.lease_duration,
         room_type = EXCLUDED.room_type,
+        booking_mode = EXCLUDED.booking_mode,
         move_in_date = EXCLUDED.move_in_date,
         total_slots = EXCLUDED.total_slots,
         available_slots = EXCLUDED.available_slots,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -70,3 +70,21 @@
 - Prevention rule: portals in SSR'd components must be gated on a `mounted` state set in
   useEffect; "typeof document" checks are not equivalent. Verify hydration-sensitive fixes
   against `pnpm build` + `pnpm start`, never the dev server.
+
+## 2026-06-13 — Edit tool normalizes mixed-EOL files → spurious 1000-line diff
+
+- Date: 2026-06-13
+- Mistake / failure mode: A 2-line logical change to `src/lib/data.ts` produced a
+  1072-line `git diff --stat` (668 ins / 542 del). The file had MIXED line endings in
+  HEAD (1740 lines, 1204 CRLF + 536 LF); the Edit tool rewrote the whole file to all-CRLF.
+- Detection signal: `git diff --stat` showed one file ballooning far beyond the edit;
+  `git diff --ignore-space-at-eol <file>` collapsed to the true ~2-line change, confirming
+  the rest was pure EOL churn. CR-count check: `grep -c $'\r'` differed between HEAD and
+  working tree (1204 → 1740).
+- Root cause: repo has no `.gitattributes` and `core.autocrlf` is unset, so mixed EOLs are
+  stored verbatim; the Edit tool normalized them on write. Uniform-EOL files were unaffected.
+- Prevention rule: after editing, run `git diff --stat`; if a touched file balloons, restore
+  with `git checkout HEAD -- <file>` and re-apply the change at byte level (Python
+  `open(...,'rb')` + `bytes.replace` with a count assertion) so non-edited bytes/EOLs are
+  preserved. Don't commit wholesale EOL flips.
+- Follow-up: none required; consider adding `.gitattributes` (`* text=auto`) repo-wide later.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,92 @@
+# P1 Fix: Listing PATCH bypasses create-time trusted-address validation
+
+## Goal + acceptance criteria
+
+`PATCH /api/listings/[id]` must enforce the **same** trusted-address validation as
+create (`POST /api/listings`) whenever the address changes. Direct-API address
+changes that only pass Nominatim forward-geocoding (best-guess) must be rejected.
+
+- Acceptance: a PATCH that changes address WITHOUT a valid `addressSuggestionToken`
+  and with Google Address Validation disabled is **blocked (503)** — never silently
+  geocoded.
+- Acceptance: with a valid server-signed `addressSuggestionToken` matching the
+  submitted fields → 200, coords come from the token (no geocode).
+- Acceptance: with `googleAddressValidation` enabled, an unverifiable address →
+  400; a verified address → 200 with validated coords; upstream outage → 503.
+- Acceptance: address-unchanged PATCH path is unaffected.
+
+## Root cause
+
+- Create path (`src/app/api/listings/route.ts:328-391`): verifies a signed
+  `addressSuggestionToken` (PREMISE precision, user+fields bound) OR calls
+  `validateAddressForPublish` (Google Address Validation); blocks otherwise.
+- PATCH path (`src/app/api/listings/[id]/route.ts:933-976`): on address change only
+  calls `geocodeAddress` (Nominatim forward-geocode), which returns coords for any
+  plausible/fake address — **no trust/precision gate**. The official EditListingForm
+  doesn't even expose address editing, so this is an API-level abuse bypass.
+
+## Scope (files/modules)
+
+- `src/app/api/listings/[id]/route.ts`
+  - imports: add `verifyAddressSuggestionToken`, `validateAddressForPublish` +
+    `GooglePlacesUnavailableError`; remove now-unused `geocodeAddress` and
+    `isCircuitOpenError`.
+  - `listingProfilePatchSchema`: add optional `addressSuggestionToken` (mirror create
+    schema: trim, max 4096, empty→undefined).
+  - destructure `addressSuggestionToken`.
+  - replace the `geocodeAddress` block with create-mirroring token → Google
+    validation → block logic, wrapped in `if (addressChanged && listing.location)`.
+- `src/__tests__/api/listings-host-managed-patch.test.ts`
+  - add mocks: `address-suggestion-token` (verify), `google-places`
+    (validateAddressForPublish + GooglePlacesUnavailableError); add
+    `googleAddressValidation` getter to the `@/lib/env` mock.
+  - update the 2 existing address-change tests to pass a valid token.
+  - add security regression tests (bypass blocked; token path; google path; 400).
+
+## Risks (auth/PII/state/DB/cost)
+
+- Security-critical path; coords persist to PostGIS `Location.coords`. No DB schema
+  change. No PII in logs (only userId-prefix + city/state, matching create).
+- Behavior change: direct-API address edits now require a verified address. The
+  first-party edit form never changed address, so no first-party UX regression.
+
+## Verification
+
+- `pnpm typecheck`
+- `pnpm test src/__tests__/api/listings-host-managed-patch.test.ts`
+- `pnpm test src/__tests__/api/listings-post.test.ts` (create path unaffected)
+- `pnpm lint` (confirm no orphaned imports)
+
+## Rollback notes
+
+- Pure code change, reversible by `git revert`. No migration/backfill.
+
+## Results + verification story
+
+Implemented on branch `fix/listing-patch-address-validation`.
+
+- `src/app/api/listings/[id]/route.ts`: PATCH now requires a valid server-signed
+  `addressSuggestionToken` OR Google Address Validation whenever the address
+  changes, mirroring create. Removed the Nominatim `geocodeAddress` fallback and
+  its now-orphaned imports (`geocodeAddress`, `isCircuitOpenError`).
+- `src/__tests__/api/listings-host-managed-patch.test.ts`: added validator mocks +
+  `googleAddressValidation` env getter; updated the 2 address-edit tests to the
+  token path; added a 5-test "P1 bypass guard" describe block.
+
+Verification (all green):
+- `pnpm typecheck` → EXIT 0
+- `npx jest listings-host-managed-patch.test.ts` → 17 passed (5 new)
+- `npx jest listings-post.test.ts` → 56 passed (create path unaffected)
+- `npx jest listings-idor.test.ts` → 32 passed ([id] route unaffected)
+- `npx eslint` on changed route → 0 errors (pre-existing `LockedListingRow`
+  warning only)
+
+Behavior: a direct-API address change without a verified token and with Google
+validation disabled now returns 503 (blocked) instead of silently geocoding. The
+first-party EditListingForm never edits the address, so no UX regression.
+
+---
+
 # Unified SearchBar — one pill, every surface (2026-06-12)
 
 Full plan: `~/.claude/plans/make-the-search-bar-expressive-sundae.md` (approved).
@@ -456,10 +545,13 @@ host's choice survived only transiently and every read path re-derived it from `
 
 **Changes (12 files):**
 - `prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql` — re-add
-  `booking_mode TEXT NOT NULL DEFAULT 'SHARED'` + roomType backfill + CHECK (NOT VALID→VALIDATE).
-  Reversible; metadata-only ADD COLUMN; no lock.
+  `booking_mode TEXT NOT NULL DEFAULT 'SHARED'`, backfill `WHOLE_UNIT` first from existing
+  `listing_inventories.room_category = 'ENTIRE_PLACE'`, then apply roomType fallback/default
+  and CHECK (NOT VALID→VALIDATE). Reversible; metadata-only ADD COLUMN; no lock.
 - `prisma/schema.prisma` — `bookingMode String @default("SHARED") @map("booking_mode")`.
-- `src/app/api/listings/route.ts` — persist in `listingCreateData`; drop transient spread.
+- `src/app/api/listings/route.ts` — persist in `listingCreateData`; when `bookingMode` is
+  omitted, default from `roomType` (`"Entire Place"` → `WHOLE_UNIT`, otherwise `SHARED`);
+  drop transient spread.
 - `src/app/api/listings/[id]/route.ts` — accept in profile-patch schema; persist on update
   only when provided (non-clobber).
 - `src/app/listings/[id]/edit/EditListingForm.tsx` — pass `bookingMode` through in detailsPayload.
@@ -469,7 +561,8 @@ host's choice survived only transiently and every read path re-derived it from `
 - `src/lib/data.ts` — legacy filter reads `l."booking_mode"` (was roomType).
 - `src/lib/listings/canonical-lifecycle.ts` — add `bookingMode` to the resync select so
   lifecycle resync preserves the divergent value (closes the durability hole).
-- Tests: +3 create-persistence (`listings-post`), +2 PATCH persist/non-clobber (`listings-idor`).
+- Tests: create-persistence/default coverage (`listings-post`, including omitted Entire Place →
+  `WHOLE_UNIT`), +2 PATCH persist/non-clobber (`listings-idor`).
 
 **Results + Verification story:**
 - `pnpm prisma validate` ✅ ; `pnpm prisma generate` ✅ ; `pnpm typecheck` ✅ (0 errors).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -439,3 +439,43 @@ two aria-hidden spacers distributing tall-viewport slack (capped max-h-14 breath
 flex-[4] photo reveal below it; both md:hidden, collapse to zero on short phones). globals.css:
 .home-hero-frame mobile padding-top clamp raised (1rem→2.25rem) for navbar breathing room; md override
 unchanged. Verified 412x860, 375x812, 360x700, 320x568 + 768 sanity (balance2-*.jpeg).
+
+---
+
+## 2026-06-13 — Fix P1: persist `bookingMode` on canonical Listing
+
+**Goal / acceptance:** A listing-create (and profile-edit) `bookingMode` (`SHARED`|`WHOLE_UNIT`)
+durably persists and is read consistently by search docs, the detail page, and canonical
+resync — including the divergent (roomType ≠ "Entire Place") case. Branch:
+`fix/listing-bookingmode-persistence`. Plan: ~/.claude/plans/parsed-hopping-waffle.md.
+
+**Root cause:** `Listing.booking_mode` was dropped in the phase-09 CFM cutover
+(`20260509000000`); create still accepted `bookingMode` but had nowhere to store it, so the
+host's choice survived only transiently and every read path re-derived it from `roomType`
+(detail page hardcoded `"SHARED"`). Masked only because the whole-unit UI is flag-gated off.
+
+**Changes (12 files):**
+- `prisma/migrations/20260613000000_readd_listing_booking_mode/migration.sql` — re-add
+  `booking_mode TEXT NOT NULL DEFAULT 'SHARED'` + roomType backfill + CHECK (NOT VALID→VALIDATE).
+  Reversible; metadata-only ADD COLUMN; no lock.
+- `prisma/schema.prisma` — `bookingMode String @default("SHARED") @map("booking_mode")`.
+- `src/app/api/listings/route.ts` — persist in `listingCreateData`; drop transient spread.
+- `src/app/api/listings/[id]/route.ts` — accept in profile-patch schema; persist on update
+  only when provided (non-clobber).
+- `src/app/listings/[id]/edit/EditListingForm.tsx` — pass `bookingMode` through in detailsPayload.
+- `src/lib/search/search-doc-sync.ts` — read stored `l."booking_mode"` (was derived from roomType).
+- `src/app/listings/[id]/page.tsx` + `src/lib/listings/public-detail.ts` — select + surface
+  stored value (was hardcoded `"SHARED"`).
+- `src/lib/data.ts` — legacy filter reads `l."booking_mode"` (was roomType).
+- `src/lib/listings/canonical-lifecycle.ts` — add `bookingMode` to the resync select so
+  lifecycle resync preserves the divergent value (closes the durability hole).
+- Tests: +3 create-persistence (`listings-post`), +2 PATCH persist/non-clobber (`listings-idor`).
+
+**Results + Verification story:**
+- `pnpm prisma validate` ✅ ; `pnpm prisma generate` ✅ ; `pnpm typecheck` ✅ (0 errors).
+- `pnpm lint` ✅ 0 errors (22 warnings, all pre-existing in untouched files).
+- `pnpm test` (full) ✅ **7850 passed, 8 skipped, 0 failed** — incl. 5 new regression tests;
+  no pglite fixture needed the new column (plan contingency not triggered).
+- Gotcha hit + fixed: Edit tool normalized mixed-EOL `data.ts` (1000-line spurious diff);
+  restored HEAD bytes + byte-level re-apply → clean 2-line diff. See lessons.md 2026-06-13.
+- NOT committed (awaiting explicit request). DB note: reversible migration, rollback in SQL header.


### PR DESCRIPTION
## Problem (P1 data-integrity)

`bookingMode` (`SHARED` | `WHOLE_UNIT`) was accepted and validated by the listing-create API but was not durably persisted on `Listing` after the phase-09 CFM cutover dropped the canonical `booking_mode` column. That made create, search docs, detail reads, lifecycle/search resyncs, repair scripts, direct writers, and legacy filters disagree, especially for the valid divergent case: non-`Entire Place` `roomType` with `bookingMode = WHOLE_UNIT`.

## Fix

- Re-add canonical `Listing.booking_mode` with default `SHARED` and Prisma mapping `bookingMode String @default("SHARED") @map("booking_mode")`.
- Backfill `WHOLE_UNIT` from each listing's own active canonical `listing_inventories` row (`inventory.id = Listing.id`, `inventory.inventory_key = 'listing:' || Listing.id`, `room_category = 'ENTIRE_PLACE'`), then fall back to `roomType = 'Entire Place'` only when no own active inventory row exists.
- Persist create-time and PATCH-time `bookingMode` server-authoritatively, including feature-off derivation, stale client-default handling, and rejection/normalization of inconsistent `Entire Place` + `SHARED` cases.
- Read the stored value in detail/public-detail selects, edit form, canonical lifecycle resync, repair/backfill scripts, seed scripts, and test helpers.
- Align legacy listing filters and search-doc projection with the effective booking-mode contract: stored `WHOLE_UNIT` or `roomType = 'Entire Place'` means effective `WHOLE_UNIT`; `SHARED` excludes entire-place rows.
- Reconcile existing `listing_search_docs.booking_mode` using that same effective CASE expression, dirty-mark affected rows with `booking_mode_backfill`, and bump `SEARCH_DOC_PROJECTION_VERSION` to `3`.

## Tests

Coverage includes create API defaults/divergent cases, feature-off behavior, inconsistent `Entire Place` + `SHARED` rejection, create form disabled selector payloads, PATCH persistence and flag-off derivation, schema migration SQL ordering/backfill/reconciliation, legacy data filters, search-doc sync projection, script regressions, and seed/test-helper booking-mode derivation.

## DB / rollback

Migration `20260613000000_readd_listing_booking_mode` is reversible:

```sql
DELETE FROM listing_search_doc_dirty WHERE reason = 'booking_mode_backfill';
ALTER TABLE "Listing" DROP CONSTRAINT "Listing_bookingMode_check";
ALTER TABLE "Listing" DROP COLUMN "booking_mode";
```

If rolling back after search docs were reconciled, regenerate `listing_search_docs` from the prior projection or restore previous search docs from backup if preserving stale denormalized values is required. The API/script/filter fixes are code-only and can be reverted independently of the migration if needed.

## Verification

Current head: `7c70ddca8999dfaf18fcb25285d8e907d87107c9`.

Latest focused local checks:

- `pnpm test --runInBand src/__tests__/schema/listing-booking-mode-migration.test.ts` passed.
- `pnpm test --runInBand src/__tests__/schema/listing-booking-mode-migration.test.ts src/__tests__/lib/search/search-doc-sync.test.ts src/__tests__/scripts/backfill-search-docs-booking-mode.test.ts` passed.
- `pnpm typecheck` passed.

Prior local slices also passed the create API, PATCH API, create form, search-doc sync, data filter, script regression, seed script `node --check`, and related booking-mode suites listed in earlier PR updates.

External checks on `7c70ddca8999dfaf18fcb25285d8e907d87107c9` are green: Vercel, CI, Stability Tests, Playwright Smoke Tests, Playwright E2E Tests, Playwright Search Release Gate, and Lighthouse CI.

Independent Critic review approved the final slice, and final Codex review on `7c70ddca89` reported no major issues.