### PR TITLE
fix(map): a11y quick wins — popup dialog, live-region empty state, 44px close button, gesture hint

### DIFF
--- a/src/__tests__/components/map/DesktopListingPreviewCard.test.tsx
+++ b/src/__tests__/components/map/DesktopListingPreviewCard.test.tsx
@@ -57,4 +57,35 @@ describe("DesktopListingPreviewCard", () => {
       "/listings/listing-1?startDate=2026-05-01&endDate=2026-06-01"
     );
   });
+
+  it("exposes dialog semantics with an accessible name from the title", () => {
+    render(
+      <DesktopListingPreviewCard
+        listing={{
+          id: "listing-1",
+          title: "Sunny Loft",
+          price: 1800,
+          availableSlots: 1,
+          location: { city: "San Francisco", state: "CA" },
+        }}
+        href="/listings/listing-1"
+        isDarkMode={false}
+        onClose={jest.fn()}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Sunny Loft");
+
+    // Accessible name is wired via aria-labelledby -> the heading id.
+    const heading = screen.getByRole("heading", { name: "Sunny Loft" });
+    expect(heading.id).toBe("map-popup-title-listing-1");
+    expect(dialog).toHaveAttribute("aria-labelledby", heading.id);
+
+    // Close control stays reachable for the focus trap.
+    expect(
+      screen.getByRole("button", { name: "Close listing preview" })
+    ).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/map/MapEmptyState.test.tsx
+++ b/src/__tests__/components/map/MapEmptyState.test.tsx
@@ -56,6 +56,13 @@ describe("MapEmptyState", () => {
     expect(onZoomOut).toHaveBeenCalledTimes(1);
   });
 
+  it("is a polite live region so it announces on appearance (parity with the mobile twin)", () => {
+    render(<MapEmptyState {...defaultProps} />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent("No listings in this area");
+  });
+
   // --- Task 1.2: Filter chips and clear-filters ---
 
   it("shows active filter chips when URL has filters", () => {

--- a/src/__tests__/components/map/MapGestureHint.test.tsx
+++ b/src/__tests__/components/map/MapGestureHint.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { MapGestureHint } from "@/components/map/MapGestureHint";
+
+const STORAGE_KEY = "roomshare-map-hints-seen";
+
+// jsdom has no Touch Events support; the hint only shows when `"ontouchstart" in window`.
+const touchWindow = window as Window & { ontouchstart?: unknown };
+
+describe("MapGestureHint", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    touchWindow.ontouchstart = null; // simulate a touch device
+  });
+
+  afterEach(() => {
+    delete touchWindow.ontouchstart;
+    sessionStorage.clear();
+  });
+
+  it("is hidden from assistive tech and is not a live region", () => {
+    const { container } = render(<MapGestureHint />);
+
+    // Still rendered visually for sighted touch users...
+    expect(screen.getByText("Pinch to zoom")).toBeInTheDocument();
+
+    // ...but the transient visual nudge must not announce via a live region.
+    const hint = container.querySelector('[aria-hidden="true"]');
+    expect(hint).toBeInTheDocument();
+    expect(hint).toHaveTextContent("Pinch to zoom");
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector("[aria-live]")).toBeNull();
+  });
+
+  it("renders nothing when already dismissed this session", () => {
+    sessionStorage.setItem(STORAGE_KEY, "1");
+    const { container } = render(<MapGestureHint />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing on non-touch devices", () => {
+    delete touchWindow.ontouchstart;
+    const { container } = render(<MapGestureHint />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -58,6 +58,7 @@ import { BoundaryLayer } from "./map/BoundaryLayer";
 import { UserMarker, useUserPin } from "./map/UserMarker";
 import DesktopMapControls from "./map/DesktopMapControls";
 import DesktopListingPreviewCard from "./map/DesktopListingPreviewCard";
+import { FocusTrap } from "./ui/FocusTrap";
 import HostIdentityBadge from "./HostIdentityBadge";
 import MobileMapToolsSheet from "./map/MobileMapToolsSheet";
 import { POILayer, usePOILayerState } from "./map/POILayer";
@@ -4661,15 +4662,23 @@ export default function MapComponent({
             subpixelPositioning
             className="z-[60] [&_.maplibregl-popup-content]:rounded-xl [&_.maplibregl-popup-content]:p-0 [&_.maplibregl-popup-content]:!bg-transparent [&_.maplibregl-popup-content]:!shadow-none [&_.maplibregl-popup-close-button]:hidden [&_.maplibregl-popup-tip]:hidden"
           >
-            <DesktopListingPreviewCard
-              key={selectedListing.id}
-              listing={selectedListing}
-              href={selectedListingHref ?? `/listings/${selectedListing.id}`}
-              isDarkMode={isDarkMode}
-              onClose={() => handleSelectedListingClose(true)}
-              cardRef={selectedPopupCardRef}
-              closeButtonRef={selectedPopupCloseButtonRef}
-            />
+            {/* Tab-containment only: close-time focus restoration stays owned by
+                restoreDesktopPopupOriginFocus (marker/list-aware), so returnFocus={false}. */}
+            <FocusTrap
+              active
+              initialFocusRef={selectedPopupCloseButtonRef}
+              returnFocus={false}
+            >
+              <DesktopListingPreviewCard
+                key={selectedListing.id}
+                listing={selectedListing}
+                href={selectedListingHref ?? `/listings/${selectedListing.id}`}
+                isDarkMode={isDarkMode}
+                onClose={() => handleSelectedListingClose(true)}
+                cardRef={selectedPopupCardRef}
+                closeButtonRef={selectedPopupCloseButtonRef}
+              />
+            </FocusTrap>
           </Popup>
         )}
 
@@ -4718,7 +4727,7 @@ export default function MapComponent({
                 <button
                   type="button"
                   onClick={() => handleSelectedListingClose(true)}
-                  className="absolute top-3 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-on-surface/55 text-white backdrop-blur-sm transition-colors hover:bg-on-surface/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                  className="absolute top-3 right-3 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-on-surface/55 text-white backdrop-blur-sm transition-colors hover:bg-on-surface/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
                   aria-label="Close listing preview"
                 >
                   <X className="w-4 h-4" />

--- a/src/components/map/DesktopListingPreviewCard.tsx
+++ b/src/components/map/DesktopListingPreviewCard.tsx
@@ -90,11 +90,15 @@ export default function DesktopListingPreviewCard({
   });
   const hasRating =
     Number.isFinite(listing.avgRating) && (listing.reviewCount ?? 0) > 0;
+  const titleId = `map-popup-title-${listing.id}`;
 
   return (
     <div
       key={listing.id}
       ref={cardRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
       data-testid="map-popup-card"
       className={`w-[320px] overflow-hidden rounded-[1.25rem] border animate-in fade-in slide-in-from-bottom-2 duration-200 ${
         isDarkMode
@@ -166,6 +170,7 @@ export default function DesktopListingPreviewCard({
           ) : null}
 
           <h3
+            id={titleId}
             className={`line-clamp-2 text-[15px] font-semibold leading-tight ${
               isDarkMode ? "text-white" : "text-on-surface"
             }`}

--- a/src/components/map/MapEmptyState.tsx
+++ b/src/components/map/MapEmptyState.tsx
@@ -112,7 +112,11 @@ export function MapEmptyState({ onZoomOut, searchParams }: MapEmptyStateProps) {
   };
 
   return (
-    <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 bg-surface-container-lowest rounded-xl shadow-ambient border border-outline-variant/20 px-5 py-4 max-w-[320px] text-center pointer-events-auto">
+    <div
+      role="status"
+      aria-live="polite"
+      className="absolute bottom-20 left-1/2 -translate-x-1/2 z-10 bg-surface-container-lowest rounded-xl shadow-ambient border border-outline-variant/20 px-5 py-4 max-w-[320px] text-center pointer-events-auto"
+    >
       <MapPin
         className="w-8 h-8 text-on-surface-variant mx-auto mb-2"
         aria-hidden="true"

--- a/src/components/map/MapGestureHint.tsx
+++ b/src/components/map/MapGestureHint.tsx
@@ -35,8 +35,7 @@ export function MapGestureHint() {
   return (
     <div
       className="absolute bottom-20 left-1/2 -translate-x-1/2 z-[50] bg-on-surface/90 backdrop-blur-md text-white rounded-2xl px-4 py-3 shadow-ambient-lg max-w-[260px] text-center animate-[fadeIn_300ms_ease-out] border border-white/10"
-      role="status"
-      aria-live="polite"
+      aria-hidden="true"
     >
       <button
         onClick={dismiss}

--- a/tests/e2e/map-popup-a11y.anon.spec.ts
+++ b/tests/e2e/map-popup-a11y.anon.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Map popup accessibility (Batch 1 a11y quick wins).
+ *
+ * - Desktop selection popup: dialog semantics + Tab focus containment so Tab no
+ *   longer escapes into the keyboard-tabbable markers behind it (audit medium #2).
+ * - Mobile preview card: close button meets the 44px touch-target standard (low).
+ *
+ * Map tests gracefully skip when WebGL markers are unavailable (headless CI).
+ */
+import { test, expect, tags, timeouts, SF_BOUNDS } from "./helpers/test-utils";
+import { waitForMapReady } from "./helpers";
+import { prepareUnclusteredMarkerViewport } from "./helpers/sync-helpers";
+import type { Page } from "@playwright/test";
+
+const boundsQS = `minLat=${SF_BOUNDS.minLat}&maxLat=${SF_BOUNDS.maxLat}&minLng=${SF_BOUNDS.minLng}&maxLng=${SF_BOUNDS.maxLng}`;
+const SEARCH_URL = `/search?${boundsQS}`;
+
+/**
+ * Open the first individual listing marker. Returns false when no markers are
+ * available (headless WebGL) so the caller can skip rather than fail.
+ */
+async function openFirstMarker(page: Page): Promise<boolean> {
+  await page.goto(SEARCH_URL);
+  await page.waitForLoadState("domcontentloaded");
+  await waitForMapReady(page);
+
+  const prepared = await prepareUnclusteredMarkerViewport(page);
+  if (!prepared) return false;
+
+  const markers = page.locator(".maplibregl-marker:visible");
+  if ((await markers.count()) === 0) return false;
+
+  // Click the .maplibregl-marker wrapper (react-map-gl's native handler).
+  await markers.first().evaluate((el) => (el as HTMLElement).click());
+  return true;
+}
+
+test.describe("Map popup accessibility — desktop dialog + focus trap", () => {
+  test.use({
+    storageState: { cookies: [], origins: [] },
+    viewport: { width: 1280, height: 800 },
+  });
+
+  test.beforeEach(async ({}, testInfo) => {
+    test.slow(); // WebGL rendering needs extra time in CI
+    test.skip(
+      testInfo.project.name.includes("Mobile"),
+      "Desktop popup requires a desktop viewport"
+    );
+    test.skip(
+      testInfo.project.name === "webkit",
+      "Map tests have timing issues on webkit"
+    );
+  });
+
+  test(`${tags.anon} ${tags.a11y} selection popup is a labelled dialog that contains Tab`, async ({
+    page,
+  }) => {
+    test.skip(!(await openFirstMarker(page)), "No map markers available (WebGL)");
+
+    const card = page.locator('[data-testid="map-popup-card"]');
+    await expect(card).toBeVisible({ timeout: timeouts.action });
+
+    // Dialog semantics with an accessible name sourced from the title heading.
+    await expect(card).toHaveAttribute("role", "dialog");
+    await expect(card).toHaveAttribute("aria-modal", "true");
+    const labelledBy = await card.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    const heading = page.locator(`[id="${labelledBy}"]`);
+    const headingText = ((await heading.textContent()) ?? "").trim();
+    expect(headingText.length).toBeGreaterThan(0);
+    await expect(card).toHaveAccessibleName(headingText);
+
+    // Focus containment: Tabbing cycles within the card and never lands on a
+    // marker behind the popup (the regression this fix targets).
+    const closeBtn = card.locator('button[aria-label="Close listing preview"]');
+    await closeBtn.focus();
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press("Tab");
+      const onMarker = await page.evaluate(
+        () => !!document.activeElement?.closest(".maplibregl-marker")
+      );
+      expect(onMarker).toBe(false);
+      const withinCard = await card.evaluate((el) =>
+        el.contains(document.activeElement)
+      );
+      expect(withinCard).toBe(true);
+    }
+
+    // Escape closes the popup and returns focus to the originating marker.
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".maplibregl-popup")).not.toBeVisible({
+      timeout: 2000,
+    });
+    const focusBackOnMarker = await page.evaluate(
+      () => !!document.activeElement?.closest(".maplibregl-marker")
+    );
+    expect(focusBackOnMarker).toBe(true);
+  });
+});
+
+test.describe("Map preview accessibility — mobile close-button touch target", () => {
+  test.use({
+    storageState: { cookies: [], origins: [] },
+    viewport: { width: 390, height: 844 },
+  });
+
+  test.beforeEach(async ({}, testInfo) => {
+    test.slow();
+    test.skip(
+      testInfo.project.name === "webkit",
+      "Map tests have timing issues on webkit"
+    );
+  });
+
+  test(`${tags.anon} ${tags.a11y} mobile preview close button meets the 44px touch target`, async ({
+    page,
+  }) => {
+    test.skip(!(await openFirstMarker(page)), "No map markers available (WebGL)");
+
+    const previewCard = page.locator('[data-testid="map-preview-card"]');
+    await expect(previewCard).toBeVisible({ timeout: timeouts.action });
+
+    const closeBtn = previewCard.locator(
+      'button[aria-label="Close listing preview"]'
+    );
+    const box = await closeBtn.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(44);
+    expect(box!.height).toBeGreaterThanOrEqual(44);
+  });
+});


### PR DESCRIPTION
## What & why

**Batch 1** of the remaining map-subsystem audit (`docs/map-audit-remaining.md`) — the "a11y quick wins" group. Four accessibility gaps in the map's selection/empty/hint overlays. Each finding was re-verified against current code (the audit's line numbers were stale post-#159) before fixing.

## Changes

| # | Finding | Fix |
|---|---------|-----|
| **medium #2** | Desktop selection popup lacked dialog semantics + focus containment — Tab escaped into the keyboard-tabbable markers behind it | `DesktopListingPreviewCard` root is now `role="dialog"` `aria-modal` with an accessible name via `aria-labelledby` → the title heading; the card is wrapped in the existing `FocusTrap` for Tab containment |
| **low** | Desktop `MapEmptyState` was not a live region (its mobile twin is) | Added `role="status" aria-live="polite"` (parity with `MobileMapStatusCard`) |
| **low** | Mobile preview close button was 32px, below the 44px touch standard | `h-8 w-8` → `h-11 w-11` (WCAG 2.5.5), matching the sibling zoom controls |
| **nit** | `MapGestureHint` live region | Dropped `role="status"`/`aria-live` for `aria-hidden="true"` — it's a static, touch-only visual nudge, not an announcement |

### Focus-management detail (medium #2)
`FocusTrap` is used for **Tab containment only** (`returnFocus={false}`). Close-time focus restoration stays owned by the existing marker/list-aware `restoreDesktopPopupOriginFocus()`, and the focus-on-mount effect + Escape handler are untouched — so no double focus management and no regression to listing-switch behavior. A full Radix Dialog was deliberately **not** used (it would portal/self-position and break the marker anchoring).

> **Note:** the gesture-hint finding's stated rationale ("announces inconsistently because the text changes per gesture") was **inaccurate** — the text is static. The live region was still inappropriate for a purely-visual touch nudge, so the `aria-hidden` fix stands.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors)
- `pnpm test` — 170 map-related unit tests green, incl. new ARIA assertions (`DesktopListingPreviewCard` dialog, `MapEmptyState` live region, new `MapGestureHint` spec)
- New `tests/e2e/map-popup-a11y.anon.spec.ts` — **2 passed against a local prod build**: dialog semantics + accessible name, Tab containment (never escapes to a marker), Escape closes + returns focus to the originating marker, and the mobile close button ≥44px

## Scope
One small, themed PR. The other 32 audit findings (correctness, perf, dedup, god-component split, test hardening) are batched into later PRs per `docs/map-audit-remaining.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)