### PR TITLE
fix(auth): restore Google OAuth broken by oauth4webapi RFC 9207 iss check

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import NextAuth from "next-auth";
+import NextAuth, { customFetch } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
@@ -41,6 +41,36 @@ async function getUser(email: string) {
     throw new Error("Failed to fetch user.");
   }
 }
+
+/**
+ * Google's OpenID discovery document advertises RFC 9207 issuer identification
+ * (`authorization_response_iss_parameter_supported: true`). oauth4webapi@3.x — pulled
+ * in by the next-auth beta.31 bump — therefore hard-requires an `iss` query parameter on
+ * the OAuth callback. Google's callback in this deployment arrives without it, which
+ * surfaces as `CallbackRouteError` → `/login?error=Configuration` and blocks ALL Google
+ * sign-in. Strip the advertised support from the discovery response so Auth.js does not
+ * require `iss`. PKCE and the `signIn` callback checks still protect the flow; this
+ * restores the behavior that worked before the dependency bump.
+ */
+const googleDiscoveryFetch: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  if (!url.includes("/.well-known/openid-configuration")) {
+    return response;
+  }
+  try {
+    const metadata = await response.clone().json();
+    delete metadata.authorization_response_iss_parameter_supported;
+    return Response.json(metadata, { status: response.status });
+  } catch {
+    return response;
+  }
+};
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   basePath: "/api/auth",
@@ -248,6 +278,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       // Enable account linking for users who registered with password then try Google OAuth
       // SAFE: email_verified === true is enforced in signIn callback above
       allowDangerousEmailAccountLinking: true,
+      // Drop RFC 9207 `iss` enforcement for Google (see googleDiscoveryFetch above).
+      [customFetch]: googleDiscoveryFetch,
     }),
     Credentials({
       async authorize(credentials, request) {


### PR DESCRIPTION
## Problem

Google sign-in on production (https://roomshare.vercel.app) fails with **"There is a problem with the server configuration"** — NextAuth's `Configuration` error.

## Root cause

The 2026-05-01 `next-auth` beta.30 → beta.31 bump pulled in **`oauth4webapi@3.8.6`**, which strictly enforces **RFC 9207** (Authorization Server Issuer Identification): it requires an `iss` query param on the OAuth callback. Google's callback in this deployment arrives **without** `iss`, so `validateAuthResponse` throws `response parameter "iss" (issuer) missing` → `CallbackRouteError` → `/login?error=Configuration`, blocking **all** Google logins. It worked in March on the older `oauth4webapi` and broke after the bump.

Ruled out as causes (all verified healthy): env vars, `GOOGLE_CLIENT_SECRET` (validated against Google's token endpoint), the database (fully migrated, `Account` table correct, account-linking works), and the `proxy.ts` middleware (preserves the query string).

## Fix

Add a `customFetch` to the Google provider that strips `authorization_response_iss_parameter_supported` from Google's discovery document, so Auth.js stops requiring `iss`. `jwks_uri` is preserved, so id-token validation is unaffected; PKCE still protects the flow.

**Security:** this disables RFC 9207 issuer identification (a mix-up-attack defense that is only relevant with multiple OAuth providers). It was not active before the May bump, so this restores the prior, working posture.

## Verification

- `pnpm typecheck` passes (0 errors).
- Confirmed Google's discovery still exposes `jwks_uri` / token / userinfo endpoints, so OIDC id-token validation is unaffected.
- **Final check before/after merge:** attempt Google login on the deployment and confirm it reaches the account chooser and returns signed-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
