### PR TITLE
fix(map): keyboard-accessible markers + clusters, neighborhood zoom-snap, in-flight empty state

### DIFF
--- a/src/__tests__/components/Map.test.tsx
+++ b/src/__tests__/components/Map.test.tsx
@@ -2646,6 +2646,89 @@ describe("Map Component", () => {
         expect(screen.queryByTestId("map-popup")).not.toBeInTheDocument();
       });
     });
+
+    it("roving tabindex: exactly one marker is tabbable, the rest are -1", async () => {
+      await renderMapAndPopulateMarkers();
+
+      const markerEls = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-listing-id]")
+      );
+      expect(markerEls.length).toBeGreaterThan(1);
+
+      const tabbable = markerEls.filter(
+        (el) => el.getAttribute("tabindex") === "0"
+      );
+      expect(tabbable).toHaveLength(1);
+      expect(
+        markerEls.filter((el) => el.getAttribute("tabindex") === "-1")
+      ).toHaveLength(markerEls.length - 1);
+      // Default tabbable marker is the first sorted (northernmost) listing.
+      expect(tabbable[0].getAttribute("data-listing-id")).toBe("listing-2");
+    });
+
+    it("ArrowDown moves the single tabbable marker to a neighbor", async () => {
+      await renderMapAndPopulateMarkers();
+
+      const tabbableBefore = document.querySelector<HTMLElement>(
+        '[data-listing-id][tabindex="0"]'
+      );
+      expect(tabbableBefore?.getAttribute("data-listing-id")).toBe("listing-2");
+
+      await act(async () => {
+        fireEvent.keyDown(tabbableBefore!, { key: "ArrowDown" });
+      });
+
+      const tabbableAfter = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '[data-listing-id][tabindex="0"]'
+        )
+      );
+      expect(tabbableAfter).toHaveLength(1);
+      expect(tabbableAfter[0].getAttribute("data-listing-id")).not.toBe(
+        "listing-2"
+      );
+      expect(mockMapInstance.easeTo).toHaveBeenCalled();
+    });
+
+    it("renders a keyboard-operable cluster button that expands on Enter", async () => {
+      const clusterZoomSpy = jest.fn(() => Promise.resolve(15));
+      mockMapInstance.getSource = jest.fn(() => ({
+        getClusterExpansionZoom: clusterZoomSpy,
+      }));
+      // Listing features + one rendered cluster (with point_count + geometry).
+      mockQuerySourceFeaturesData = [
+        ...listingsToFeatures(mockListings),
+        {
+          properties: { cluster_id: 1, point_count: 5 },
+          geometry: { type: "Point", coordinates: [-122.42, 37.78] },
+        },
+      ] as unknown as typeof mockQuerySourceFeaturesData;
+
+      render(<MapComponent listings={mockListings} />);
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      const handlers = (
+        window as unknown as Record<string, { onIdle?: () => void }>
+      ).__mapHandlers;
+      await act(async () => {
+        handlers?.onIdle?.();
+      });
+
+      const clusterButton = screen.getByTestId("map-cluster-1");
+      expect(clusterButton).toHaveAttribute(
+        "aria-label",
+        "Group of 5 listings. Press Enter to zoom in."
+      );
+      // Sole cluster → it is the default tabbable member of the cluster group.
+      expect(clusterButton).toHaveAttribute("tabindex", "0");
+
+      await act(async () => {
+        fireEvent.keyDown(clusterButton, { key: "Enter" });
+      });
+      // Enter routes through the shared expandCluster path (same as a click).
+      expect(clusterZoomSpy).toHaveBeenCalledWith(1);
+    });
   });
 
   describe("accessibility", () => {

--- a/src/__tests__/components/PersistentMapWrapper.networking.test.tsx
+++ b/src/__tests__/components/PersistentMapWrapper.networking.test.tsx
@@ -13,11 +13,29 @@ jest.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
-// Mock the DynamicMap component (lazy loaded)
+// Mock the DynamicMap component (lazy loaded).
+// Surfaces the empty-state-gating props (not just listings.length) so tests can
+// assert they actually reach the map, per the map-subsystem audit.
 jest.mock("@/components/DynamicMap", () => ({
   __esModule: true,
-  default: ({ listings }: { listings: unknown[] }) => (
-    <div data-testid="dynamic-map" data-listings-count={listings.length}>
+  default: ({
+    listings,
+    isFetchingData,
+    hasFetchError,
+    suppressEmptyState,
+  }: {
+    listings: unknown[];
+    isFetchingData?: boolean;
+    hasFetchError?: boolean;
+    suppressEmptyState?: boolean;
+  }) => (
+    <div
+      data-testid="dynamic-map"
+      data-listings-count={listings.length}
+      data-is-fetching={String(Boolean(isFetchingData))}
+      data-has-fetch-error={String(Boolean(hasFetchError))}
+      data-suppress-empty={String(Boolean(suppressEmptyState))}
+    >
       Map with {listings.length} listings
     </div>
   ),
@@ -269,6 +287,41 @@ describe("PersistentMapWrapper - Networking & Race Conditions (P1-7)", () => {
       expect(reactWarnings.length).toBe(0);
 
       consoleError.mockRestore();
+    });
+  });
+
+  describe("In-flight empty-state gating", () => {
+    it("passes isFetchingData=true to the map while a fetch is in flight", async () => {
+      // A fetch that never resolves keeps isFetchingMapData truthy. This is the
+      // signal that prevents the map from flashing "No listings in this area"
+      // mid-load (see shouldShowEmptyState + map-view-state.test.ts).
+      mockFetch.mockImplementation(() => new Promise(() => {}));
+
+      render(<PersistentMapWrapper shouldRenderMap={true} />);
+
+      await act(async () => {
+        jest.advanceTimersByTime(MAP_FETCH_DEBOUNCE_MS);
+      });
+
+      expect(mockFetch).toHaveBeenCalled();
+      const map = screen.getByTestId("dynamic-map");
+      expect(map).toHaveAttribute("data-is-fetching", "true");
+      // In flight is NOT an error state.
+      expect(map).toHaveAttribute("data-has-fetch-error", "false");
+    });
+
+    it("passes isFetchingData=false once the fetch resolves", async () => {
+      render(<PersistentMapWrapper shouldRenderMap={true} />);
+
+      await act(async () => {
+        jest.advanceTimersByTime(MAP_FETCH_DEBOUNCE_MS);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const map = screen.getByTestId("dynamic-map");
+      expect(map).toHaveAttribute("data-is-fetching", "false");
     });
   });
 

--- a/src/__tests__/components/map/touch-gestures.test.tsx
+++ b/src/__tests__/components/map/touch-gestures.test.tsx
@@ -815,7 +815,9 @@ describe("Map Touch Gestures", () => {
       // which may not fully execute in JSDOM environment.
       // Full hover behavior should be verified in Playwright E2E tests.
       expect(markerContent).toHaveAttribute("role", "button");
-      expect(markerContent).toHaveAttribute("tabIndex", "0");
+      // Roving tabindex: every marker is keyboard-focusable; exactly one is
+      // "0" (tabbable) and the rest are "-1" (reachable via arrow keys/.focus()).
+      expect(["0", "-1"]).toContain(markerContent!.getAttribute("tabindex"));
     });
 
     it("should handle marker tap/click on touch devices", async () => {
@@ -1151,9 +1153,10 @@ describe("Map Touch Gestures", () => {
       const markers = screen.getAllByTestId("map-marker");
       const markerContent = markers[0].querySelector("[data-listing-id]");
 
-      // Marker content should have role="button" and aria-label
+      // Marker content should have role="button" and aria-label.
+      // Roving tabindex: each marker is "0" (tabbable) or "-1" (focusable).
       expect(markerContent).toHaveAttribute("role", "button");
-      expect(markerContent).toHaveAttribute("tabIndex", "0");
+      expect(["0", "-1"]).toContain(markerContent!.getAttribute("tabindex"));
       expect(markerContent).toHaveAttribute("aria-label");
     });
 

--- a/src/__tests__/components/neighborhood/NeighborhoodMap.clustering.test.tsx
+++ b/src/__tests__/components/neighborhood/NeighborhoodMap.clustering.test.tsx
@@ -5,6 +5,7 @@ import type { POI } from "@/lib/places/types";
 
 let lastMapProps: Record<string, unknown> = {};
 const mockFlyTo = jest.fn();
+const mockGetZoom = jest.fn(() => 16);
 const mockGetCanvas = jest.fn(() => ({ style: { cursor: "" } }));
 const mockGetSource = jest.fn(() => ({
   getClusterExpansionZoom: jest.fn().mockResolvedValue(15),
@@ -18,6 +19,7 @@ jest.mock("react-map-gl/maplibre", () => {
       lastMapProps = props;
       React.useImperativeHandle(ref, () => ({
         flyTo: mockFlyTo,
+        getZoom: mockGetZoom,
         getCanvas: mockGetCanvas,
         getSource: mockGetSource,
       }));
@@ -113,5 +115,62 @@ describe("NeighborhoodMap clustering", () => {
     expect(onPoiClick).toHaveBeenCalledWith(
       expect.objectContaining({ placeId: "place-3" })
     );
+  });
+
+  describe("fly to selected POI", () => {
+    it("flies to the selected POI once, reading the live zoom (not viewState)", () => {
+      render(
+        <NeighborhoodMap
+          center={{ lat: 37.77, lng: -122.42 }}
+          pois={makePois(15)}
+          selectedPlaceId="place-3"
+        />
+      );
+
+      // place-3 → lat 37.773, lng -122.417; zoom = max(getZoom()=16, 15) = 16.
+      expect(mockFlyTo).toHaveBeenCalledTimes(1);
+      expect(mockFlyTo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          center: [-122.417, 37.773],
+          zoom: 16,
+        })
+      );
+      expect(mockGetZoom).toHaveBeenCalled();
+    });
+
+    it("does not re-fly when only the viewport zoom changes (no snap-back)", () => {
+      render(
+        <NeighborhoodMap
+          center={{ lat: 37.77, lng: -122.42 }}
+          pois={makePois(15)}
+          selectedPlaceId="place-3"
+        />
+      );
+
+      expect(mockFlyTo).toHaveBeenCalledTimes(1);
+
+      // Simulate the user zooming: onMove updates viewState every frame. The
+      // fly-to effect must NOT re-fire (that was the snap-back bug).
+      act(() => {
+        (
+          lastMapProps.onMove as
+            | ((evt: { viewState: Record<string, number> }) => void)
+            | undefined
+        )?.({
+          viewState: { longitude: -122.42, latitude: 37.77, zoom: 11 },
+        });
+      });
+      act(() => {
+        (
+          lastMapProps.onMove as
+            | ((evt: { viewState: Record<string, number> }) => void)
+            | undefined
+        )?.({
+          viewState: { longitude: -122.42, latitude: 37.77, zoom: 18 },
+        });
+      });
+
+      expect(mockFlyTo).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/__tests__/lib/maps/map-view-state.test.ts
+++ b/src/__tests__/lib/maps/map-view-state.test.ts
@@ -20,6 +20,7 @@ const settledEmpty: EmptyStateInput = {
   isSearching: false,
   suppressEmptyState: false,
   hasFetchError: false,
+  isFetchingData: false,
   listingsCount: 0,
 };
 
@@ -42,6 +43,22 @@ describe("shouldShowEmptyState", () => {
     expect(shouldShowEmptyState(afterRetry)).toBe(true);
   });
 
+  it("REGRESSION: never shows while a fetch is in flight, even with 0 listings", () => {
+    // A filter/query change after a prior zero-result can leave listings=[] with
+    // a refetch in flight; the overlay must wait, not flash "No listings".
+    expect(
+      shouldShowEmptyState({ ...settledEmpty, isFetchingData: true })
+    ).toBe(false);
+  });
+
+  it("shows again once an in-flight fetch settles to zero results", () => {
+    const duringFetch = { ...settledEmpty, isFetchingData: true };
+    expect(shouldShowEmptyState(duringFetch)).toBe(false);
+
+    const afterSettle = { ...duringFetch, isFetchingData: false };
+    expect(shouldShowEmptyState(afterSettle)).toBe(true);
+  });
+
   it("never shows when listings are present, regardless of error state", () => {
     expect(
       shouldShowEmptyState({ ...settledEmpty, listingsCount: 44 })
@@ -61,6 +78,7 @@ describe("shouldShowEmptyState", () => {
       ["map not initialized", { isMapInitialized: false }],
       ["tiles loading", { areTilesLoading: true }],
       ["search in flight", { isSearching: true }],
+      ["data fetch in flight", { isFetchingData: true }],
       ["caller suppression (info banner)", { suppressEmptyState: true }],
     ];
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -173,6 +173,14 @@ interface MarkerPosition {
   lng: number;
 }
 
+/** A rendered MapLibre cluster, surfaced for keyboard-accessible DOM markers. */
+interface ClusterPosition {
+  clusterId: number;
+  pointCount: number;
+  lat: number;
+  lng: number;
+}
+
 type PinDisplayMode = "dots" | "tiered" | "all";
 
 interface ClusterFeatureProperties {
@@ -253,6 +261,74 @@ function areMarkerListingSetsEqual(a: Listing[], b: Listing[]): boolean {
       listing.location.lng === next.location.lng
     );
   });
+}
+
+function areClusterSetsEqual(
+  a: ClusterPosition[],
+  b: ClusterPosition[]
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((cluster, index) => {
+    const next = b[index];
+    return (
+      cluster.clusterId === next.clusterId &&
+      cluster.pointCount === next.pointCount &&
+      cluster.lat === next.lat &&
+      cluster.lng === next.lng
+    );
+  });
+}
+
+/**
+ * Roving keyboard navigation: given a position-sorted list and the current
+ * index, return the index of the spatially-nearest item in the arrow-key
+ * direction (or the Home/End target), or null if there is none. Shared by the
+ * marker and cluster keyboard-navigation handlers so the nearest-neighbor
+ * logic lives in exactly one place.
+ */
+function findAdjacentByDirection(
+  positions: { lat: number; lng: number }[],
+  currentIndex: number,
+  key: string
+): number | null {
+  if (currentIndex < 0 || currentIndex >= positions.length) return null;
+  const current = positions[currentIndex];
+  const nearestWhere = (
+    predicate: (p: { lat: number; lng: number }) => boolean
+  ): number | null => {
+    let bestIndex = -1;
+    let bestDistance = Infinity;
+    for (let i = 0; i < positions.length; i++) {
+      if (i === currentIndex) continue;
+      const pos = positions[i];
+      if (!predicate(pos)) continue;
+      const distance = Math.sqrt(
+        Math.pow(pos.lat - current.lat, 2) +
+          Math.pow(pos.lng - current.lng, 2)
+      );
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = i;
+      }
+    }
+    return bestIndex === -1 ? null : bestIndex;
+  };
+  switch (key) {
+    case "ArrowUp":
+      return nearestWhere((p) => p.lat > current.lat);
+    case "ArrowDown":
+      return nearestWhere((p) => p.lat < current.lat);
+    case "ArrowLeft":
+      return nearestWhere((p) => p.lng < current.lng);
+    case "ArrowRight":
+      return nearestWhere((p) => p.lng > current.lng);
+    case "Home":
+      return 0;
+    case "End":
+      return positions.length - 1;
+    default:
+      return null;
+  }
 }
 
 /**
@@ -395,6 +471,14 @@ export interface MapComponentProps {
    * @default false
    */
   hasFetchError?: boolean;
+
+  /**
+   * A map-data fetch is currently in flight (the wrapper is showing its
+   * loading bar). Gates the empty state so an in-flight fetch never presents
+   * as "No listings in this area" mid-load.
+   * @default false
+   */
+  isFetchingData?: boolean;
 }
 
 
@@ -878,6 +962,13 @@ interface MapMarkerItemProps {
   isActive: boolean;
   isDimmed: boolean;
   isKeyboardFocused: boolean;
+  /**
+   * Whether this marker is the single tabbable member of the roving-tabindex
+   * group. Exactly one marker is tabbable at a time (the keyboard-focused one,
+   * or the first marker when none is focused) so Tab enters/exits the marker
+   * group as one stop and arrow keys move within it.
+   */
+  isTabbable: boolean;
   isViewed: boolean;
   onClickById: (id: string) => void;
   onPointerEnter: (e: React.PointerEvent<HTMLDivElement>) => void;
@@ -900,6 +991,7 @@ const MapMarkerItem = React.memo(function MapMarkerItem({
   isActive,
   isDimmed,
   isKeyboardFocused,
+  isTabbable,
   isViewed,
   onClickById,
   onPointerEnter,
@@ -989,7 +1081,7 @@ const MapMarkerItem = React.memo(function MapMarkerItem({
                 : "none"
         }
         role="button"
-        tabIndex={0}
+        tabIndex={isTabbable ? 0 : -1}
         aria-label={ariaLabel}
         aria-describedby="map-marker-instructions"
         onFocus={handleFocus}
@@ -1026,6 +1118,103 @@ const MapMarkerItem = React.memo(function MapMarkerItem({
           />
         )}
       </div>
+    </Marker>
+  );
+});
+
+interface ClusterMarkerItemProps {
+  clusterId: number;
+  pointCount: number;
+  lng: number;
+  lat: number;
+  /** Whether this cluster is the single tabbable member of the cluster roving group. */
+  isTabbable: boolean;
+  onExpand: (clusterId: number, center: [number, number]) => void;
+  onKeyboardNav: (
+    e: ReactKeyboardEvent<HTMLButtonElement>,
+    clusterId: number
+  ) => void;
+  onFocusChange: React.Dispatch<React.SetStateAction<number | null>>;
+  clusterRefsMap: React.RefObject<globalThis.Map<number, HTMLButtonElement>>;
+}
+
+/**
+ * ClusterMarkerItem — a keyboard-operable DOM button overlaying a GL cluster
+ * circle. The GL layers still draw the visible bubble + count; this transparent
+ * 44px button gives keyboard/AT users a focusable target that expands the
+ * cluster on Enter/Space (mirroring the mouse path) and participates in the
+ * cluster roving-tabindex group.
+ */
+const ClusterMarkerItem = React.memo(function ClusterMarkerItem({
+  clusterId,
+  pointCount,
+  lng,
+  lat,
+  isTabbable,
+  onExpand,
+  onKeyboardNav,
+  onFocusChange,
+  clusterRefsMap,
+}: ClusterMarkerItemProps) {
+  const refCallback = useCallback(
+    (el: HTMLButtonElement | null) => {
+      if (el) {
+        clusterRefsMap.current.set(clusterId, el);
+      } else {
+        clusterRefsMap.current.delete(clusterId);
+      }
+    },
+    [clusterId, clusterRefsMap]
+  );
+
+  const handleFocus = useCallback(() => {
+    onFocusChange(clusterId);
+  }, [clusterId, onFocusChange]);
+
+  const handleBlur = useCallback(() => {
+    onFocusChange((current) => (current === clusterId ? null : current));
+  }, [clusterId, onFocusChange]);
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        e.stopPropagation();
+        onExpand(clusterId, [lng, lat]);
+      } else if (
+        ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(
+          e.key
+        )
+      ) {
+        onKeyboardNav(e, clusterId);
+      }
+    },
+    [clusterId, lng, lat, onExpand, onKeyboardNav]
+  );
+
+  const handleClick = useCallback(
+    (e: { originalEvent: { stopPropagation: () => void } }) => {
+      e.originalEvent.stopPropagation();
+      onExpand(clusterId, [lng, lat]);
+    },
+    [clusterId, lng, lat, onExpand]
+  );
+
+  return (
+    <Marker longitude={lng} latitude={lat} anchor="center" onClick={handleClick}>
+      <button
+        ref={refCallback}
+        type="button"
+        data-cluster-id={clusterId}
+        data-testid={`map-cluster-${clusterId}`}
+        tabIndex={isTabbable ? 0 : -1}
+        aria-label={`Group of ${pointCount} listings. Press Enter to zoom in.`}
+        aria-describedby="map-cluster-instructions"
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        className="min-w-[44px] min-h-[44px] cursor-pointer rounded-full border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-[#9a4027] focus-visible:ring-offset-2"
+      />
     </Marker>
   );
 });
@@ -1094,6 +1283,7 @@ export default function MapComponent({
   selectionPresentation = "popup",
   suppressEmptyState = false,
   hasFetchError = false,
+  isFetchingData = false,
 }: MapComponentProps) {
   // --- Controlled vs Uncontrolled View State ---
   // When viewState prop is provided, map runs in controlled mode
@@ -1200,6 +1390,15 @@ export default function MapComponent({
     null
   );
   const markerRefs = useRef<globalThis.Map<string, HTMLDivElement>>(
+    new globalThis.Map()
+  );
+  // Keyboard-accessible cluster markers (their own roving-tabindex group,
+  // independent of the marker group above).
+  const [clusterPositions, setClusterPositions] = useState<ClusterPosition[]>(
+    []
+  );
+  const [clusterFocusedId, setClusterFocusedId] = useState<number | null>(null);
+  const clusterMarkerRefs = useRef<globalThis.Map<number, HTMLButtonElement>>(
     new globalThis.Map()
   );
   const {
@@ -1561,16 +1760,15 @@ export default function MapComponent({
   }, [listings]);
 
   // Handle cluster click to zoom in and expand
-  const onClusterClick = useCallback(
-    async (event: MapLayerMouseEvent) => {
-      const feature = event.features?.[0];
-      if (!feature || !mapRef.current) return;
-
+  // Core cluster-expansion logic, shared by the mouse path (onClusterClick) and
+  // the keyboard path (ClusterMarkerItem Enter/Space). Zooms to the cluster's
+  // expansion zoom and flags the move programmatic so the follow-up auto-search
+  // is suppressed.
+  const expandCluster = useCallback(
+    async (clusterId: number, center: [number, number]) => {
+      if (!mapRef.current) return;
       // Guard: skip if already expanding a cluster to prevent multiple simultaneous flyTo calls
       if (isClusterExpandingRef.current) return;
-
-      const clusterId = feature.properties?.cluster_id;
-      if (!clusterId) return;
 
       const mapboxSource = mapRef.current.getSource("listings") as
         | GeoJSONSource
@@ -1579,7 +1777,6 @@ export default function MapComponent({
 
       try {
         const zoom = await mapboxSource.getClusterExpansionZoom(clusterId);
-        if (!feature.geometry || feature.geometry.type !== "Point") return;
         // P0 Issue #25: Guard against stale callback after unmount
         if (!isMountedRef.current) return;
 
@@ -1601,7 +1798,7 @@ export default function MapComponent({
           }
         }, PROGRAMMATIC_MOVE_TIMEOUT_MS);
         mapRef.current?.flyTo({
-          center: feature.geometry.coordinates as [number, number],
+          center,
           zoom: zoom,
           duration: 700,
           padding: { top: 50, bottom: 50, left: 50, right: 50 },
@@ -1613,6 +1810,21 @@ export default function MapComponent({
       }
     },
     [setProgrammaticMove, isProgrammaticMoveRef]
+  );
+
+  const onClusterClick = useCallback(
+    (event: MapLayerMouseEvent) => {
+      const feature = event.features?.[0];
+      if (!feature) return;
+      const clusterId = feature.properties?.cluster_id;
+      if (clusterId == null) return;
+      if (!feature.geometry || feature.geometry.type !== "Point") return;
+      void expandCluster(
+        clusterId,
+        feature.geometry.coordinates as [number, number]
+      );
+    },
+    [expandCluster]
   );
 
   // Update unclustered listings when map moves (for rendering individual markers)
@@ -1704,6 +1916,36 @@ export default function MapComponent({
     setUnclusteredListings((current) =>
       areMarkerListingSetsEqual(current, unique) ? current : unique
     );
+
+    // Surface rendered clusters so keyboard users get focusable DOM cluster
+    // markers (the GL layers stay the visible bubble). Rides this same
+    // sourcedata/onIdle-driven refresh — no separate lifecycle wiring.
+    const clusterFeatures = map.querySourceFeatures("listings", {
+      filter: ["has", "point_count"],
+    });
+    const nextClusters: ClusterPosition[] = [];
+    const seenClusters = new Set<number>();
+    for (const f of clusterFeatures) {
+      const props = (f.properties ?? {}) as {
+        cluster_id?: number;
+        point_count?: number;
+      };
+      const clusterId = props.cluster_id;
+      if (clusterId == null || seenClusters.has(clusterId)) continue;
+      if (!f.geometry || f.geometry.type !== "Point") continue;
+      const [lng, lat] = f.geometry.coordinates as [number, number];
+      seenClusters.add(clusterId);
+      nextClusters.push({
+        clusterId,
+        pointCount: Number(props.point_count) || 0,
+        lat,
+        lng,
+      });
+    }
+    setClusterPositions((current) =>
+      areClusterSetsEqual(current, nextClusters) ? current : nextClusters
+    );
+
     return unique.length;
   }, [imagesByListingId, listings.length, useClustering]);
 
@@ -1896,6 +2138,68 @@ export default function MapComponent({
     });
   }, [markerPositions]);
 
+  // Roving tabindex: the single marker that is tabbable when no marker is
+  // keyboard-focused, so Tab can still enter the marker group as one stop.
+  // Defaults to the first sorted marker (northwesternmost).
+  const defaultTabbableMarkerId = sortedMarkerPositions[0]?.listing.id ?? null;
+
+  // Cluster roving group (mirrors the marker group: same sort, same default
+  // tabbable rule). Kept separate from the marker nav state machine per design.
+  const sortedClusterPositions = useMemo(() => {
+    return [...clusterPositions].sort((a, b) => {
+      const latDiff = b.lat - a.lat;
+      if (Math.abs(latDiff) > 0.001) return latDiff; // ~100m threshold for "same row"
+      return a.lng - b.lng;
+    });
+  }, [clusterPositions]);
+  const defaultTabbableClusterId =
+    sortedClusterPositions[0]?.clusterId ?? null;
+
+  // Drop cluster focus when the focused cluster is no longer rendered (e.g. it
+  // split into markers after a zoom), mirroring the marker-focus cleanup.
+  useEffect(() => {
+    if (
+      clusterFocusedId != null &&
+      !clusterPositions.some((c) => c.clusterId === clusterFocusedId)
+    ) {
+      setClusterFocusedId(null);
+    }
+  }, [clusterFocusedId, clusterPositions]);
+
+  const handleClusterKeyboardNavigation = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>, currentClusterId: number) => {
+      const currentIndex = sortedClusterPositions.findIndex(
+        (c) => c.clusterId === currentClusterId
+      );
+      if (currentIndex === -1) return;
+
+      const nextIndex = findAdjacentByDirection(
+        sortedClusterPositions,
+        currentIndex,
+        e.key
+      );
+      if (nextIndex === null || nextIndex === currentIndex) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      const next = sortedClusterPositions[nextIndex];
+      setClusterFocusedId(next.clusterId);
+
+      const el = clusterMarkerRefs.current.get(next.clusterId);
+      if (el) {
+        el.focus();
+      }
+
+      if (mapRef.current) {
+        mapRef.current.easeTo({
+          center: [next.lng, next.lat],
+          duration: 300,
+        });
+      }
+    },
+    [sortedClusterPositions]
+  );
+
   // Find marker index in sorted list
   const findMarkerIndex = useCallback(
     (id: string | null): number => {
@@ -1905,140 +2209,40 @@ export default function MapComponent({
     [sortedMarkerPositions]
   );
 
-  // Keyboard navigation handler for arrow keys
+  // Keyboard navigation handler for arrow keys (shares findAdjacentByDirection
+  // with the cluster group so the nearest-neighbor logic lives in one place).
   const handleMarkerKeyboardNavigation = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>, currentListingId: string) => {
       const currentIndex = findMarkerIndex(currentListingId);
       if (currentIndex === -1 || sortedMarkerPositions.length === 0) return;
 
-      let nextIndex: number | null = null;
-      const currentPos = sortedMarkerPositions[currentIndex];
+      const nextIndex = findAdjacentByDirection(
+        sortedMarkerPositions,
+        currentIndex,
+        e.key
+      );
+      if (nextIndex === null || nextIndex === currentIndex) return;
 
-      switch (e.key) {
-        case "ArrowUp": {
-          // Find the nearest marker above (higher latitude)
-          let bestIndex = -1;
-          let bestDistance = Infinity;
-          for (let i = 0; i < sortedMarkerPositions.length; i++) {
-            if (i === currentIndex) continue;
-            const pos = sortedMarkerPositions[i];
-            if (pos.lat > currentPos.lat) {
-              const distance = Math.sqrt(
-                Math.pow(pos.lat - currentPos.lat, 2) +
-                  Math.pow(pos.lng - currentPos.lng, 2)
-              );
-              if (distance < bestDistance) {
-                bestDistance = distance;
-                bestIndex = i;
-              }
-            }
-          }
-          if (bestIndex !== -1) nextIndex = bestIndex;
-          break;
-        }
-        case "ArrowDown": {
-          // Find the nearest marker below (lower latitude)
-          let bestIndex = -1;
-          let bestDistance = Infinity;
-          for (let i = 0; i < sortedMarkerPositions.length; i++) {
-            if (i === currentIndex) continue;
-            const pos = sortedMarkerPositions[i];
-            if (pos.lat < currentPos.lat) {
-              const distance = Math.sqrt(
-                Math.pow(pos.lat - currentPos.lat, 2) +
-                  Math.pow(pos.lng - currentPos.lng, 2)
-              );
-              if (distance < bestDistance) {
-                bestDistance = distance;
-                bestIndex = i;
-              }
-            }
-          }
-          if (bestIndex !== -1) nextIndex = bestIndex;
-          break;
-        }
-        case "ArrowLeft": {
-          // Find the nearest marker to the left (lower longitude)
-          let bestIndex = -1;
-          let bestDistance = Infinity;
-          for (let i = 0; i < sortedMarkerPositions.length; i++) {
-            if (i === currentIndex) continue;
-            const pos = sortedMarkerPositions[i];
-            if (pos.lng < currentPos.lng) {
-              const distance = Math.sqrt(
-                Math.pow(pos.lat - currentPos.lat, 2) +
-                  Math.pow(pos.lng - currentPos.lng, 2)
-              );
-              if (distance < bestDistance) {
-                bestDistance = distance;
-                bestIndex = i;
-              }
-            }
-          }
-          if (bestIndex !== -1) nextIndex = bestIndex;
-          break;
-        }
-        case "ArrowRight": {
-          // Find the nearest marker to the right (higher longitude)
-          let bestIndex = -1;
-          let bestDistance = Infinity;
-          for (let i = 0; i < sortedMarkerPositions.length; i++) {
-            if (i === currentIndex) continue;
-            const pos = sortedMarkerPositions[i];
-            if (pos.lng > currentPos.lng) {
-              const distance = Math.sqrt(
-                Math.pow(pos.lat - currentPos.lat, 2) +
-                  Math.pow(pos.lng - currentPos.lng, 2)
-              );
-              if (distance < bestDistance) {
-                bestDistance = distance;
-                bestIndex = i;
-              }
-            }
-          }
-          if (bestIndex !== -1) nextIndex = bestIndex;
-          break;
-        }
-        case "Home": {
-          // Jump to first marker
-          if (sortedMarkerPositions.length > 0) {
-            nextIndex = 0;
-          }
-          break;
-        }
-        case "End": {
-          // Jump to last marker
-          if (sortedMarkerPositions.length > 0) {
-            nextIndex = sortedMarkerPositions.length - 1;
-          }
-          break;
-        }
-        default:
-          return; // Don't prevent default for other keys
+      e.preventDefault();
+      e.stopPropagation();
+      const nextMarker = sortedMarkerPositions[nextIndex];
+      const nextId = nextMarker.listing.id;
+
+      // Update keyboard focus state
+      setKeyboardFocusedId(nextId);
+
+      // Focus the marker element
+      const markerEl = markerRefs.current.get(nextId);
+      if (markerEl) {
+        markerEl.focus();
       }
 
-      if (nextIndex !== null && nextIndex !== currentIndex) {
-        e.preventDefault();
-        e.stopPropagation();
-        const nextMarker = sortedMarkerPositions[nextIndex];
-        const nextId = nextMarker.listing.id;
-
-        // Update keyboard focus state
-        setKeyboardFocusedId(nextId);
-
-        // Focus the marker element
-        const markerEl = markerRefs.current.get(nextId);
-        if (markerEl) {
-          markerEl.focus();
-        }
-
-        // Pan map to show the focused marker
-        if (mapRef.current) {
-          mapRef.current.easeTo({
-            center: [nextMarker.lng, nextMarker.lat],
-            duration: 300,
-          });
-        }
+      // Pan map to show the focused marker
+      if (mapRef.current) {
+        mapRef.current.easeTo({
+          center: [nextMarker.lng, nextMarker.lat],
+          duration: 300,
+        });
       }
     },
     [findMarkerIndex, sortedMarkerPositions]
@@ -3475,6 +3679,7 @@ export default function MapComponent({
     isSearching,
     suppressEmptyState,
     hasFetchError,
+    isFetchingData,
     listingsCount: listings.length,
   });
   const mobileMapStatus = useMemo<MobileMapStatus | null>(() => {
@@ -3945,6 +4150,30 @@ export default function MapComponent({
           })()}
       </div>
 
+      {/* Screen reader instructions for cluster keyboard navigation */}
+      <div id="map-cluster-instructions" className="sr-only">
+        Use arrow keys to move between listing groups based on their position on
+        the map. Press Enter or Space to zoom into a group.
+      </div>
+
+      {/* Screen reader announcement for cluster keyboard navigation */}
+      <div
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {clusterFocusedId != null &&
+          (() => {
+            const index = sortedClusterPositions.findIndex(
+              (c) => c.clusterId === clusterFocusedId
+            );
+            if (index === -1) return "";
+            const cluster = sortedClusterPositions[index];
+            return `Listing group ${index + 1} of ${sortedClusterPositions.length}: ${cluster.pointCount} listings. Press Enter to zoom in.`;
+          })()}
+      </div>
+
       <Map
         key={mapRemountKey}
         ref={mapRef}
@@ -4215,9 +4444,13 @@ export default function MapComponent({
           // P2-FIX (#110): Check if click originated from a marker element.
           // stopPropagation on Marker's onClick stops DOM bubbling, but
           // mapbox-gl still detects the click via canvas hit-testing.
-          // Skip cluster handling if click was on a marker to prevent both firing.
+          // Skip cluster handling if click was on a marker (or on a DOM cluster
+          // button, which handles its own expansion) to prevent both firing.
           const target = e.originalEvent?.target as HTMLElement | undefined;
-          if (target?.closest("[data-listing-id]")) {
+          if (
+            target?.closest("[data-listing-id]") ||
+            target?.closest("[data-cluster-id]")
+          ) {
             return;
           }
           if (
@@ -4363,6 +4596,11 @@ export default function MapComponent({
                     ? position.memberIds.includes(keyboardFocusedId)
                     : false
                 }
+                isTabbable={
+                  keyboardFocusedId
+                    ? position.memberIds.includes(keyboardFocusedId)
+                    : position.listing.id === defaultTabbableMarkerId
+                }
                 isViewed={viewedIds.has(position.listing.id)}
                 onClickById={handleMarkerClickById}
                 onPointerEnter={handleMarkerPointerEnter}
@@ -4384,6 +4622,28 @@ export default function MapComponent({
           markerPositionIds={markerPositionIds}
           listings={listings}
         />
+
+        {/* Keyboard-accessible cluster markers: transparent DOM buttons over
+            the GL cluster circles. Their own roving-tabindex group; Enter/Space
+            expands via the same logic as a mouse click. */}
+        {sortedClusterPositions.map((cluster) => (
+          <ClusterMarkerItem
+            key={cluster.clusterId}
+            clusterId={cluster.clusterId}
+            pointCount={cluster.pointCount}
+            lng={cluster.lng}
+            lat={cluster.lat}
+            isTabbable={
+              clusterFocusedId != null
+                ? cluster.clusterId === clusterFocusedId
+                : cluster.clusterId === defaultTabbableClusterId
+            }
+            onExpand={expandCluster}
+            onKeyboardNav={handleClusterKeyboardNavigation}
+            onFocusChange={setClusterFocusedId}
+            clusterRefsMap={clusterMarkerRefs}
+          />
+        ))}
 
         {usesPopupSelection && selectedListing && (
           <Popup

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -1258,6 +1258,9 @@ export default function PersistentMapWrapper({
             listings={stableEffectiveListings}
             suppressEmptyState={Boolean(infoMessage)}
             hasFetchError={Boolean(error)}
+            isFetchingData={
+              isFetchingMapData || isListTransitioning || showV2LoadingOverlay
+            }
             selectionPresentation={isDesktop === false ? "preview" : "popup"}
           />
         </Suspense>

--- a/src/components/neighborhood/NeighborhoodMap.tsx
+++ b/src/components/neighborhood/NeighborhoodMap.tsx
@@ -408,20 +408,28 @@ export function NeighborhoodMap({
     }
   }, [onPoiHover]);
 
-  // Fly to selected POI
+  // Fly to selected POI.
+  // Read the live zoom via mapRef inside the effect rather than depending on
+  // viewState.zoom: onMove writes viewState every frame, so depending on it
+  // would re-fire this effect on every user zoom while a POI is selected and
+  // snap the camera back to the POI. Now it fires only when the selection
+  // (selectedPlaceId / poiLookup) changes.
   useEffect(() => {
     if (selectedPlaceId && mapRef.current) {
       const poi = poiLookup.get(selectedPlaceId);
       if (poi) {
+        const currentZoom = mapRef.current.getZoom?.() ?? viewState.zoom;
         mapRef.current.flyTo({
           center: [poi.lng, poi.lat],
-          zoom: Math.max(viewState.zoom, 15),
+          zoom: Math.max(currentZoom, 15),
           duration: 300,
         });
         setPopupPoi(poi);
       }
     }
-  }, [selectedPlaceId, poiLookup, viewState.zoom]);
+    // viewState.zoom intentionally omitted — read live via getZoom() above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPlaceId, poiLookup]);
 
   // Close popup when selection changes
   useEffect(() => {

--- a/src/lib/maps/map-view-state.ts
+++ b/src/lib/maps/map-view-state.ts
@@ -2,10 +2,10 @@
  * Pure view-state predicates for the search map.
  *
  * Extracted from Map.tsx so the "should the empty state show?" decision is
- * unit-testable. The critical invariant: a failed/timed-out map-data fetch
- * must NEVER present as "No listings in this area" — an error banner with
- * retry is the wrapper's job; claiming emptiness would be lying about
- * inventory the list pane may well be showing.
+ * unit-testable. The critical invariant: a failed/timed-out OR still-in-flight
+ * map-data fetch must NEVER present as "No listings in this area" — an error
+ * banner (failure) or loading bar (in flight) is the wrapper's job; claiming
+ * emptiness would be lying about inventory the list pane may well be showing.
  */
 
 export interface EmptyStateInput {
@@ -21,13 +21,16 @@ export interface EmptyStateInput {
   suppressEmptyState: boolean;
   /** The last map-data fetch failed or timed out (error banner is showing) */
   hasFetchError: boolean;
+  /** A map-data fetch is currently in flight (loading bar is showing) */
+  isFetchingData: boolean;
   /** Listings currently rendered on the map */
   listingsCount: number;
 }
 
 /**
  * True only when the viewport is CONFIRMED empty: map settled, no search in
- * flight, no suppression, and — crucially — the last fetch succeeded.
+ * flight, no suppression, and — crucially — the last fetch succeeded AND no
+ * fetch is currently in flight.
  */
 export function shouldShowEmptyState(input: EmptyStateInput): boolean {
   return (
@@ -37,6 +40,7 @@ export function shouldShowEmptyState(input: EmptyStateInput): boolean {
     !input.isSearching &&
     !input.suppressEmptyState &&
     !input.hasFetchError &&
+    !input.isFetchingData &&
     input.listingsCount === 0
   );
 }

--- a/tests/e2e/map-markers.anon.spec.ts
+++ b/tests/e2e/map-markers.anon.spec.ts
@@ -685,9 +685,12 @@ test.describe("Map Marker Interactions", () => {
       const markerInner = marker.locator('[role="button"]');
       await expect(markerInner).toBeVisible();
 
-      // Check tabIndex for keyboard accessibility
+      // Check tabIndex for keyboard accessibility.
+      // Roving tabindex: every marker is keyboard-focusable; exactly one is
+      // "0" (the tabbable group entry) and the rest are "-1" (reachable via
+      // arrow keys / programmatic focus). The first DOM marker may be either.
       const tabIndex = await markerInner.getAttribute("tabindex");
-      expect(tabIndex).toBe("0");
+      expect(["0", "-1"]).toContain(tabIndex);
 
       // Check aria-label contains price and navigation hint
       // Format: "$1200 per month, Title, N spots available. Use arrow keys to navigate between markers."
@@ -940,15 +943,21 @@ test.describe("Map Marker Interactions", () => {
       const markerCount = await waitForMarkersWithClusterExpansion(page);
       test.skip(markerCount === 0, "No markers available");
 
-      // All marker inner elements should have tabindex="0"
+      // Roving tabindex: every marker is keyboard-focusable, but exactly ONE
+      // is the tabbable group entry (tabindex="0") and the rest are "-1", so
+      // Tab enters/exits the marker group as a single stop and arrow keys move
+      // within it.
       const markerButtons = page.locator('.maplibregl-marker [role="button"]');
       const count = await markerButtons.count();
 
       if (count > 0) {
-        for (let i = 0; i < Math.min(count, 5); i++) {
-          const tabIndex = await markerButtons.nth(i).getAttribute("tabindex");
-          expect(tabIndex).toBe("0");
-        }
+        const tabIndexes = await markerButtons.evaluateAll((els) =>
+          els.map((el) => el.getAttribute("tabindex"))
+        );
+        // Every marker is focusable (0 or -1), none missing/other.
+        expect(tabIndexes.every((t) => t === "0" || t === "-1")).toBe(true);
+        // Exactly one tabbable entry point into the group.
+        expect(tabIndexes.filter((t) => t === "0")).toHaveLength(1);
       }
     });
 


### PR DESCRIPTION
Resolves four defects surfaced by the full map-subsystem audit — the two **high** items (map keyboard accessibility) plus two correctness/UX fixes.

## Fixes

**1. Roving tabindex for search-map markers (high, WCAG 2.4.3)**
Every marker hard-coded `tabIndex={0}`, making each one a tab stop. Now exactly one marker is tabbable (the keyboard-focused one, else the northernmost), so Tab enters the marker group as a single stop and arrow keys move within it.

**2. Keyboard-operable clusters (high, WCAG 2.1.1)**
Cluster bubbles were GL paint layers, reachable only by mouse — so clustered listings were unreachable by keyboard. Added transparent focusable `<button>`s overlaying the GL circles as their own roving-tabindex group; Enter/Space zooms in via the same `expandCluster()` path as a click. Cluster positions are surfaced from `querySourceFeatures` on the existing `sourcedata`/`onIdle` refresh (no new lifecycle).

**3. NeighborhoodMap zoom-snap**
The "fly to selected POI" effect depended on `viewState.zoom` (updated every frame by `onMove`), so the camera snapped back to the POI on every user zoom. Now reads live zoom via `getZoom()`; fires only when the selection changes.

**4. In-flight empty-state flash**
`PersistentMapWrapper` never passed its `isFetchingMapData` state down, so "No listings in this area" could flash mid-fetch. Threaded `isFetchingData` into the `shouldShowEmptyState` gate (which already honored `hasFetchError`).

## Refactor
Extracted the shared `findAdjacentByDirection` nearest-neighbor helper and reused it for both marker and cluster keyboard nav, removing ~130 lines of duplicated arrow-key loops the audit flagged.

## Tests
- `map-view-state`: in-flight gate suppresses + re-shows on settle
- `Map.test`: roving-tabindex invariant, ArrowDown movement, cluster Enter-to-expand
- `PersistentMapWrapper`: `isFetchingData` true in flight / false on resolve (also enriched the prop-discarding mock the audit flagged)
- `NeighborhoodMap`: flies once reading live zoom, no re-fly on zoom change
- Updated 2 `touch-gestures` assertions that encoded the old per-marker `tabIndex=0`

## Verification
- `pnpm typecheck` clean · `pnpm lint` 0 errors · **894** map/search tests pass
- **Live (prod build + Playwright):** roving tabindex confirmed (1 tabbable of 10), cluster buttons render with correct aria-labels and roving group, and **Enter on a focused cluster expands it** (4-listing cluster → 2 markers + sub-cluster) — i.e. the previously keyboard-unreachable all-clustered state now works.

## Risk / scope
No DB, schema, auth, or PII surface touched; no new dependencies. Largest change is additive in `Map.tsx` (GL cluster layers + `onClusterClick` retained; double-expansion guarded by `isClusterExpandingRef`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)