### PR TITLE
fix(map): correctness — antimeridian padBounds, (0,0) rounding guard, derived-bounds clamp

### DIFF
--- a/src/__tests__/api/map-listings-route.test.ts
+++ b/src/__tests__/api/map-listings-route.test.ts
@@ -67,6 +67,9 @@ jest.mock("@/lib/timeout-wrapper", () => ({
 
 jest.mock("@/lib/validation", () => ({
   validateAndParseBounds: jest.fn(),
+  // Route clamps derived bounds; identity pass-through is enough here (real
+  // clamp behavior is covered in lib/search/location-bounds.test.ts).
+  clampBoundsToMaxSpan: jest.fn((bounds: unknown) => bounds),
 }));
 
 jest.mock("@/lib/request-context", () => ({

--- a/src/__tests__/lib/maps/pad-bounds.test.ts
+++ b/src/__tests__/lib/maps/pad-bounds.test.ts
@@ -1,0 +1,93 @@
+import { padBounds, FETCH_BOUNDS_PADDING } from "@/lib/maps/pad-bounds";
+import {
+  MAP_FETCH_MAX_LAT_SPAN,
+  MAP_FETCH_MAX_LNG_SPAN,
+} from "@/lib/constants";
+import type { MapBounds } from "@/lib/validation";
+
+/** Crossing-aware longitude span, matching the lib helpers. */
+function lngSpanOf(b: MapBounds): number {
+  return b.minLng > b.maxLng
+    ? 180 - b.minLng + (b.maxLng + 180)
+    : b.maxLng - b.minLng;
+}
+
+describe("padBounds", () => {
+  describe("non-crossing viewport", () => {
+    it("pads outward symmetrically by the padding fraction", () => {
+      const bounds: MapBounds = {
+        minLat: 40,
+        maxLat: 42,
+        minLng: -74,
+        maxLng: -72,
+      };
+
+      const result = padBounds(bounds); // FETCH_BOUNDS_PADDING = 0.2
+
+      // latSpan = 2, lngSpan = 2 -> pad 0.4 each edge. Within limits -> no clamp.
+      expect(result.minLat).toBeCloseTo(39.6);
+      expect(result.maxLat).toBeCloseTo(42.4);
+      expect(result.minLng).toBeCloseTo(-74.4);
+      expect(result.maxLng).toBeCloseTo(-71.6);
+      expect(FETCH_BOUNDS_PADDING).toBe(0.2);
+    });
+
+    it("clamps an oversized non-crossing span to the max, centered", () => {
+      const bounds: MapBounds = {
+        minLat: 0,
+        maxLat: 10,
+        minLng: -100,
+        maxLng: 40, // span 140 -> padded 196 -> exceeds 130
+      };
+
+      const result = padBounds(bounds);
+
+      expect(lngSpanOf(result)).toBeLessThanOrEqual(MAP_FETCH_MAX_LNG_SPAN + 1e-9);
+      expect(result.maxLat - result.minLat).toBeLessThanOrEqual(
+        MAP_FETCH_MAX_LAT_SPAN + 1e-9
+      );
+      expect(result.minLng).toBeGreaterThanOrEqual(-180);
+      expect(result.maxLng).toBeLessThanOrEqual(180);
+    });
+  });
+
+  describe("antimeridian-crossing viewport (regression for the negative-span bug)", () => {
+    it("keeps a valid crossing box instead of producing inverted out-of-range bounds", () => {
+      const bounds: MapBounds = {
+        minLat: 10,
+        maxLat: 20,
+        minLng: 170,
+        maxLng: -170, // crossing: true 20-degree window across +/-180
+      };
+
+      const result = padBounds(bounds);
+
+      // The old buggy code produced minLng=238, maxLng=-238 (out of range).
+      expect(result.minLng).toBeGreaterThan(result.maxLng); // crossing preserved
+      expect(result.minLng).toBeLessThanOrEqual(180);
+      expect(result.minLng).toBeGreaterThanOrEqual(-180);
+      expect(result.maxLng).toBeLessThanOrEqual(180);
+      expect(result.maxLng).toBeGreaterThanOrEqual(-180);
+      // span ~ 20 * (1 + 2*0.2) = 28
+      expect(lngSpanOf(result)).toBeCloseTo(28, 5);
+      expect(result.minLng).toBeCloseTo(166);
+      expect(result.maxLng).toBeCloseTo(-166);
+    });
+
+    it("clamps an oversized crossing span and preserves the crossing", () => {
+      const bounds: MapBounds = {
+        minLat: 10,
+        maxLat: 20,
+        minLng: 120,
+        maxLng: -120, // crossing span 120 -> padded 168 -> exceeds 130
+      };
+
+      const result = padBounds(bounds);
+
+      expect(result.minLng).toBeGreaterThan(result.maxLng); // still crossing
+      expect(lngSpanOf(result)).toBeLessThanOrEqual(MAP_FETCH_MAX_LNG_SPAN + 1e-9);
+      expect(result.minLng).toBeLessThanOrEqual(180);
+      expect(result.maxLng).toBeGreaterThanOrEqual(-180);
+    });
+  });
+});

--- a/src/__tests__/lib/maps/sanitize-map-listings.test.ts
+++ b/src/__tests__/lib/maps/sanitize-map-listings.test.ts
@@ -32,6 +32,27 @@ describe("sanitize-map-listings", () => {
     ]);
   });
 
+  it("drops near-origin coordinates that round to (0,0) at public precision", () => {
+    // 0.001 passes the raw !(lat===0 && lng===0) guard but rounds to 0.00 at
+    // 2dp -> null island, so it must be dropped after rounding.
+    expect(
+      sanitizeMapListing({
+        id: "near-origin",
+        availableSlots: 1,
+        location: { lat: 0.001, lng: 0.001 },
+      })
+    ).toBeNull();
+
+    // A coordinate far enough from the origin to survive 2dp rounding stays.
+    expect(
+      sanitizeMapListing({
+        id: "near-but-valid",
+        availableSlots: 1,
+        location: { lat: 0.02, lng: 0.02 },
+      })?.location
+    ).toEqual(expect.objectContaining({ lat: 0.02, lng: 0.02 }));
+  });
+
   it("normalizes numeric fields and image arrays into safe map values", () => {
     const listing = sanitizeMapListing({
       id: "listing-1",

--- a/src/__tests__/lib/search/location-bounds.test.ts
+++ b/src/__tests__/lib/search/location-bounds.test.ts
@@ -1,0 +1,37 @@
+import {
+  deriveSearchBoundsFromPoint,
+  boundsTupleToObject,
+} from "@/lib/search/location-bounds";
+import { clampBoundsToMaxSpan } from "@/lib/validation";
+import {
+  MAP_FETCH_MAX_LAT_SPAN,
+  MAP_FETCH_MAX_LNG_SPAN,
+} from "@/lib/constants";
+
+/** Mirrors how /api/map-listings clamps the lat/lng-derived bounds path. */
+function deriveClamped(lat: number, lng: number) {
+  return clampBoundsToMaxSpan(
+    boundsTupleToObject(deriveSearchBoundsFromPoint(lat, lng)),
+    MAP_FETCH_MAX_LAT_SPAN,
+    MAP_FETCH_MAX_LNG_SPAN
+  );
+}
+
+describe("derived map-listings bounds clamp", () => {
+  it("clamps the near-pole 360-degree longitude widening to the max span", () => {
+    // deriveSearchBoundsFromPoint widens to +/-180 when cos(lat) < 0.01.
+    const result = deriveClamped(89.9, 0);
+
+    expect(result.maxLng - result.minLng).toBeLessThanOrEqual(
+      MAP_FETCH_MAX_LNG_SPAN + 1e-9
+    );
+    expect(result.maxLat - result.minLat).toBeLessThanOrEqual(
+      MAP_FETCH_MAX_LAT_SPAN + 1e-9
+    );
+  });
+
+  it("leaves a normal-latitude derived viewport unchanged (no over-clamping)", () => {
+    const derived = boundsTupleToObject(deriveSearchBoundsFromPoint(40.7, -74));
+    expect(deriveClamped(40.7, -74)).toEqual(derived);
+  });
+});

--- a/src/__tests__/lib/search/v2-map-data.test.ts
+++ b/src/__tests__/lib/search/v2-map-data.test.ts
@@ -129,4 +129,40 @@ describe("searchV2MapToListings", () => {
     });
     expect(JSON.stringify(listings[0])).not.toContain("raw-unit-key");
   });
+
+  it("drops near-origin features that round to (0,0) at public precision", () => {
+    // GeoJSON is [lng, lat]; 0.001 passes the raw guard but rounds to 0.00.
+    const listings = searchV2MapToListings({
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [0.001, 0.001] },
+            properties: {
+              id: "near-origin",
+              title: "Near origin",
+              price: 1000,
+              availableSlots: 1,
+              image: "x.jpg",
+            },
+          },
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [0.02, 0.02] },
+            properties: {
+              id: "near-but-valid",
+              title: "Near but valid",
+              price: 1000,
+              availableSlots: 1,
+              image: "y.jpg",
+            },
+          },
+        ],
+      },
+    } as any);
+
+    expect(listings.map((l) => l.id)).toEqual(["near-but-valid"]);
+    expect(listings[0].location).toEqual({ lat: 0.02, lng: 0.02 });
+  });
 });

--- a/src/app/api/map-listings/route.ts
+++ b/src/app/api/map-listings/route.ts
@@ -14,7 +14,7 @@ import {
 import { features } from "@/lib/env";
 import { withRateLimitRedis } from "@/lib/with-rate-limit-redis";
 import { withTimeout, DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
-import { validateAndParseBounds } from "@/lib/validation";
+import { validateAndParseBounds, clampBoundsToMaxSpan } from "@/lib/validation";
 import {
   createContextFromHeaders,
   runWithRequestContext,
@@ -257,7 +257,14 @@ export async function GET(request: NextRequest) {
           lng >= -180 &&
           lng <= 180
         ) {
-          bounds = boundsTupleToObject(deriveSearchBoundsFromPoint(lat, lng));
+          // Clamp the derived bounds to the same max spans the explicit-bounds
+          // path applies (no-op for realistic latitudes; guards the near-pole
+          // longitude widening in deriveSearchBoundsFromPoint).
+          bounds = clampBoundsToMaxSpan(
+            boundsTupleToObject(deriveSearchBoundsFromPoint(lat, lng)),
+            MAP_FETCH_MAX_LAT_SPAN,
+            MAP_FETCH_MAX_LNG_SPAN
+          );
         }
       }
 

--- a/src/components/PersistentMapWrapper.tsx
+++ b/src/components/PersistentMapWrapper.tsx
@@ -53,12 +53,9 @@ import { searchV2MapToListings } from "@/lib/search/v2-map-data";
 import {
   MAP_FETCH_MAX_LAT_SPAN,
   MAP_FETCH_MAX_LNG_SPAN,
-  LAT_MIN,
-  LAT_MAX,
-  LNG_MIN,
-  LNG_MAX,
   AREA_COUNT_CACHE_TTL_MS,
 } from "@/lib/constants";
+import { padBounds } from "@/lib/maps/pad-bounds";
 import { getScenarioHeaderValue } from "@/lib/search/testing/search-scenarios";
 import { emitSearchClientMetric } from "@/lib/search/search-telemetry-client";
 
@@ -73,7 +70,6 @@ const MAP_FETCH_TIMEOUT_MS = 15_000;
 // Spatial cache constants
 const SPATIAL_CACHE_MAX_ENTRIES = 20;
 const MAX_MAP_MARKERS = 200;
-const FETCH_BOUNDS_PADDING = 0.2;
 
 // ============================================
 // Spatial Cache Types & Utilities
@@ -124,38 +120,6 @@ function isViewportContained(
   const overlapArea =
     (overlapMaxLat - overlapMinLat) * (overlapMaxLng - overlapMinLng);
   return overlapArea / innerArea >= threshold;
-}
-
-/**
- * Pad viewport bounds by a percentage to pre-fetch nearby listings.
- * Clamps to LAT/LNG limits and map fetch max spans.
- */
-function padBounds(
-  bounds: ViewportBounds,
-  padding = FETCH_BOUNDS_PADDING
-): ViewportBounds {
-  const latSpan = bounds.maxLat - bounds.minLat;
-  const lngSpan = bounds.maxLng - bounds.minLng;
-  const padded = {
-    minLat: Math.max(LAT_MIN, bounds.minLat - latSpan * padding),
-    maxLat: Math.min(LAT_MAX, bounds.maxLat + latSpan * padding),
-    minLng: Math.max(LNG_MIN, bounds.minLng - lngSpan * padding),
-    maxLng: Math.min(LNG_MAX, bounds.maxLng + lngSpan * padding),
-  };
-  // Clamp padded result to map fetch max spans
-  const paddedLatSpan = padded.maxLat - padded.minLat;
-  const paddedLngSpan = padded.maxLng - padded.minLng;
-  if (paddedLatSpan > MAP_FETCH_MAX_LAT_SPAN) {
-    const center = (padded.minLat + padded.maxLat) / 2;
-    padded.minLat = center - MAP_FETCH_MAX_LAT_SPAN / 2;
-    padded.maxLat = center + MAP_FETCH_MAX_LAT_SPAN / 2;
-  }
-  if (paddedLngSpan > MAP_FETCH_MAX_LNG_SPAN) {
-    const center = (padded.minLng + padded.maxLng) / 2;
-    padded.minLng = center - MAP_FETCH_MAX_LNG_SPAN / 2;
-    padded.maxLng = center + MAP_FETCH_MAX_LNG_SPAN / 2;
-  }
-  return padded;
 }
 
 /** Build a filter-only key (excludes viewport params) for cache invalidation */

--- a/src/lib/maps/pad-bounds.ts
+++ b/src/lib/maps/pad-bounds.ts
@@ -1,0 +1,69 @@
+import { crossesAntimeridian } from "@/lib/search-types";
+import { clampBoundsToMaxSpan, type MapBounds } from "@/lib/validation";
+import {
+  LAT_MIN,
+  LAT_MAX,
+  LNG_MIN,
+  LNG_MAX,
+  MAP_FETCH_MAX_LAT_SPAN,
+  MAP_FETCH_MAX_LNG_SPAN,
+} from "@/lib/constants";
+
+/** Fraction of the viewport span to expand by when pre-fetching nearby listings. */
+export const FETCH_BOUNDS_PADDING = 0.2;
+
+/** Normalize a longitude into [-180, 180). */
+function wrapLng(lng: number): number {
+  return ((((lng + 180) % 360) + 360) % 360) - 180;
+}
+
+/**
+ * Pad viewport bounds by `padding` (a fraction of the span) to pre-fetch nearby
+ * listings, then clamp to the map-fetch max spans.
+ *
+ * Antimeridian-aware: for a dateline-crossing viewport (`minLng > maxLng`) the
+ * longitude span is computed the crossing-aware way and each edge is expanded
+ * outward with wrap — mirroring `isValidViewport` / `validateAndParseBounds` /
+ * `clampBoundsToMaxSpan`. A plain `maxLng - minLng` would be negative for a
+ * crossing viewport and pad/clamp the wrong way (e.g. 170/-170 -> 238/-238).
+ *
+ * The clamp is delegated to `clampBoundsToMaxSpan`, which is a no-op when the
+ * padded bounds are already within limits, so the common (non-crossing,
+ * small-viewport) prefetch path is unchanged.
+ */
+export function padBounds(
+  bounds: MapBounds,
+  padding: number = FETCH_BOUNDS_PADDING
+): MapBounds {
+  const latSpan = bounds.maxLat - bounds.minLat;
+  const crosses = crossesAntimeridian(bounds.minLng, bounds.maxLng);
+  const lngSpan = crosses
+    ? 180 - bounds.minLng + (bounds.maxLng + 180)
+    : bounds.maxLng - bounds.minLng;
+
+  const latPad = latSpan * padding;
+  const lngPad = lngSpan * padding;
+
+  const minLat = Math.max(LAT_MIN, bounds.minLat - latPad);
+  const maxLat = Math.min(LAT_MAX, bounds.maxLat + latPad);
+
+  const padded: MapBounds = crosses
+    ? {
+        minLat,
+        maxLat,
+        minLng: wrapLng(bounds.minLng - lngPad),
+        maxLng: wrapLng(bounds.maxLng + lngPad),
+      }
+    : {
+        minLat,
+        maxLat,
+        minLng: Math.max(LNG_MIN, bounds.minLng - lngPad),
+        maxLng: Math.min(LNG_MAX, bounds.maxLng + lngPad),
+      };
+
+  return clampBoundsToMaxSpan(
+    padded,
+    MAP_FETCH_MAX_LAT_SPAN,
+    MAP_FETCH_MAX_LNG_SPAN
+  );
+}

--- a/src/lib/maps/sanitize-map-listings.ts
+++ b/src/lib/maps/sanitize-map-listings.ts
@@ -101,6 +101,11 @@ export function sanitizeMapListing(
     return null;
   }
   const publicCoordinates = toPublicCoordinates({ lat, lng });
+  // Re-validate after rounding: near-origin coords pass the raw guard but can
+  // round to (0,0) (null island) at the public 2dp precision and must be dropped.
+  if (!hasValidCoordinateRange(publicCoordinates.lat, publicCoordinates.lng)) {
+    return null;
+  }
 
   const publicAvailability =
     listing.publicAvailability ??

--- a/src/lib/search/v2-map-data.ts
+++ b/src/lib/search/v2-map-data.ts
@@ -146,6 +146,13 @@ export function searchV2MapToListings(mapData: SearchV2Map): MapListingData[] {
       }
 
       const publicCoordinates = toPublicCoordinates({ lat, lng });
+      // Re-validate after rounding: near-origin coords pass the raw guard but
+      // can round to (0,0) (null island) at the public 2dp precision.
+      if (
+        !hasValidCoordinateRange(publicCoordinates.lat, publicCoordinates.lng)
+      ) {
+        return listings;
+      }
       const publicAvailability = toMapPublicAvailability(properties);
 
       listings.push({


### PR DESCRIPTION
## What & why

**Batch 2** of the remaining map-subsystem audit (`docs/map-audit-remaining.md`) — the **correctness** group. Each finding was re-verified against current `main` before fixing (audit line numbers were stale).

## Changes

| # | Finding | Fix |
|---|---------|-----|
| **medium #4** | `padBounds` ignored antimeridian crossing — `lngSpan = maxLng − minLng` goes **negative** for a dateline-crossing viewport (`minLng > maxLng`), padding the wrong way and no-op-ing the span clamp, so garbage bounds (e.g. `170/−170` → `238/−238`) reached `/api/map-listings` | Extracted `padBounds` to **`src/lib/maps/pad-bounds.ts`** (now unit-testable), made it crossing-aware via `crossesAntimeridian`, and delegated the clamp to `clampBoundsToMaxSpan` |
| **low** | The `(0,0)`/null-island guard ran on **raw** coords *before* `toPublicCoordinates` rounds to 2 dp, so near-origin points (`\|c\| < 0.005`) passed the guard then rounded to `(0,0)` | Re-validate after rounding in `sanitize-map-listings.ts` and `v2-map-data.ts` |
| **needs-context** | The lat/lng-**derived** bounds path in `map-listings/route.ts` skipped the span clamp the explicit path applies | Clamp it for symmetry/hygiene (no-op for realistic latitudes) |

### Why the `padBounds` change is low-risk
`clampBoundsToMaxSpan` is a **no-op when bounds are within limits**, so the common (non-crossing, small-viewport) prefetch path is byte-identical to before. Only the dateline-crossing branch and oversized-clamp behavior change — both toward correctness. The function moved out of the 1300-line client component into a pure lib module so it could finally be unit-tested.

> **Deferred to Batch 4:** the `toFiniteNumber` divergence between the two sanitizers is **latent** (v2 only consumes JSON primitives, so the missing `object→Number()` branch is inert; the audit's "BigInt" claim is also incorrect). It's resolved structurally by Batch 4's shared-helper extraction rather than adding inert code now.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors)
- `pnpm test` — **88 lib/api/component tests green**, including:
  - new `pad-bounds.test.ts` — non-crossing parity (regression guard), crossing `170/−170` stays a valid crossing box (**not** `238/−238`), oversized-crossing clamp
  - new `location-bounds.test.ts` — derived-bounds clamp at a near-pole point; unchanged at normal latitude
  - near-origin `(0,0)`-rounding cases added to `sanitize-map-listings` + `v2-map-data`
  - `PersistentMapWrapper`, `validation`, `bounds-clamping` suites stay green
- Pure-logic/server changes → unit/integration tests are the right level; no browser e2e needed.

## Scope
One small, themed correctness PR. Remaining batches (perf, dedup, god-component split, test hardening) per `docs/map-audit-remaining.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)