### PR TITLE
fix(alerts): send delivery email outside the outbox SERIALIZABLE transaction

### DIFF
--- a/src/__tests__/lib/outbox/drain.test.ts
+++ b/src/__tests__/lib/outbox/drain.test.ts
@@ -31,7 +31,10 @@ jest.mock("@/lib/outbox/handlers", () => ({
     CACHE_INVALIDATE: jest.fn(),
     GEOCODE_NEEDED: jest.fn(),
     EMBED_NEEDED: jest.fn(),
+    ALERT_MATCH: jest.fn(),
+    ALERT_DELIVER: jest.fn(),
   },
+  SELF_TRANSACTIONAL_KINDS: new Set(["ALERT_MATCH", "ALERT_DELIVER"]),
 }));
 
 jest.mock("@/lib/outbox/dlq", () => ({
@@ -428,6 +431,84 @@ describe("drainOutboxOnce() - exception from handler", () => {
     const result = await drainOutboxOnce();
     expect(result.processed).toBe(1);
     expect(result.completed).toBe(1);
+  });
+});
+
+describe("drainOutboxOnce() - self-transactional kinds", () => {
+  // Regression: ALERT_DELIVER sends email with retry/backoff; wrapping it in
+  // the drain's SERIALIZABLE withActor transaction held a pooled connection
+  // open for the duration (review finding, 2026-07-01).
+  it("invokes ALERT_DELIVER directly with the root client, bypassing withActor", async () => {
+    const row = makeOutboxRow({
+      kind: "ALERT_DELIVER",
+      aggregateType: "ALERT_DELIVERY",
+      attemptCount: 0,
+    });
+
+    (mockPrisma.$transaction as jest.Mock).mockImplementationOnce(
+      async (fn: Function) => {
+        return fn({
+          $queryRaw: jest.fn().mockResolvedValue([row]),
+          $executeRaw: jest.fn().mockResolvedValue(1),
+        });
+      }
+    );
+
+    (mockHandlers.ALERT_DELIVER as jest.Mock).mockResolvedValueOnce({
+      outcome: "completed",
+    });
+
+    const result = await drainOutboxOnce();
+
+    expect(result.completed).toBe(1);
+    expect(mockWithActor).not.toHaveBeenCalled();
+    expect(mockHandlers.ALERT_DELIVER).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({ id: row.id })
+    );
+  });
+
+  it("still wraps non-self-transactional kinds in withActor", async () => {
+    const row = makeOutboxRow({ kind: "INVENTORY_UPSERTED", attemptCount: 0 });
+
+    (mockPrisma.$transaction as jest.Mock).mockImplementationOnce(
+      async (fn: Function) => {
+        return fn({
+          $queryRaw: jest.fn().mockResolvedValue([row]),
+          $executeRaw: jest.fn().mockResolvedValue(1),
+        });
+      }
+    );
+
+    mockWithActor.mockResolvedValueOnce({ outcome: "completed" });
+
+    const result = await drainOutboxOnce();
+
+    expect(result.completed).toBe(1);
+    expect(mockWithActor).toHaveBeenCalledTimes(1);
+    expect(mockHandlers.ALERT_DELIVER).not.toHaveBeenCalled();
+  });
+
+  it("treats a thrown self-transactional handler as transient_error", async () => {
+    const row = makeOutboxRow({ kind: "ALERT_DELIVER", attemptCount: 0 });
+
+    (mockPrisma.$transaction as jest.Mock).mockImplementationOnce(
+      async (fn: Function) => {
+        return fn({
+          $queryRaw: jest.fn().mockResolvedValue([row]),
+          $executeRaw: jest.fn().mockResolvedValue(1),
+        });
+      }
+    );
+
+    (mockHandlers.ALERT_DELIVER as jest.Mock).mockRejectedValueOnce(
+      new Error("resend down")
+    );
+
+    const result = await drainOutboxOnce();
+
+    expect(result.retryScheduled).toBe(1);
+    expect(result.dlq).toBe(0);
   });
 });
 

--- a/src/__tests__/lib/search-alerts.test.ts
+++ b/src/__tests__/lib/search-alerts.test.ts
@@ -7,6 +7,9 @@ jest.mock("@/lib/prisma", () => ({
     $transaction: jest.fn(async (callback: (tx: unknown) => unknown) =>
       callback((jest.requireMock("@/lib/prisma") as { prisma: unknown }).prisma)
     ),
+    // withActor's setActorContext runs set_config via $executeRaw inside the
+    // short per-phase transactions that deliverQueuedSearchAlert opens.
+    $executeRaw: jest.fn(),
     savedSearch: {
       findMany: jest.fn(),
       update: jest.fn(),

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -17,9 +17,13 @@
  */
 
 import { prisma } from "@/lib/prisma";
-import { withActor } from "@/lib/db/with-actor";
+import { withActor, type TransactionClient } from "@/lib/db/with-actor";
 import type { OutboxKind } from "@/lib/outbox/append";
-import { HANDLERS, type OutboxRow } from "@/lib/outbox/handlers";
+import {
+  HANDLERS,
+  SELF_TRANSACTIONAL_KINDS,
+  type OutboxRow,
+} from "@/lib/outbox/handlers";
 import { routeToDlq } from "@/lib/outbox/dlq";
 import {
   recordStaleEventSkip,
@@ -183,11 +187,17 @@ export async function drainOutboxOnce(
 
     let result;
     try {
-      result = await withActor(
-        { role: "system", id: null },
-        (tx) => handler(tx, event),
-        { client: prisma }
-      );
+      // Self-transactional handlers (email/network I/O) get the root client
+      // and manage their own short actor transactions — wrapping them here
+      // would hold a SERIALIZABLE transaction (and its pooled connection)
+      // open across outbound HTTP retries.
+      result = SELF_TRANSACTIONAL_KINDS.has(event.kind as OutboxKind)
+        ? await handler(prisma as unknown as TransactionClient, event)
+        : await withActor(
+            { role: "system", id: null },
+            (tx) => handler(tx, event),
+            { client: prisma }
+          );
     } catch (err) {
       result = {
         outcome: "transient_error" as const,

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -6,7 +6,7 @@
  * uses to determine what to do with the outbox row (complete, retry, DLQ).
  */
 
-import type { TransactionClient } from "@/lib/db/with-actor";
+import type { TransactionClient, TransactionHost } from "@/lib/db/with-actor";
 import { features } from "@/lib/env";
 import type { OutboxKind } from "@/lib/outbox/append";
 import { rebuildInventorySearchProjection } from "@/lib/projections/inventory-projection";
@@ -485,7 +485,13 @@ async function handleAlertDeliverEvent(
       typeof event.payload.deliveryId === "string"
         ? event.payload.deliveryId
         : event.aggregateId;
-    const result = await deliverQueuedSearchAlert(tx, deliveryId);
+    // ALERT_DELIVER is in SELF_TRANSACTIONAL_KINDS, so the drain passes the
+    // root prisma client here (not an open transaction) — the delivery flow
+    // manages its own short actor transactions and sends email outside them.
+    const result = await deliverQueuedSearchAlert(
+      tx as unknown as TransactionHost,
+      deliveryId
+    );
 
     if (result.status === "retry") {
       return {
@@ -509,6 +515,19 @@ async function handleAlertDeliverEvent(
 // ─────────────────────────────────────────────────────────────────────────────
 // Handler routing table
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Kinds whose handlers perform outbound network I/O (email) or run their own
+ * multi-step sweeps. The drain must NOT wrap these in its long-lived
+ * SERIALIZABLE withActor transaction: holding a pooled connection open across
+ * HTTP calls with retry/backoff starves unrelated writes (bookings/holds).
+ * These handlers receive the root prisma client and open their own short
+ * actor transactions for the DB phases.
+ */
+export const SELF_TRANSACTIONAL_KINDS: ReadonlySet<OutboxKind> = new Set<OutboxKind>([
+  "ALERT_MATCH",
+  "ALERT_DELIVER",
+]);
 
 export const HANDLERS: Record<OutboxKind, OutboxHandler> = {
   UNIT_UPSERTED: handleUnitUpserted,

--- a/src/lib/search-alerts.ts
+++ b/src/lib/search-alerts.ts
@@ -12,7 +12,11 @@ import { parseLocalDate } from "./utils";
 import { getUsersWithUnlockedSearchAlerts } from "@/lib/payments/search-alert-paywall";
 import { resolvePublicListingVisibilityState } from "@/lib/listings/public-contact-contract";
 import { appendOutboxEvent } from "@/lib/outbox/append";
-import type { TransactionClient } from "@/lib/db/with-actor";
+import {
+  withActor,
+  type TransactionClient,
+  type TransactionHost,
+} from "@/lib/db/with-actor";
 
 /**
  * Validate alert filters from DB. Uses validateSearchFilters for common fields
@@ -396,14 +400,83 @@ async function countCurrentlyDeliverableTargets(
   return listings.filter(isDeliverableAlertListing).length;
 }
 
+const SYSTEM_ACTOR = { role: "system", id: null } as const;
+
+/** Everything phase 2/3 need after the eligibility transaction commits. */
+interface PreparedAlertSend {
+  deliveryId: string;
+  savedSearchId: string;
+  subscriptionId: string;
+  deliveryKind: string;
+  targetListingId: string | null;
+  userId: string;
+  userName: string;
+  userEmail: string;
+  searchName: string;
+  newListingsCount: number;
+  notificationLink: string;
+  payloadListingTitle: string | null;
+}
+
+/**
+ * Deliver one queued search alert.
+ *
+ * Runs in three phases so the outbound email is NEVER sent while a database
+ * transaction is open: Resend retries with backoff can take seconds, and
+ * holding a SERIALIZABLE transaction (and its pooled connection) that long
+ * starves unrelated writes (bookings/holds). Idempotency is unchanged: a
+ * crash between send and record leaves the delivery QUEUED and the outbox
+ * retry re-runs the phase-1 status check — the same duplicate-email window
+ * the single-transaction version had when it aborted after a successful send.
+ *
+ * `client` must be a transaction-capable client (the root prisma client),
+ * not an already-open transaction.
+ */
 export async function deliverQueuedSearchAlert(
-  client: TransactionClient,
+  client: TransactionHost,
   deliveryId: string
 ): Promise<AlertDeliveryOutcome> {
-  const db = client as unknown as typeof prisma;
   if (features.disableAlerts) {
     return { status: "retry", error: "Search alerts disabled" };
   }
+
+  // Phase 1 — eligibility checks and drops in a short actor transaction.
+  const prep = await withActor(
+    SYSTEM_ACTOR,
+    (tx) => prepareAlertDeliveryForSend(tx, deliveryId),
+    { client }
+  );
+  if ("outcome" in prep) {
+    return prep.outcome;
+  }
+  const send = prep.send;
+
+  // Phase 2 — email send, outside any transaction.
+  const emailResult = await sendNotificationEmail("searchAlert", send.userEmail, {
+    userName: send.userName,
+    searchName: send.searchName,
+    listingTitle:
+      send.newListingsCount === 1
+        ? "a matching listing"
+        : `${send.newListingsCount} matching listings`,
+    listingId: send.targetListingId ?? undefined,
+    ctaHref: send.notificationLink,
+    ctaLabel: send.targetListingId ? "View Listing" : "View Matches",
+  });
+
+  // Phase 3 — record the outcome in a second short actor transaction.
+  return withActor(
+    SYSTEM_ACTOR,
+    (tx) => recordAlertDeliveryOutcome(tx, send, emailResult),
+    { client }
+  );
+}
+
+async function prepareAlertDeliveryForSend(
+  client: TransactionClient,
+  deliveryId: string
+): Promise<{ outcome: AlertDeliveryOutcome } | { send: PreparedAlertSend }> {
+  const db = client as unknown as typeof prisma;
 
   const delivery = await db.alertDelivery.findUnique({
     where: { id: deliveryId },
@@ -425,15 +498,15 @@ export async function deliverQueuedSearchAlert(
   });
 
   if (!delivery) {
-    return { status: "dropped", reason: "TARGET_MISSING" };
+    return { outcome: { status: "dropped", reason: "TARGET_MISSING" } };
   }
 
   if (delivery.status === "DELIVERED" || delivery.status === "DROPPED") {
-    return { status: "noop" };
+    return { outcome: { status: "noop" } };
   }
 
   if (delivery.expiresAt.getTime() <= Date.now()) {
-    return dropAlertDelivery(db, delivery.id, "EXPIRED");
+    return { outcome: await dropAlertDelivery(db, delivery.id, "EXPIRED") };
   }
 
   if (
@@ -441,12 +514,16 @@ export async function deliverQueuedSearchAlert(
     !delivery.savedSearch.active ||
     !delivery.savedSearch.alertEnabled
   ) {
-    return dropAlertDelivery(db, delivery.id, "SUBSCRIPTION_INACTIVE");
+    return {
+      outcome: await dropAlertDelivery(db, delivery.id, "SUBSCRIPTION_INACTIVE"),
+    };
   }
 
   const user = delivery.savedSearch.user;
   if (!user.email || !isSearchAlertsEnabled(user.notificationPreferences)) {
-    return dropAlertDelivery(db, delivery.id, "PREFERENCE_DISABLED");
+    return {
+      outcome: await dropAlertDelivery(db, delivery.id, "PREFERENCE_DISABLED"),
+    };
   }
 
   const unlockedIds = await getUsersWithUnlockedSearchAlerts(
@@ -454,12 +531,16 @@ export async function deliverQueuedSearchAlert(
     db as Parameters<typeof getUsersWithUnlockedSearchAlerts>[1]
   );
   if (!unlockedIds.has(user.id)) {
-    return dropAlertDelivery(db, delivery.id, "PAYWALL_LOCKED");
+    return {
+      outcome: await dropAlertDelivery(db, delivery.id, "PAYWALL_LOCKED"),
+    };
   }
 
   const filters = parseFiltersForAlerts(delivery.savedSearch.filters);
   if (!filters) {
-    return dropAlertDelivery(db, delivery.id, "TARGET_MISSING");
+    return {
+      outcome: await dropAlertDelivery(db, delivery.id, "TARGET_MISSING"),
+    };
   }
 
   const payload = getPayloadObject(delivery.payload);
@@ -476,7 +557,9 @@ export async function deliverQueuedSearchAlert(
     });
 
     if (!listing) {
-      return dropAlertDelivery(db, delivery.id, "TARGET_MISSING");
+      return {
+        outcome: await dropAlertDelivery(db, delivery.id, "TARGET_MISSING"),
+      };
     }
 
     if (
@@ -484,11 +567,15 @@ export async function deliverQueuedSearchAlert(
       listing.physicalUnitId &&
       delivery.targetUnitId !== listing.physicalUnitId
     ) {
-      return dropAlertDelivery(db, delivery.id, "STALE_EPOCH");
+      return {
+        outcome: await dropAlertDelivery(db, delivery.id, "STALE_EPOCH"),
+      };
     }
 
     if (!isDeliverableAlertListing(listing)) {
-      return dropAlertDelivery(db, delivery.id, "TARGET_NOT_PUBLIC");
+      return {
+        outcome: await dropAlertDelivery(db, delivery.id, "TARGET_NOT_PUBLIC"),
+      };
     }
 
     newListingsCount = 1;
@@ -500,28 +587,44 @@ export async function deliverQueuedSearchAlert(
       targetListingIds
     );
     if (targetListingIds.length > 0 && deliverableCount === 0) {
-      return dropAlertDelivery(db, delivery.id, "TARGET_NOT_PUBLIC");
+      return {
+        outcome: await dropAlertDelivery(db, delivery.id, "TARGET_NOT_PUBLIC"),
+      };
     }
     if (deliverableCount > 0) {
       newListingsCount = deliverableCount;
     }
   }
 
-  const emailResult = await sendNotificationEmail("searchAlert", user.email, {
-    userName: user.name || "User",
-    searchName: delivery.savedSearch.name,
-    listingTitle:
-      newListingsCount === 1
-        ? "a matching listing"
-        : `${newListingsCount} matching listings`,
-    listingId: delivery.targetListingId ?? undefined,
-    ctaHref: notificationLink,
-    ctaLabel: delivery.targetListingId ? "View Listing" : "View Matches",
-  });
+  return {
+    send: {
+      deliveryId: delivery.id,
+      savedSearchId: delivery.savedSearchId,
+      subscriptionId: delivery.subscriptionId,
+      deliveryKind: delivery.deliveryKind,
+      targetListingId: delivery.targetListingId,
+      userId: user.id,
+      userName: user.name || "User",
+      userEmail: user.email,
+      searchName: delivery.savedSearch.name,
+      newListingsCount,
+      notificationLink,
+      payloadListingTitle:
+        typeof payload.listingTitle === "string" ? payload.listingTitle : null,
+    },
+  };
+}
+
+async function recordAlertDeliveryOutcome(
+  client: TransactionClient,
+  send: PreparedAlertSend,
+  emailResult: Awaited<ReturnType<typeof sendNotificationEmail>>
+): Promise<AlertDeliveryOutcome> {
+  const db = client as unknown as typeof prisma;
 
   if (!emailResult.success) {
     await db.alertDelivery.update({
-      where: { id: delivery.id },
+      where: { id: send.deliveryId },
       data: {
         status: "PENDING",
         lastError: emailResult.error || "Email failed",
@@ -533,23 +636,22 @@ export async function deliverQueuedSearchAlert(
 
   await db.notification.create({
     data: {
-      userId: user.id,
+      userId: send.userId,
       type: "SEARCH_ALERT",
       title:
-        delivery.deliveryKind === "INSTANT"
+        send.deliveryKind === "INSTANT"
           ? "New listing matches your search!"
           : "New listings match your search!",
       message:
-        delivery.deliveryKind === "INSTANT" &&
-        typeof payload.listingTitle === "string"
-          ? `"${payload.listingTitle}" matches your saved search "${delivery.savedSearch.name}"`
-          : `${newListingsCount} new listing${newListingsCount > 1 ? "s" : ""} match your saved search "${delivery.savedSearch.name}"`,
-      link: notificationLink,
+        send.deliveryKind === "INSTANT" && send.payloadListingTitle !== null
+          ? `"${send.payloadListingTitle}" matches your saved search "${send.searchName}"`
+          : `${send.newListingsCount} new listing${send.newListingsCount > 1 ? "s" : ""} match your saved search "${send.searchName}"`,
+      link: send.notificationLink,
     },
   });
 
   await db.alertDelivery.update({
-    where: { id: delivery.id },
+    where: { id: send.deliveryId },
     data: {
       status: "DELIVERED",
       deliveredAt: new Date(),
@@ -558,12 +660,12 @@ export async function deliverQueuedSearchAlert(
   });
 
   await db.savedSearch.update({
-    where: { id: delivery.savedSearchId },
+    where: { id: send.savedSearchId },
     data: { lastAlertAt: new Date() },
   });
 
   await db.alertSubscription.update({
-    where: { id: delivery.subscriptionId },
+    where: { id: send.subscriptionId },
     data: { lastDeliveredAt: new Date() },
   });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,4 +1,59 @@
-# Fix critical issues from search & map review (2026-07-01)
+# Move alert-email send out of the SERIALIZABLE outbox transaction (2026-07-02)
+
+## Goal + acceptance criteria
+Review finding (high, reliability): `drainOutboxOnce` wraps every handler in a
+30s SERIALIZABLE `withActor` transaction; `ALERT_DELIVER` sends the Resend
+email (up to 3 retries + backoff) INSIDE it, holding a pooled connection for
+seconds under provider latency — risking pool starvation for bookings/holds.
+`ALERT_MATCH` has the same defect (handler ignores its tx entirely but the
+wrapper still holds one open for the whole sweep).
+AC: email send happens outside any DB transaction; all DB writes keep actor
+GUCs via short `withActor` transactions; delivery idempotency preserved
+(status re-check on retry); regression tests prove ALERT kinds bypass the
+drain's transaction wrapper while other kinds keep it.
+
+## Scope
+- src/lib/outbox/handlers.ts — export SELF_TRANSACTIONAL_KINDS; pass-through client
+- src/lib/outbox/drain.ts — route ALERT kinds around withActor
+- src/lib/search-alerts.ts — deliverQueuedSearchAlert → 3 phases
+  (prepare tx / email no-tx / record tx)
+- tests: drain.test.ts (mock + regression), search-alerts.test.ts (mock $executeRaw)
+
+## Risks
+- Actor GUC loss on writes → keep withActor for both write phases.
+- Crash between email send and record → outbox retry re-runs phase-1 status
+  check; duplicate-email window is the SAME as the old single-tx version
+  (which could abort after a successful send). No new failure mode.
+- Phase split loses cross-phase atomicity → each phase internally atomic;
+  terminal states (DROPPED/DELIVERED) all single-phase.
+
+## Checklist
+- [x] search-alerts.ts 3-phase restructure
+- [x] handlers.ts + drain.ts routing
+- [x] test updates + regression tests
+- [x] jest (outbox + search-alerts suites) + lint + typecheck
+
+## Results + verification story
+- `deliverQueuedSearchAlert` now takes a TransactionHost (root prisma) and runs
+  prepare (withActor tx) → sendNotificationEmail (NO tx) → record (withActor tx).
+  All eligibility/drop/record semantics preserved verbatim; actor GUCs kept for
+  every DB phase.
+- `SELF_TRANSACTIONAL_KINDS` (ALERT_MATCH, ALERT_DELIVER) exported from
+  handlers.ts; drain routes those kinds around its 30s SERIALIZABLE withActor
+  wrapper and passes the root client. ALERT_MATCH previously ignored its tx
+  while the wrapper held a connection through the whole sweep — same defect,
+  fixed by the same routing.
+- Regression tests: drain.test.ts proves ALERT_DELIVER bypasses withActor
+  (called with root client), non-alert kinds still wrapped, and a thrown
+  self-transactional handler still maps to transient_error.
+- Verification: outbox suites + search-alerts + cron routes + phase02
+  integration = 150 tests green (NODE_OPTIONS=--experimental-vm-modules
+  required for PGlite suites — bare `npx jest` false-fails them); eslint 0
+  errors; typecheck clean. NOT run: full e2e (CI).
+
+---
+
+# ARCHIVED: Fix critical issues from search & map review (2026-07-01)
 
 ## Goal + acceptance criteria
 Fix the 3 critical findings from the search/map discovery review:


### PR DESCRIPTION
## Summary

Fixes the last high-severity reliability finding from the search & map review: the outbox drain wraps every handler in a 30s `SERIALIZABLE` `withActor` transaction, and `ALERT_DELIVER` sent the Resend email (up to 3 retries + exponential backoff) **inside** it — holding a pooled DB connection open for the duration. Under email-provider latency this starves unrelated writes (bookings/holds). `ALERT_MATCH` had the same defect: its handler ignores the wrapped tx entirely, but the wrapper still held a connection through the whole sweep.

## Changes

- `deliverQueuedSearchAlert` now runs three phases:
  1. **prepare** — eligibility checks and drops in a short actor transaction
  2. **send** — the email, outside any transaction
  3. **record** — outcome writes (notification, DELIVERED/PENDING status, timestamps) in a second short actor transaction
- Actor GUCs (`app.actor_role`/`app.actor_id`) are preserved for every DB phase via `withActor`.
- New `SELF_TRANSACTIONAL_KINDS` (`ALERT_MATCH`, `ALERT_DELIVER`) exported from `handlers.ts`; the drain routes those kinds around its transaction wrapper and hands them the root client.

## Idempotency (unchanged)

A crash between send and record leaves the delivery `QUEUED`; the outbox retry re-runs the phase-1 status check. This duplicate-email window is the **same** one the single-transaction version had when the transaction aborted after a successful send (SERIALIZABLE conflicts made that a real path). No new failure mode; delivery/drop terminal states are each single-phase atomic.

## Verification

- Regression tests: `ALERT_DELIVER` invoked with the root client bypassing `withActor`; non-alert kinds still wrapped; thrown self-transactional handler still maps to `transient_error`
- 150 tests green across outbox suites (incl. PGlite-backed handlers), search-alerts, cron routes, and the phase-02 outbox→projection integration suite
- eslint 0 errors; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
