### PR TITLE
fix(security): allow same-origin requests in API origin guard (fixes 403 on web-vitals/metrics)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -91,10 +91,10 @@ Local Docker default: `postgresql://postgres:password@localhost:5433/roomshare?s
 
 | Variable | Required | Description | Example |
 |----------|----------|-------------|---------|
-| `ALLOWED_ORIGINS` | Prod only | Comma-separated allowed origins | `https://roomshare.com,https://www.roomshare.com` |
-| `ALLOWED_HOSTS` | Prod only | Comma-separated allowed hosts | `roomshare.com,www.roomshare.com` |
+| `ALLOWED_ORIGINS` | Optional | Comma-separated *additional* cross-origin origins | `https://roomshare.com,https://www.roomshare.com` |
+| `ALLOWED_HOSTS` | Optional | Comma-separated *additional* allowed hosts | `roomshare.com,www.roomshare.com` |
 
-These are enforced by `/api/agent`, `/api/chat`, and `/api/metrics` to reject cross-origin requests.
+These are enforced by `/api/agent`, `/api/chat`, `/api/metrics`, `/api/metrics/search`, and `/api/web-vitals` to reject cross-origin requests. Same-origin requests (the app's own pages) are always allowed without configuration — the guard matches the request's `Origin` host against its `Host` header — so `ALLOWED_ORIGINS` / `ALLOWED_HOSTS` are only needed to allow extra cross-origin callers.
 
 ### Error Tracking (Sentry)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -520,6 +520,14 @@ Configured via environment variables:
 - `ALLOWED_ORIGINS` -- comma-separated full origin URLs (e.g., `https://roomshare.com`)
 - `ALLOWED_HOSTS` -- comma-separated hostnames (e.g., `roomshare.com`)
 
+**Same-origin requests are always allowed.** A first-party request whose `Origin`
+header host equals the request's own `Host` header is treated as same-origin and
+passes the guard on any domain — production, custom domains, preview deployments,
+and local production builds — without needing `ALLOWED_ORIGINS`. `ALLOWED_ORIGINS` /
+`ALLOWED_HOSTS` are therefore only required to permit *additional cross-origin*
+callers. The Vercel production domain is also auto-trusted via
+`VERCEL_PROJECT_PRODUCTION_URL` (and the per-deployment URL via `VERCEL_URL`).
+
 In development, `http://localhost:3000` and `localhost` are automatically added.
 
 ### Enforcement Points

--- a/src/__tests__/api/agent.test.ts
+++ b/src/__tests__/api/agent.test.ts
@@ -34,6 +34,7 @@ jest.mock("@sentry/nextjs", () => ({
 jest.mock("@/lib/origin-guard", () => ({
   isOriginAllowed: jest.fn().mockReturnValue(false),
   isHostAllowed: jest.fn().mockReturnValue(false),
+  isSameOrigin: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock("next/server", () => ({

--- a/src/__tests__/api/metrics.test.ts
+++ b/src/__tests__/api/metrics.test.ts
@@ -11,6 +11,7 @@
 
 const mockIsOriginAllowed = jest.fn().mockReturnValue(true);
 const mockIsHostAllowed = jest.fn().mockReturnValue(true);
+const mockIsSameOrigin = jest.fn().mockReturnValue(false);
 
 const mockCheckMetricsRateLimit = jest
   .fn()
@@ -27,6 +28,7 @@ const mockWithScope = jest.fn();
 jest.mock("@/lib/origin-guard", () => ({
   isOriginAllowed: (...args: unknown[]) => mockIsOriginAllowed(...args),
   isHostAllowed: (...args: unknown[]) => mockIsHostAllowed(...args),
+  isSameOrigin: (...args: unknown[]) => mockIsSameOrigin(...args),
 }));
 
 jest.mock("@/lib/rate-limit-redis", () => ({
@@ -126,6 +128,7 @@ describe("POST /api/metrics", () => {
     // Reset defaults
     mockIsOriginAllowed.mockReturnValue(true);
     mockIsHostAllowed.mockReturnValue(true);
+    mockIsSameOrigin.mockReturnValue(false);
     mockCheckMetricsRateLimit.mockResolvedValue({ success: true });
     mockGetClientIP.mockReturnValue("127.0.0.1");
     // Restore env in case a previous test mutated it
@@ -161,6 +164,23 @@ describe("POST /api/metrics", () => {
       expect(res.status).toBe(403);
       const data = await res.json();
       expect(data.error).toBe("Forbidden");
+    });
+
+    it("allows a same-origin request even when origin is not in the allowlist", async () => {
+      // First-party beacon: Origin host === Host header. The allowlist may be
+      // empty (no ALLOWED_ORIGINS / VERCEL_URL), but same-origin must still pass.
+      mockIsOriginAllowed.mockReturnValue(false);
+      mockIsSameOrigin.mockReturnValue(true);
+      const req = makeRequest(VALID_PAYLOAD, {
+        origin: "http://localhost:3000",
+        host: "localhost:3000",
+      });
+      const res = await POST(req);
+      expect(mockIsSameOrigin).toHaveBeenCalledWith(
+        "http://localhost:3000",
+        "localhost:3000"
+      );
+      expect(res.status).not.toBe(403);
     });
 
     it("falls back to host check when origin header is absent", async () => {

--- a/src/__tests__/api/search-telemetry.test.ts
+++ b/src/__tests__/api/search-telemetry.test.ts
@@ -6,9 +6,21 @@ jest.mock("@/lib/rate-limit", () => ({
   getClientIP: jest.fn(() => "127.0.0.1"),
 }));
 
+const mockIsOriginAllowed = jest.fn().mockReturnValue(true);
+const mockIsHostAllowed = jest.fn().mockReturnValue(true);
+
 jest.mock("@/lib/origin-guard", () => ({
-  isOriginAllowed: jest.fn(() => true),
-  isHostAllowed: jest.fn(() => true),
+  isOriginAllowed: (...args: unknown[]) => mockIsOriginAllowed(...args),
+  isHostAllowed: (...args: unknown[]) => mockIsHostAllowed(...args),
+  // Use the real same-origin logic so production-path tests are meaningful.
+  isSameOrigin: (origin: string | null, host: string | null) => {
+    if (!origin || !host) return false;
+    try {
+      return new URL(origin).host === host;
+    } catch {
+      return false;
+    }
+  },
 }));
 
 jest.mock("@/lib/logger", () => ({
@@ -32,6 +44,10 @@ describe("POST /api/metrics/search", () => {
   beforeEach(() => {
     resetSearchTelemetryForTests();
     jest.clearAllMocks();
+    // clearAllMocks() resets call history but leaks mockReturnValue overrides,
+    // so re-assert the allow-by-default origin/host guard each test.
+    mockIsOriginAllowed.mockReturnValue(true);
+    mockIsHostAllowed.mockReturnValue(true);
   });
 
   it("records a client abort metric", async () => {
@@ -116,5 +132,61 @@ describe("POST /api/metrics/search", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(200);
+  });
+
+  describe("production origin enforcement", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv, NODE_ENV: "production" };
+      // Empty allowlist: this is exactly the local-prod-build / unconfigured case.
+      mockIsOriginAllowed.mockReturnValue(false);
+      mockIsHostAllowed.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    const ABORT_PAYLOAD = {
+      metric: "search_client_abort_total",
+      route: "search-results-client",
+      queryHash: "hash-1",
+      reason: "superseded",
+    };
+
+    it("accepts a same-origin beacon even when the allowlist is empty", async () => {
+      const req = new Request("http://localhost:3000/api/metrics/search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          origin: "http://localhost:3000",
+          host: "localhost:3000",
+        },
+        body: JSON.stringify(ABORT_PAYLOAD),
+      });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(getSearchTelemetrySnapshot().clientAbortTotal).toBe(1);
+    });
+
+    it("rejects a cross-origin beacon (returns 403)", async () => {
+      const req = new Request("http://localhost:3000/api/metrics/search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://evil.com",
+          host: "localhost:3000",
+        },
+        body: JSON.stringify(ABORT_PAYLOAD),
+      });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(403);
+      expect(getSearchTelemetrySnapshot().clientAbortTotal).toBe(0);
+    });
   });
 });

--- a/src/__tests__/api/web-vitals.test.ts
+++ b/src/__tests__/api/web-vitals.test.ts
@@ -111,4 +111,42 @@ describe("POST /api/web-vitals", () => {
     expect(response.status).toBe(403);
     expect(mockCheckMetricsRateLimit).not.toHaveBeenCalled();
   });
+
+  it("accepts a same-origin beacon when the allowlist is empty (local prod build)", async () => {
+    // pnpm build && pnpm start on localhost: no ALLOWED_ORIGINS, no VERCEL_URL.
+    // The Origin host matches the Host header, so the first-party beacon passes.
+    delete process.env.VERCEL_URL;
+    const request = new Request("http://localhost:3000/api/web-vitals", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://localhost:3000",
+        host: "localhost:3000",
+      },
+      body: JSON.stringify(VALID_PAYLOAD),
+    });
+
+    const response = await POST(request);
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects a cross-origin beacon whose origin host differs from the host header", async () => {
+    delete process.env.VERCEL_URL;
+    const request = new Request("http://localhost:3000/api/web-vitals", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://evil.com",
+        host: "localhost:3000",
+      },
+      body: JSON.stringify(VALID_PAYLOAD),
+    });
+
+    const response = await POST(request);
+
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(response.status).toBe(403);
+  });
 });

--- a/src/__tests__/lib/origin-guard.test.ts
+++ b/src/__tests__/lib/origin-guard.test.ts
@@ -10,6 +10,7 @@ describe("origin-guard", () => {
     jest.resetModules();
     process.env = { ...ORIGINAL_ENV };
     delete process.env.VERCEL_URL;
+    delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
   });
 
   afterAll(() => {
@@ -54,6 +55,16 @@ describe("origin-guard", () => {
         "https://roomshare-random.vercel.app",
       ]);
     });
+
+    it("adds the production-domain origin from VERCEL_PROJECT_PRODUCTION_URL", async () => {
+      delete process.env.ALLOWED_ORIGINS;
+      process.env.VERCEL_PROJECT_PRODUCTION_URL = "roomshare.com";
+      (process.env as any).NODE_ENV = "production";
+
+      const { getAllowedOrigins } = await import("@/lib/origin-guard");
+
+      expect(getAllowedOrigins()).toEqual(["https://roomshare.com"]);
+    });
   });
 
   describe("isOriginAllowed", () => {
@@ -92,6 +103,35 @@ describe("origin-guard", () => {
     });
   });
 
+  describe("isSameOrigin", () => {
+    it("returns true when the origin host matches the request host", async () => {
+      const { isSameOrigin } = await import("@/lib/origin-guard");
+      expect(isSameOrigin("https://roomshare.com", "roomshare.com")).toBe(true);
+    });
+
+    it("returns true for a matching host that includes a port (local prod build)", async () => {
+      const { isSameOrigin } = await import("@/lib/origin-guard");
+      expect(isSameOrigin("http://localhost:3000", "localhost:3000")).toBe(true);
+    });
+
+    it("returns false for a cross-origin request", async () => {
+      const { isSameOrigin } = await import("@/lib/origin-guard");
+      expect(isSameOrigin("https://evil.com", "roomshare.com")).toBe(false);
+      expect(isSameOrigin("https://evil.com", "localhost:3000")).toBe(false);
+    });
+
+    it("returns false when origin or host is null", async () => {
+      const { isSameOrigin } = await import("@/lib/origin-guard");
+      expect(isSameOrigin(null, "roomshare.com")).toBe(false);
+      expect(isSameOrigin("https://roomshare.com", null)).toBe(false);
+    });
+
+    it("returns false for a malformed origin", async () => {
+      const { isSameOrigin } = await import("@/lib/origin-guard");
+      expect(isSameOrigin("not a url", "roomshare.com")).toBe(false);
+    });
+  });
+
   describe("getAllowedHosts", () => {
     it("parses a comma-separated ALLOWED_HOSTS env variable", async () => {
       process.env.ALLOWED_HOSTS = "example.com,api.example.com";
@@ -111,6 +151,16 @@ describe("origin-guard", () => {
         "example.com",
         "roomshare-random.vercel.app",
       ]);
+    });
+
+    it("adds the production-domain host from VERCEL_PROJECT_PRODUCTION_URL", async () => {
+      delete process.env.ALLOWED_HOSTS;
+      process.env.VERCEL_PROJECT_PRODUCTION_URL = "roomshare.com";
+      (process.env as any).NODE_ENV = "production";
+
+      const { getAllowedHosts } = await import("@/lib/origin-guard");
+
+      expect(getAllowedHosts()).toEqual(["roomshare.com"]);
     });
   });
 

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { auth } from "@/auth";
 import { withRateLimit } from "@/lib/with-rate-limit";
 import { logger, sanitizeErrorMessage } from "@/lib/logger";
-import { isOriginAllowed, isHostAllowed } from "@/lib/origin-guard";
+import { isOriginAllowed, isHostAllowed, isSameOrigin } from "@/lib/origin-guard";
 
 interface AgentRequest {
   question: string;
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
   const host = request.headers.get("host");
 
   if (process.env.NODE_ENV === "production") {
-    if (origin && !isOriginAllowed(origin)) {
+    if (origin && !isOriginAllowed(origin) && !isSameOrigin(origin, host)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     if (!origin && !isHostAllowed(host)) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -19,7 +19,7 @@ import {
 import { DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
 import { logger, sanitizeErrorMessage } from "@/lib/logger";
 import * as Sentry from "@sentry/nextjs";
-import { isOriginAllowed, isHostAllowed } from "@/lib/origin-guard";
+import { isOriginAllowed, isHostAllowed, isSameOrigin } from "@/lib/origin-guard";
 
 /**
  * Neighborhood Chat API Route
@@ -262,7 +262,7 @@ export async function POST(request: Request) {
 
     // In production, enforce origin/host
     if (process.env.NODE_ENV === "production") {
-      if (origin && !isOriginAllowed(origin)) {
+      if (origin && !isOriginAllowed(origin) && !isSameOrigin(origin, host)) {
         return new Response(JSON.stringify({ error: "Forbidden" }), {
           status: 403,
           headers: { "Content-Type": "application/json" },

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { checkMetricsRateLimit } from "@/lib/rate-limit-redis";
 import { getClientIP } from "@/lib/rate-limit";
-import { isOriginAllowed, isHostAllowed } from "@/lib/origin-guard";
+import { isOriginAllowed, isHostAllowed, isSameOrigin } from "@/lib/origin-guard";
 import { logger, sanitizeErrorMessage } from "@/lib/logger";
 import { hmacListingId, hasHmacSecret } from "./hmac";
 
@@ -165,7 +165,7 @@ export async function POST(request: Request) {
 
     // In production, enforce origin/host
     if (process.env.NODE_ENV === "production") {
-      if (origin && !isOriginAllowed(origin)) {
+      if (origin && !isOriginAllowed(origin) && !isSameOrigin(origin, host)) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
 

--- a/src/app/api/metrics/search/route.ts
+++ b/src/app/api/metrics/search/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { checkMetricsRateLimit } from "@/lib/rate-limit-redis";
 import { getClientIP } from "@/lib/rate-limit";
-import { isOriginAllowed, isHostAllowed } from "@/lib/origin-guard";
+import { isOriginAllowed, isHostAllowed, isSameOrigin } from "@/lib/origin-guard";
 import { logger, sanitizeErrorMessage } from "@/lib/logger";
 import {
   LEGACY_URL_ALIASES,
@@ -267,7 +267,7 @@ export async function POST(request: Request) {
     const host = request.headers.get("host");
 
     if (process.env.NODE_ENV === "production") {
-      if (origin && !isOriginAllowed(origin)) {
+      if (origin && !isOriginAllowed(origin) && !isSameOrigin(origin, host)) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
       if (!origin && !isHostAllowed(host)) {

--- a/src/app/api/web-vitals/route.ts
+++ b/src/app/api/web-vitals/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { checkMetricsRateLimit } from "@/lib/rate-limit-redis";
 import { getClientIP } from "@/lib/rate-limit";
-import { isOriginAllowed, isHostAllowed } from "@/lib/origin-guard";
+import { isOriginAllowed, isHostAllowed, isSameOrigin } from "@/lib/origin-guard";
 import { logger, sanitizeErrorMessage } from "@/lib/logger";
 
 /**
@@ -104,7 +104,7 @@ export async function POST(request: Request) {
     const host = request.headers.get("host");
 
     if (process.env.NODE_ENV === "production") {
-      if (origin && !isOriginAllowed(origin)) {
+      if (origin && !isOriginAllowed(origin) && !isSameOrigin(origin, host)) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
       if (!origin && !isHostAllowed(host)) {

--- a/src/lib/origin-guard.ts
+++ b/src/lib/origin-guard.ts
@@ -3,13 +3,24 @@
  * Used by: chat, agent, metrics routes.
  */
 
-function getVercelDeploymentHost(): string | null {
-  const rawUrl = process.env.VERCEL_URL?.trim();
-  if (!rawUrl) return null;
+function normalizeHost(rawUrl: string | undefined): string | null {
+  const trimmed = rawUrl?.trim();
+  if (!trimmed) return null;
 
-  const withoutProtocol = rawUrl.replace(/^https?:\/\//i, "");
+  const withoutProtocol = trimmed.replace(/^https?:\/\//i, "");
   const host = withoutProtocol.split("/")[0]?.trim();
   return host || null;
+}
+
+function getVercelDeploymentHost(): string | null {
+  // Per-deployment URL (e.g. my-app-abc123.vercel.app) — NOT the user-facing domain.
+  return normalizeHost(process.env.VERCEL_URL);
+}
+
+function getVercelProductionHost(): string | null {
+  // The production/custom-domain URL. Unlike VERCEL_URL, this matches the domain
+  // users actually visit, so same-site requests are trusted without ALLOWED_ORIGINS.
+  return normalizeHost(process.env.VERCEL_PROJECT_PRODUCTION_URL);
 }
 
 export function getAllowedOrigins(): string[] {
@@ -21,6 +32,10 @@ export function getAllowedOrigins(): string[] {
   const vercelHost = getVercelDeploymentHost();
   if (vercelHost) {
     parsed.push(`https://${vercelHost}`);
+  }
+  const prodHost = getVercelProductionHost();
+  if (prodHost) {
+    parsed.push(`https://${prodHost}`);
   }
   if (process.env.NODE_ENV === "development") {
     parsed.push("http://localhost:3000");
@@ -38,6 +53,10 @@ export function getAllowedHosts(): string[] {
   if (vercelHost) {
     parsed.push(vercelHost);
   }
+  const prodHost = getVercelProductionHost();
+  if (prodHost) {
+    parsed.push(prodHost);
+  }
   if (process.env.NODE_ENV === "development") {
     parsed.push("localhost:3000", "localhost");
   }
@@ -54,4 +73,24 @@ export function isHostAllowed(host: string | null): boolean {
   const allowed = getAllowedHosts();
   const hostWithoutPort = host.split(":")[0];
   return allowed.some((h) => h === host || h === hostWithoutPort);
+}
+
+/**
+ * Same-origin check (CSRF-safe). A first-party browser request carries an
+ * `Origin` header whose host equals the request's own `Host` header. This holds
+ * on any domain — production, custom domains, preview deployments, and local
+ * production builds — without needing ALLOWED_ORIGINS configured. Cross-origin
+ * browser requests carry a foreign origin and are not matched here.
+ */
+export function isSameOrigin(
+  origin: string | null,
+  host: string | null
+): boolean {
+  if (!origin || !host) return false;
+  try {
+    // URL.host includes the port (when non-default), matching the Host header.
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Problem

`/api/web-vitals` returned **403** on every page and `/api/metrics/search` returned **403** after toggling the search map. The browser fired repeated console errors and failed pings.

**Root cause.** All five guarded routes (`web-vitals`, `metrics`, `metrics/search`, `chat`, `agent`) share one production origin guard:

```ts
if (process.env.NODE_ENV === "production") {
  if (origin && !isOriginAllowed(origin)) return 403; // fires
  ...
}
```

`getAllowedOrigins()` only trusted `ALLOWED_ORIGINS` + `https://${VERCEL_URL}`. `VERCEL_URL` is the **per-deployment** URL, not the user-facing production/custom domain — so legitimate **same-origin** beacons (`navigator.sendBeacon` / `fetch`) were rejected with 403 on local production builds, and on Vercel prod whenever `ALLOWED_ORIGINS` wasn't set to the exact visited domain.

## Fix

Add a CSRF-safe **same-origin allowance** in `src/lib/origin-guard.ts`: a request whose `Origin`-header host equals its own `Host` header is first-party and passes on any domain / preview / local prod build with no env configuration. Cross-origin browser requests still carry a foreign `Origin` and remain blocked. Also trust `VERCEL_PROJECT_PRODUCTION_URL` (the production domain, unlike `VERCEL_URL`). Composed into all 5 route guards; `chat`/`agent` keep their separate session-auth layer.

```ts
export function isSameOrigin(origin, host) {
  if (!origin || !host) return false;
  try { return new URL(origin).host === host; } catch { return false; }
}
// guard: if (origin && !isOriginAllowed(origin) && !isSameOrigin(origin, host)) return 403;
```

## Verification

- **163 tests pass** across the blast radius, incl. new regression cases proving same-origin → 200 and cross-origin → 403 through the real guard (`origin-guard`, `metrics`, `web-vitals`, `search-telemetry`, `agent`, `chat`).
- **Typecheck** + **lint** clean.
- **Local prod build smoke test** (`pnpm build && pnpm start`): same-origin → `200 {"ok":true}`, cross-origin (`evil.com`) → `403 {"error":"Forbidden"}` on `/api/web-vitals` and `/api/metrics/search`.
- **CDP browser verification on `:3000`**: web-vitals beacons + `metrics/search` return 200, zero 403s, no console errors.

## Risk & rollback

Same-origin allowance is the standard CSRF-safe check — never admits cross-origin browser requests. Additive (only widens what passes; nothing previously allowed is now blocked). Fully reversible: revert `origin-guard.ts` + the five route imports. No DB or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)