### PR TITLE
fix(listings): harden create-listing submit, collision & error UX (audit follow-ups)

### DIFF
--- a/src/__tests__/api/listings-post.test.ts
+++ b/src/__tests__/api/listings-post.test.ts
@@ -1058,9 +1058,15 @@ describe("POST /api/listings — extended edge cases", () => {
       );
       const data = await response.json();
 
-      expect(response.status).toBe(503);
+      // Flag-off is a permanent config state, not a transient outage: return a
+      // 400 address field error (retrying the manual address can never succeed)
+      // rather than a misleading "try again" 503.
+      expect(response.status).toBe(400);
       expect(data.error).toBe(
-        "Address verification temporarily unavailable. Please try again."
+        "Please select an address from the suggestions to publish your listing."
+      );
+      expect(data.fields.address).toBe(
+        "Please select an address from the suggestions to publish your listing."
       );
       expect(geocodeAddress).not.toHaveBeenCalled();
     });

--- a/src/__tests__/api/listings/create-listing-collision-endpoint.integration.test.ts
+++ b/src/__tests__/api/listings/create-listing-collision-endpoint.integration.test.ts
@@ -379,7 +379,35 @@ describe("POST /api/listings collision flow", () => {
     expect(recordListingCreateCollisionResolved).toHaveBeenCalledWith({
       ownerHashPrefix8: "deadbeef",
       action: "proceed",
+      reasonProvided: false,
     });
+  });
+
+  it("threads create-separate justification metadata (not raw text) into telemetry", async () => {
+    process.env.FEATURE_LISTING_CREATE_COLLISION_WARN = "true";
+    const { tx } = createTx();
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback) =>
+      callback(tx)
+    );
+
+    const reason = "These are two genuinely separate rooms in the same house.";
+    const response = await POST(
+      makeRequest(
+        { ...validBody, createSeparateReason: reason },
+        { "x-collision-ack": "1" }
+      )
+    );
+
+    expect(response.status).toBe(201);
+    expect(recordListingCreateCollisionResolved).toHaveBeenCalledWith({
+      ownerHashPrefix8: "deadbeef",
+      action: "proceed",
+      reasonProvided: true,
+      reasonLength: reason.length,
+    });
+    // The raw justification text must never be handed to telemetry (PII).
+    const calls = (recordListingCreateCollisionResolved as jest.Mock).mock.calls;
+    expect(JSON.stringify(calls)).not.toContain(reason);
   });
 
   it("blocks the fourth acked collision in 24 hours", async () => {

--- a/src/__tests__/components/CreateListingForm.test.tsx
+++ b/src/__tests__/components/CreateListingForm.test.tsx
@@ -744,6 +744,88 @@ describe("CreateListingForm", () => {
       // No error banner should appear for AbortError
       expect(screen.queryByTestId("form-error-banner")).not.toBeInTheDocument();
     });
+
+    it("surfaces a friendly, time-aware message on a 429 rate limit", async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: { get: () => "120" },
+        json: () =>
+          Promise.resolve({
+            error: "Too many requests",
+            message: "Please wait before making more requests",
+            retryAfter: 120,
+          }),
+      } as unknown as Response);
+
+      render(<CreateListingForm />);
+      await addImageAndSubmit();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/listing creation limit.*try again in 2 minutes/i)
+        ).toBeInTheDocument();
+      });
+      // The bare server error must not be what the user sees.
+      expect(screen.queryByText("Too many requests")).not.toBeInTheDocument();
+    });
+
+    it("shows a friendly fallback (not a parser error) when the error body is not JSON", async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        headers: { get: () => null },
+        json: () =>
+          Promise.reject(
+            new SyntaxError("Unexpected token < in JSON at position 0")
+          ),
+      } as unknown as Response);
+
+      render(<CreateListingForm />);
+      await addImageAndSubmit();
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to create listing")).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/Unexpected token/i)).not.toBeInTheDocument();
+    });
+
+    it("re-opens the collision modal so the choice can be retried after a transient resubmit failure", async () => {
+      const sibling = {
+        id: "listing-existing",
+        title: "Existing Listing",
+        createdAt: "2026-06-01",
+        moveInDate: "2026-07-01",
+        canUpdate: true,
+      };
+      fetchSpy
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 409,
+          headers: { get: () => null },
+          json: () =>
+            Promise.resolve({
+              error: "COLLISION_CANDIDATES",
+              siblings: [sibling],
+            }),
+        } as unknown as Response)
+        .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      render(<CreateListingForm />);
+      await addImageAndSubmit();
+
+      // The 409 opens the collision modal; pick "additional start date" + continue.
+      const modal = await screen.findByTestId("collision-modal");
+      fireEvent.click(within(modal).getByTestId("collision-radio-add-date"));
+      fireEvent.click(within(modal).getByTestId("collision-continue"));
+
+      // The resubmit fails transiently — the modal must return for a retry
+      // instead of stranding the user, with the error shown as a toast.
+      await waitFor(() => {
+        expect(screen.getByTestId("collision-modal")).toBeInTheDocument();
+      });
+      expect(toast.error).toHaveBeenCalled();
+    });
   });
 
   describe("submission guards", () => {

--- a/src/__tests__/lib/create-listing-schema.test.ts
+++ b/src/__tests__/lib/create-listing-schema.test.ts
@@ -1241,4 +1241,43 @@ describe("createListingApiSchema", () => {
       expect(r.success).toBe(true);
     });
   });
+
+  describe("createSeparateReason", () => {
+    const reason = "These are two separate rooms in the same house.";
+
+    it("accepts a valid 10–500 char justification", () => {
+      const r = createListingApiSchema.safeParse({
+        ...validApi,
+        createSeparateReason: reason,
+      });
+      expect(r.success).toBe(true);
+      if (r.success) {
+        expect(r.data.createSeparateReason).toBe(reason);
+      }
+    });
+
+    it("is optional — absent input is valid", () => {
+      const r = createListingApiSchema.safeParse({ ...validApi });
+      expect(r.success).toBe(true);
+      if (r.success) {
+        expect(r.data.createSeparateReason).toBeUndefined();
+      }
+    });
+
+    it("rejects a justification shorter than 10 characters", () => {
+      const r = createListingApiSchema.safeParse({
+        ...validApi,
+        createSeparateReason: "too short",
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it("rejects a justification longer than 500 characters", () => {
+      const r = createListingApiSchema.safeParse({
+        ...validApi,
+        createSeparateReason: "x".repeat(501),
+      });
+      expect(r.success).toBe(false);
+    });
+  });
 });

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -284,6 +284,7 @@ export async function POST(request: Request) {
       moveInDate,
       bookingMode,
       addressSuggestionToken,
+      createSeparateReason,
     } = validatedFields.data;
 
     // 8. Language compliance check on title AND description (2G)
@@ -384,12 +385,14 @@ export async function POST(request: Request) {
         city,
         state,
       });
+      // Flag-off is a persistent config state, not a transient outage — a
+      // bare manual address can never be verified here, so retrying is futile.
+      // Direct the user to the only path that works: pick a suggested address.
+      const message =
+        "Please select an address from the suggestions to publish your listing.";
       return NextResponse.json(
-        {
-          error:
-            "Address verification temporarily unavailable. Please try again.",
-        },
-        { status: 503, headers: { "Retry-After": "10" } }
+        { error: message, field: "address", fields: { address: message } },
+        { status: 400 }
       );
     }
 
@@ -527,6 +530,8 @@ export async function POST(request: Request) {
           recordListingCreateCollisionResolved({
             ownerHashPrefix8,
             action: "proceed",
+            reasonProvided: Boolean(createSeparateReason),
+            reasonLength: createSeparateReason?.length,
           });
         }
       }

--- a/src/app/listings/create/CreateListingForm.tsx
+++ b/src/app/listings/create/CreateListingForm.tsx
@@ -156,6 +156,21 @@ function focusFirstFieldError(errors: Record<string, string>) {
   }
 }
 
+// Turn a Retry-After value (seconds) into a human phrase for 429 messaging.
+function formatRetryAfter(retryAfter: string | number | null | undefined): string {
+  const seconds = Number(retryAfter);
+  if (!Number.isFinite(seconds) || seconds <= 0) return "a little while";
+  if (seconds < 60) return `${Math.ceil(seconds)} seconds`;
+  // Branch on raw seconds (not on a ceiled minute count) so a ~59-minute wait
+  // is not rounded up to "1 hour". Ceil keeps the estimate from under-promising.
+  if (seconds < 3600) {
+    const minutes = Math.ceil(seconds / 60);
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  const hours = Math.ceil(seconds / 3600);
+  return `${hours} hour${hours === 1 ? "" : "s"}`;
+}
+
 interface CreateListingFormProps {
   enableWholeUnitMode?: boolean;
 }
@@ -457,6 +472,8 @@ export default function CreateListingForm({
   const performCollisionAckResubmit = async (
     bodyObj: Record<string, unknown>
   ) => {
+    // Remember siblings so a transient failure can re-open the modal for retry.
+    const previousSiblings = collisionSiblings;
     setCollisionSiblings(null);
     setLoading(true);
     isSubmittingRef.current = true;
@@ -501,7 +518,13 @@ export default function CreateListingForm({
           json && typeof json === "object" && typeof json.error === "string"
             ? json.error
             : "Failed to create listing";
-        showError(msg);
+        // Keep the collision modal available so the user can retry their choice
+        // instead of being stranded behind a page-level error banner.
+        toast.error(msg);
+        if (previousSiblings) {
+          setCollisionSiblings(previousSiblings);
+          setCollisionBody(bodyObj);
+        }
         if (
           res.status >= 400 &&
           res.status < 500 &&
@@ -521,6 +544,7 @@ export default function CreateListingForm({
       clearPersistedData();
       navGuard.disable();
       idempotencyKeyRef.current = crypto.randomUUID();
+      setCollisionSiblings(null);
       setCollisionBody(null);
       toast.success("Listing published successfully!", {
         description:
@@ -534,9 +558,24 @@ export default function CreateListingForm({
       }, 1000);
     } catch (err: unknown) {
       if (err instanceof Error && err.name === "AbortError") return;
+      Sentry.captureException(err, {
+        tags: {
+          component: "CreateListingForm",
+          action: "collision-ack-resubmit",
+        },
+      });
+      // Intentionally do NOT regenerate the idempotency key here: a network
+      // error may mean the request committed but its response was lost, so a
+      // retry with the same key returns the cached 201 instead of double-creating.
+      // Re-open the collision modal so the choice can be retried, surfacing the
+      // error as a toast rather than the page-level banner.
+      if (previousSiblings) {
+        setCollisionSiblings(previousSiblings);
+        setCollisionBody(bodyObj);
+      }
       const msg =
         err instanceof Error ? err.message : "An unexpected error occurred";
-      showError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
       isSubmittingRef.current = false;
@@ -704,7 +743,9 @@ export default function CreateListingForm({
       if (abortController.signal.aborted) return;
 
       if (!res.ok) {
-        const json = await res.json();
+        // Guard against non-JSON error bodies (502/504/HTML/empty) so a parser
+        // error doesn't mask the real failure with "Unexpected token <".
+        const json = await res.json().catch(() => ({}));
 
         // Collision warning path: server returned 409 COLLISION_CANDIDATES
         // with a siblings payload. Open the modal and pause submission;
@@ -720,6 +761,18 @@ export default function CreateListingForm({
           setLoading(false);
           isSubmittingRef.current = false;
           return;
+        }
+
+        // Rate limited: surface a time-aware message instead of the bare
+        // "Too many requests" the server returns.
+        if (res.status === 429) {
+          idempotencyKeyRef.current = crypto.randomUUID();
+          const retryPhrase = formatRetryAfter(
+            json?.retryAfter ?? res.headers.get("Retry-After")
+          );
+          throw new Error(
+            `You've reached the listing creation limit. Please try again in ${retryPhrase}.`
+          );
         }
 
         // Regenerate key when the server definitively rejected (no listing created).

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -285,6 +285,16 @@ export const createListingApiSchema = createListingSchema.extend({
     .max(4096, "Address suggestion token is invalid")
     .optional()
     .transform((value) => (value && value.length > 0 ? value : undefined)),
+  // Justification supplied when a host overrides a duplicate-listing collision
+  // via "Create a separate listing anyway". Validated here so it is no longer
+  // silently stripped; the raw text is never logged (PII), only its presence
+  // and length are recorded in collision telemetry.
+  createSeparateReason: z
+    .string()
+    .trim()
+    .min(10, "Please explain why this should be a separate listing.")
+    .max(500, "Reason must be 500 characters or fewer.")
+    .optional(),
 });
 
 export type CreateListingApiInput = z.infer<typeof createListingApiSchema>;

--- a/src/lib/search/search-telemetry.ts
+++ b/src/lib/search/search-telemetry.ts
@@ -363,14 +363,22 @@ export function recordListingCreateCollisionDetected({
 export function recordListingCreateCollisionResolved({
   ownerHashPrefix8,
   action,
+  reasonProvided = false,
+  reasonLength,
 }: {
   ownerHashPrefix8: string;
   action: "proceed" | "moderation_gated";
+  // Whether a "create separate" justification accompanied the override, and its
+  // length. The raw reason text is intentionally NOT logged (may contain PII).
+  reasonProvided?: boolean;
+  reasonLength?: number;
 }): void {
   telemetryStore.listingCreateCollisionResolvedTotal += 1;
   logger.sync.info("listing_create_collision_resolved_total", {
     ownerHashPrefix8,
     action,
+    reasonProvided,
+    ...(reasonLength !== undefined ? { reasonLength } : {}),
     total: telemetryStore.listingCreateCollisionResolvedTotal,
   });
 }

--- a/tests/e2e/create-listing/create-listing.resilience.spec.ts
+++ b/tests/e2e/create-listing/create-listing.resilience.spec.ts
@@ -92,13 +92,19 @@ test.describe("Create Listing – Resilience", () => {
     const formData = toPomData(listingData);
     createPage = await setupFilledForm(page, formData);
 
+    // Realistic limiter response: generic error/message + a retryAfter window.
     await createPage.mockListingApiError(429, {
-      error: "Rate limit exceeded. Try again later.",
+      error: "Too many requests",
+      message: "Please wait before making more requests",
+      retryAfter: 120,
     });
 
     await createPage.submitAndWaitForResponse();
 
-    await createPage.expectErrorBanner(/rate limit/i);
+    // The client surfaces a friendly, time-aware limit message built from
+    // retryAfter (120s → "2 minutes") rather than echoing the terse server error.
+    await createPage.expectErrorBanner(/try again in 2 minutes/i);
+    await expect(createPage.errorBanner).not.toContainText(/too many requests/i);
     await createPage.expectOnCreatePage();
     await expect(createPage.titleInput).toHaveValue(listingData.title);
   });


### PR DESCRIPTION
## Summary

Six **low-severity** follow-ups from the create-listing audit, focused on submit robustness, the duplicate-listing collision flow, and honest error messaging. (Builds on #157, which fixed the draft + a11y findings.)

## What changed

1. **`createSeparateReason`** (`schemas.ts`, `route.ts`, `search-telemetry.ts`) — the collision modal forces a 10–500 char justification for "Create a separate listing anyway", but it wasn't in `createListingApiSchema` so Zod silently stripped it. Now validated server-side and threaded into `recordListingCreateCollisionResolved` as **PII-safe metadata** (`reasonProvided` + `reasonLength` — the raw text is never logged).
2. **Non-JSON error crash** (`CreateListingForm.tsx`) — the error-path `res.json()` is now `.catch(() => ({}))`, so a 502/504/HTML/empty body shows a friendly fallback instead of a raw `Unexpected token <`.
3. **429 Retry-After** (`CreateListingForm.tsx`) — a time-aware message ("try again in N minutes") built from `json.retryAfter` / the `Retry-After` header, instead of the bare "Too many requests".
4. **Geocoding flag-off** (`route.ts`) — returns a **400 address field error** ("select an address from the suggestions") instead of a misleading transient **503**; the flag-off state is permanent, so retrying a manual address can never succeed.
5. **Collision-ack resubmit** (`CreateListingForm.tsx`) — on a transient/network failure, restores the collision siblings (re-opening the modal) with a toast instead of the page banner, so the choice can be retried. The idempotency key is intentionally kept on network errors so a committed-but-lost response replays the cached 201 rather than double-creating.
6. **Sentry** added to the collision-ack resubmit catch (previously swallowed).

## Tests
- Schema accept/reject for `createSeparateReason`; server telemetry threading **+ a mechanical assertion that the raw reason never reaches telemetry**; 429 friendly message; non-JSON fallback; collision-modal retry-on-failure.
- Updated two existing tests that asserted the old behavior (503→400; telemetry args).

## Verification
- ✅ `pnpm typecheck` clean · ✅ `eslint` 0 errors · ✅ **320 related tests pass**
- ✅ Independent code review — no critical issues; PII invariant + idempotency handling confirmed; the two review findings (`formatRetryAfter` ceiling bug, idempotency-key comment) folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)