### PR TITLE
fix(search): include gender filters in facets cache key

### DIFF
--- a/src/__tests__/api/search/facets/route.test.ts
+++ b/src/__tests__/api/search/facets/route.test.ts
@@ -744,3 +744,78 @@ describe("eligibility parity with list search (H1)", () => {
     expect(amenitiesQuery).toContain("(d.move_in_date IS NULL OR d.move_in_date <=");
   });
 });
+
+describe("cache key regression (gender filters)", () => {
+  const boundsParams = {
+    minLng: "-97.8",
+    maxLng: "-97.6",
+    minLat: "30.2",
+    maxLat: "30.4",
+  };
+
+  function queueEmptyFacetResults() {
+    // 4 queries when no price data (histogram skipped on null min/max):
+    // amenities, houseRules, roomTypes, priceRanges
+    mockQueryRawUnsafe
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ min: null, max: null, median: null }]);
+  }
+
+  // Runs one GET and returns the serialized filter portion of the
+  // unstable_cache key (["search-facets", <key>]) it was invoked with.
+  async function cacheKeyFor(params: Record<string, string>): Promise<string> {
+    const { unstable_cache } = await import("next/cache");
+    const mockUnstableCache = jest.mocked(unstable_cache);
+    const callsBefore = mockUnstableCache.mock.calls.length;
+    queueEmptyFacetResults();
+    await GET(createRequest(params));
+    const call = mockUnstableCache.mock.calls[callsBefore];
+    expect(call).toBeDefined();
+    const keyParts = call[1] as unknown as string[];
+    return keyParts[1];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecuteRawUnsafe.mockResolvedValue(undefined);
+  });
+
+  it("varies by genderPreference (regression: searches differing only by gender filter shared one cache entry)", async () => {
+    const female = await cacheKeyFor({
+      ...boundsParams,
+      genderPreference: "FEMALE_ONLY",
+    });
+    const male = await cacheKeyFor({
+      ...boundsParams,
+      genderPreference: "MALE_ONLY",
+    });
+    const none = await cacheKeyFor(boundsParams);
+
+    expect(female).toContain("FEMALE_ONLY");
+    expect(new Set([female, male, none]).size).toBe(3);
+  });
+
+  it("varies by householdGender", async () => {
+    const allFemale = await cacheKeyFor({
+      ...boundsParams,
+      householdGender: "ALL_FEMALE",
+    });
+    const none = await cacheKeyFor(boundsParams);
+
+    expect(allFemale).toContain("ALL_FEMALE");
+    expect(allFemale).not.toBe(none);
+  });
+
+  it("treats any as no gender filter, matching the WHERE-builder semantics", async () => {
+    const explicitAny = await cacheKeyFor({
+      ...boundsParams,
+      genderPreference: "any",
+      householdGender: "any",
+    });
+    const none = await cacheKeyFor(boundsParams);
+
+    expect(explicitAny).toBe(none);
+  });
+});

--- a/src/app/api/search/facets/route.ts
+++ b/src/app/api/search/facets/route.ts
@@ -352,6 +352,18 @@ function generateFacetsCacheKey(
     minPrice: filterParams.minPrice ?? "",
     moveInDate: filterParams.moveInDate || "",
     endDate: filterParams.endDate || "",
+    // Mirror buildFacetWhereConditions: "any" applies no WHERE filter, so it
+    // must share a key with the absent case — but real values must NOT share
+    // a key with each other (omitting these served one user's counts to
+    // another whose search differed only by gender filter).
+    genderPreference:
+      filterParams.genderPreference && filterParams.genderPreference !== "any"
+        ? filterParams.genderPreference
+        : "",
+    householdGender:
+      filterParams.householdGender && filterParams.householdGender !== "any"
+        ? filterParams.householdGender
+        : "",
     q: filterParams.query?.toLowerCase().trim() || "",
     roomType: filterParams.roomType?.toLowerCase() || "",
     bookingMode: filterParams.bookingMode || "",


### PR DESCRIPTION
## Summary

Fixes a facets cache-poisoning bug found in the search & map discovery review: `generateFacetsCacheKey` omitted `genderPreference` and `householdGender`, so two searches differing **only** by gender filter shared one `unstable_cache` entry. For up to 30s (the cache TTL), one user was served the other filter state's amenity counts and price histogram in the filter drawer.

The key now mirrors `buildFacetWhereConditions` semantics exactly:

- real values (`FEMALE_ONLY`, `ALL_FEMALE`, ...) produce distinct cache keys
- `"any"` shares a key with the absent case, since it applies no WHERE filter (no needless key-space blowup)

## Verification

- New regression tests assert key distinctness per gender param and the `any` == absent equivalence
- Verified **red against the unfixed route** (2 failures) and green with the fix
- Full facets suite: 32/32 pass; lint 0 errors; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
