### PR TITLE
fix(search): repair P1/P2 defects from the multislot search+listings review

### DIFF
--- a/docs/host-managed-patch-contract.md
+++ b/docs/host-managed-patch-contract.md
@@ -1,262 +1,158 @@
-# Host-Managed Listing PATCH Contract
+# Host-Managed Availability & Status Contract
 
-Authoritative reference for `PATCH /api/listings/:id` when the listing's
-`availabilitySource` is `HOST_MANAGED`. The route has **two** branches under
-one endpoint:
+**Last verified: 2026-07-02** (against current `main`). Uses stable anchors
+(function / schema names) rather than line numbers — the route is under active
+edit. If types / tests and this doc conflict, types win.
 
-1. **Dedicated host-managed branch** — narrow schema, optimistic CAS,
-   server-derived status transitions. Triggered when the listing is
-   `HOST_MANAGED` **and** the payload is "pure" (only host-managed keys).
-2. **Generic PATCH branch** — used for legacy listings, and for content-only
-   edits (title/description/images) on host-managed listings. Refuses to
-   touch inventory fields on host-managed rows.
+Post contact-first cutover, **every** listing is host-managed; there is no
+`availabilitySource` dispatch and no legacy-booking write path. Availability and
+status are edited through **two independent server surfaces**, each with its own
+authorization, optimistic-lock, and validation rules:
 
-Source of truth: `src/app/api/listings/[id]/route.ts` and the helper at
-`src/lib/listings/host-managed-write.ts`. If types / tests and this doc
-conflict, types win.
+| Surface | Entry point | Mutates | Auth model |
+|---|---|---|---|
+| **Availability PATCH** | `PATCH /api/listings/:id` — availability branch (`isHostManagedAvailabilityPatch`) | Inventory numbers (`openSlots`, `totalSlots`, `moveInDate`, `availableUntil`, `minStayMonths`) + a caller-supplied `status` | Owner-only, in-tx `FOR UPDATE` + version CAS |
+| **Status server action** | `updateListingStatus` / `recoverHostManagedListing` in `src/app/actions/listing-status.ts` | `status` + `statusReason` only (recovery also refreshes freshness timestamps) | Owner-only, in-tx `FOR UPDATE` + version CAS |
 
-Ticket history: CFM-301 (helper), CFM-302 (this contract), CFM-504 (extended
-mixed-state guard). See `docs/plans/cfm-migration-plan.md`.
-
----
-
-## 1. Dispatch
-
-### 1.1 `isPureHostManagedPatchPayload`
-
-Defined at `src/app/api/listings/[id]/route.ts:198-210`. Returns true when:
-
-- The body is a plain object (not an array, not null).
-- It contains `expectedVersion`.
-- Every key is in `HOST_MANAGED_PATCH_KEYS` (`route.ts:184-192`):
-  `expectedVersion`, `openSlots`, `totalSlots`, `moveInDate`, `availableUntil`,
-  `minStayMonths`, `status`.
-
-Any extra key (e.g., `title`, `amenities`) falls to the generic branch.
-
-### 1.2 Branch selection
-
-`route.ts:469-471`:
-
-```ts
-const useDedicatedHostManagedPatch =
-  listing.availabilitySource === "HOST_MANAGED" &&
-  isPureHostManagedPatchPayload(rawBody);
-```
-
-Both conditions required. A legacy listing that happens to send a pure
-host-managed payload falls through to `prepareHostManagedListingWrite`, which
-rejects at `host-managed-write.ts:194-196` with
-`HOST_MANAGED_WRITE_PATH_REQUIRED`.
+Source of truth: `src/app/api/listings/[id]/route.ts` (PATCH dispatch + schema)
+and `src/app/actions/listing-status.ts` (status transitions). There is **no**
+`src/lib/listings/host-managed-write.ts` helper — it was removed; all logic is
+inline in those two files.
 
 ---
 
-## 2. Request schema — dedicated branch
+## 1. PATCH dispatch — payload shape, not `availabilitySource`
 
-`hostManagedPatchSchema` at `src/app/api/listings/[id]/route.ts:167-177` (Zod
-`.strict()`):
+`PATCH /api/listings/:id` picks a branch purely from the request body shape:
+
+- **Availability branch** — `isHostManagedAvailabilityPatch(rawBody)` is true
+  when the body is a plain object (not array/null) containing **`openSlots` or
+  `status`**. Parsed by `hostManagedAvailabilityPatchSchema`.
+- **Profile branch** — everything else. Parsed by `listingProfilePatchSchema`
+  (title/description/price/amenities/location/etc.). Rejects any
+  availability-adjacent key (see §4, mixed-write guard).
+
+The two branches are mutually exclusive and both schemas are Zod `.strict()`, so
+a body cannot straddle them: a `title` sent alongside `openSlots` lands in the
+availability branch and is rejected as an unknown key (400); a bare inventory
+key sent without `openSlots`/`status` lands in the profile branch and is
+rejected by the mixed-write guard (409).
+
+---
+
+## 2. Availability branch — schema is a full snapshot, not a partial patch
+
+`hostManagedAvailabilityPatchSchema` (Zod `.strict()` + `.superRefine`). Every
+core field is **required** — this is a whole-availability replacement, not a
+sparse merge:
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `expectedVersion` | non-negative integer | ✅ | Optimistic-lock CAS token. |
-| `openSlots` | integer \| null | — | `null` clears; 0 is a valid "full" count. |
-| `totalSlots` | positive integer | — | Capacity. Helper requires ≥ 1. |
-| `moveInDate` | `YYYY-MM-DD` \| null | — | Earliest accepted move-in. |
-| `availableUntil` | `YYYY-MM-DD` \| null | — | Last day marketed. Must not be before `moveInDate`. |
-| `minStayMonths` | positive integer | — | Helper requires ≥ 1. |
-| `status` | `"ACTIVE"` \| `"PAUSED"` \| `"RENTED"` | — | Explicit override; omit to let the server auto-derive. |
+| `expectedVersion` | coerced int ≥ 1 | ✅ | Optimistic-lock CAS token. |
+| `openSlots` | coerced int, 0–20 | ✅ | 0 is a valid "full" count. Also written to `availableSlots`. |
+| `totalSlots` | coerced int, 1–20 | ✅ | Capacity. |
+| `moveInDate` | `YYYY-MM-DD` \| null | ✅ (key required; value nullable) | Earliest accepted move-in. |
+| `availableUntil` | `YYYY-MM-DD` \| null | — (optional key) | Omit ⇒ keep existing; `null` ⇒ clear. |
+| `minStayMonths` | coerced int ≥ 1 | ✅ | |
+| `status` | `"ACTIVE"` \| `"PAUSED"` \| `"RENTED"` | ✅ | Caller-supplied; **not** server-derived. |
 
-Because the schema is `.strict()`, extra keys produce a 400 with Zod errors
-in `{ fields: ... }`.
+Calendar-date strings are pre-validated (`getHostManagedDateOnlyErrors`) →
+400 `{ error: "Validation failed", fields }` before Zod runs. Because the schema
+is `.strict()`, unknown keys also produce 400 with `fields`.
 
-### 2.1 "Empty" payload
+### Invariants enforced (verified in code)
 
-A payload containing only `{ expectedVersion }` passes the gate
-(`isPureHostManagedPatchPayload`) and runs the helper. The helper computes
-`availabilityAffecting = false` (see `host-managed-write.ts:277-282`) and the
-only data mutation is `version` + `status` (unchanged) + `statusReason`
-(recomputed from the existing row). This is effectively a no-op version bump
-and is harmless.
+- **`openSlots ≤ totalSlots`** — `.superRefine`, field error on `openSlots`.
+- **`ACTIVE ⇒ openSlots > 0` and `moveInDate` present** — `.superRefine`.
+- **`availableUntil` not in the past, and `≥ moveInDate`** — enforced twice:
+  in `.superRefine` on the request, and re-checked inside the transaction
+  against the resolved `nextAvailableUntil`/`nextMoveInDate` (since `availableUntil`
+  may be omitted and inherited from the row).
+- **`availableSlots` is kept equal to `openSlots`** on write.
+- On success the write also stamps `lastConfirmedAt = now` and clears the
+  freshness timers (`freshnessReminderSentAt`, `freshnessWarningSentAt`,
+  `autoPausedAt`) — an availability edit counts as a reconfirmation.
 
----
+### `statusReason` handling on the availability branch
 
-## 3. Optimistic locking (version CAS)
-
-Callers read `listing.version`, send it as `expectedVersion`, and the helper
-compares at `host-managed-write.ts:198-200`:
-
-```ts
-if (input.expectedVersion !== current.version) {
-  return makeWriteError("VERSION_CONFLICT", 409);
-}
-```
-
-On success the helper sets `nextVersion = current.version + 1` and includes
-it in the update payload (`host-managed-write.ts:288-293`). Clients must
-refresh their cached version after each successful PATCH.
-
-Test coverage for the CAS path:
-
-- Unit: `src/__tests__/lib/listings/host-managed-write.test.ts`.
-- API integration: the host-managed PATCH tests at
-  `src/__tests__/api/listings-host-managed-patch.test.ts` cover the happy
-  path; the mixed-write test at `src/__tests__/api/listings-idor.test.ts`
-  covers `HOST_MANAGED_WRITE_PATH_REQUIRED` dispatches.
+`status` is taken as given; only `statusReason` is derived: `PAUSED` ⇒
+`HOST_PAUSED`; a currently host-cleared reason (`HOST_PAUSED`,
+`STALE_AUTO_PAUSE`, `FRESHNESS_WARNING`) is cleared to `null`; otherwise the
+existing `statusReason` is preserved. There is **no** server auto-derivation of
+`RENTED` from `openSlots === 0` (that behavior was removed).
 
 ---
 
-## 4. Machine error codes
+## 3. Status server action — transitions only
 
-All codes defined at `src/lib/listings/host-managed-write.ts:19-36`. HTTP
-status is returned via `WriteError.httpStatus`.
+`updateListingStatus(listingId, status, expectedVersion)` changes `status` +
+`statusReason` without touching inventory. `expectedVersion` here is validated as
+int ≥ 0 (note: the PATCH branch requires ≥ 1). Ordering inside the `FOR UPDATE`
+transaction:
 
-| Code | HTTP | Trigger | Caller recovery |
-|---|---|---|---|
-| `VERSION_CONFLICT` | 409 | `expectedVersion !== listing.version` | Re-fetch the listing, re-apply the edit, retry. |
-| `HOST_MANAGED_WRITE_PATH_REQUIRED` | 409 | Legacy listing received a host-managed payload (helper rejects at L194-196) **OR** host-managed listing received a mixed payload via the generic path (CFM-504 guard at `route.ts:803-822`). | Reload the listing and use the dedicated availability editor. |
-| `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS` | 400 | Explicit `status=ACTIVE` with `openSlots` null or `<= 0`. | Set a positive `openSlots` or drop the explicit `status`. |
-| `HOST_MANAGED_INVALID_DATE_RANGE` | 400 | `availableUntil < moveInDate` (day-only comparison); or `ACTIVE` status with missing `moveInDate` / past `availableUntil`. | Fix the date pair before retrying. |
-| `HOST_MANAGED_INVALID_MIN_STAY` | 400 | `minStayMonths < 1`. | Use an integer ≥ 1. |
-| `HOST_MANAGED_INVALID_TOTAL_SLOTS` | 400 | `totalSlots < 1`. | Use a positive total. |
-| `HOST_MANAGED_INVALID_OPEN_SLOTS` | 400 | `openSlots < 0`, `openSlots > totalSlots`, or `openSlots=null` on an availability-affecting write. | Clamp to `[0, totalSlots]`. |
-| `HOST_MANAGED_MIGRATION_REVIEW_REQUIRED` | 400 | Explicit `status=ACTIVE` while `needsMigrationReview = true`. | Complete the migration-review workflow (CFM-503) first. |
+1. Ownership (`ownerId` mismatch ⇒ "You can only update your own listings").
+2. Moderation write-lock (§4).
+3. Version CAS ⇒ `VERSION_CONFLICT`.
+4. `ACTIVE` while `statusReason ∈ {STALE_AUTO_PAUSE, FRESHNESS_WARNING}` ⇒
+   `LISTING_REQUIRES_RECONFIRMATION` (must reconfirm availability first).
+5. `ACTIVE` requires effective open slots > 0
+   (`openSlots ?? availableSlots ?? totalSlots`) ⇒ else
+   `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS`.
+6. `resolveHostStatusReason`: `PAUSED` ⇒ `HOST_PAUSED`; `ACTIVE` clears a prior
+   `HOST_PAUSED`; otherwise preserved.
 
-Codes are surfaced in the JSON body as `{ error, code }`. The host-managed
-PATCH branch does NOT include Zod `fields` on helper errors — field-level
-errors are only returned on the upstream Zod step (schema parse) where the
-shape is well-defined.
+Then `markListingDirtyInTx(..., "status_changed")` +
+`syncListingLifecycleProjectionInTx` in the same tx.
 
----
+`recoverHostManagedListing(listingId, expectedVersion, mode)` (`RECONFIRM` |
+`REOPEN`) is the reconfirmation companion: same CAS/lock guards, refreshes
+`lastConfirmedAt` and clears freshness timers, and on `REOPEN` flips to `ACTIVE`
+(also gated by `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS`).
 
-## 5. Server-derived status transitions
-
-When `input.status` is **omitted**, the helper picks the next status from
-row state (`host-managed-write.ts:243-250`):
-
-| Condition | Resulting status | `statusReason` |
-|---|---|---|
-| `nextOpenSlots === 0` | `RENTED` | `NO_OPEN_SLOTS` |
-| `availableUntilPast` (today past `availableUntil`) | `RENTED` | `AVAILABLE_UNTIL_PASSED` |
-| Otherwise | keep `current.status` | keep `current.statusReason` |
-
-When `input.status` is **explicit**, the helper validates and normalizes the
-reason via `statusReasonForExplicitStatus` (`host-managed-write.ts:252-255`).
-Explicit `ACTIVE` additionally:
-
-- Rejects if `needsMigrationReview` — see `HOST_MANAGED_MIGRATION_REVIEW_REQUIRED`.
-- Requires `openSlots > 0` and a valid date window.
-- Clears `statusReason` to `null`.
-
-Allowed `statusReason` values (`host-managed-write.ts:6-17`):
-`NO_OPEN_SLOTS`, `AVAILABLE_UNTIL_PASSED`, `HOST_PAUSED`, `ADMIN_PAUSED`,
-`MIGRATION_REVIEW`, `STALE_AUTO_PAUSE`, `MANUAL_CLOSED`.
+`reviewListingMigration` is a **retired stub** — it now returns
+`MIGRATION_REVIEW_RETIRED` unconditionally. The old migration-review gate
+(`HOST_MANAGED_MIGRATION_REVIEW_REQUIRED`) no longer exists.
 
 ---
 
-## 6. Invalid field combinations rejected deterministically
+## 4. Surviving error codes
 
-| Case | Code | Where enforced |
-|---|---|---|
-| Extra key in payload (e.g., `title`) | 400 (Zod) | `hostManagedPatchSchema.strict()` |
-| `availableUntil < moveInDate` | `HOST_MANAGED_INVALID_DATE_RANGE` | `host-managed-write.ts:232-238` |
-| `ACTIVE` + `openSlots == null` | `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS` | `host-managed-write.ts:263-268` |
-| `ACTIVE` + missing `moveInDate` / past `availableUntil` | `HOST_MANAGED_INVALID_DATE_RANGE` | `host-managed-write.ts:270-272` |
-| Availability-affecting write with `openSlots=null` | `HOST_MANAGED_INVALID_OPEN_SLOTS` | `host-managed-write.ts:284-286` |
-| Host-managed row receives mixed payload on generic path (touches `moveInDate` / `bookingMode` / `totalSlots` / `availableUntil` / `minStayMonths`) | `HOST_MANAGED_WRITE_PATH_REQUIRED` | `route.ts:803-822` (CFM-504) |
-| Legacy row receives pure host-managed payload | `HOST_MANAGED_WRITE_PATH_REQUIRED` | `host-managed-write.ts:194-196` |
-| `expectedVersion` stale | `VERSION_CONFLICT` | `host-managed-write.ts:198-200` |
+The old `HOST_MANAGED_INVALID_*` taxonomy is gone. Slot/date validation failures
+now return generic `400 { error: "Validation failed", fields }` (Zod field
+errors, **no machine `code`**). The codes that remain:
 
----
+| Code | Surface | HTTP / return | Trigger | Recovery |
+|---|---|---|---|---|
+| `VERSION_CONFLICT` | both | 409 (PATCH) / action error | `expectedVersion !== listing.version` | Re-fetch, re-apply, retry. |
+| `HOST_MANAGED_WRITE_PATH_REQUIRED` | PATCH profile branch | 409 | Profile PATCH carries a retired availability key (`totalSlots`, `moveInDate`, `availableUntil`, `minStayMonths`) with no `openSlots`/`status` | Reload; use the availability editor. |
+| `LISTING_LOCKED` | both | 423 (PATCH) / action error | `statusReason ∈ {ADMIN_PAUSED, SUPPRESSED}` — computed **before** the `moderationWriteLocks` flag, so enforced regardless of flag state; includes `lockReason` | Locked under review; no host edit. |
+| `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS` | status action | action error | Transition to `ACTIVE` with effective open slots ≤ 0 | Add an open slot or don't go ACTIVE. |
+| `LISTING_REQUIRES_RECONFIRMATION` | status action | action error | `ACTIVE` while stale/freshness-paused | Reconfirm via `recoverHostManagedListing`. |
+| `MIGRATION_REVIEW_RETIRED` | status action | action error | `reviewListingMigration` (retired) | N/A — call removed. |
+| `INVALID_VERSION` | status action | action error | `expectedVersion` fails int-≥0 parse | Send a valid version. |
 
-## 7. What the generic PATCH branch can do to host-managed rows
+Non-code failures: PATCH availability branch also returns `404 "Listing not
+found"` (missing row or non-owner) and `409 "Listing location is missing"`.
 
-The generic branch (L566-924) covers content-only edits. On host-managed
-rows it can safely change: `title`, `description`, `price`, `amenities`,
-`houseRules`, `householdLanguages`, `genderPreference`, `householdGender`,
-`primaryHomeLanguage`, `leaseDuration`, `roomType`, `images`, and location
-fields (`address`, `city`, `state`, `zip`).
-
-Inventory / availability fields are gated by the CFM-504 extended
-mixed-state guard at `route.ts:803-822`: `moveInDateChanged`,
-`bookingModeChanged`, `totalSlotsChanged`, `availableUntilChanged`,
-`minStayMonthsChanged` — any one on a `HOST_MANAGED` row throws
-`HOST_MANAGED_WRITE_PATH_REQUIRED`.
+The mixed-write guard, version CAS under `FOR UPDATE`, and the in-tx
+`markListingDirtyInTx` mark were each verified present in the live code.
 
 ---
 
-## 8. UI payload audit — `EditListingForm.tsx`
+## 5. Tests
 
-Audited at `src/app/listings/[id]/edit/EditListingForm.tsx` during CFM-302.
-Findings:
-
-- The top-level `EditListingForm` component at `L1681-1687` dispatches by
-  `availabilitySource`:
-  ```ts
-  if (props.listing.availabilitySource === "HOST_MANAGED") {
-    return <HostManagedEditListingForm {...props} />;
-  }
-  return <LegacyEditListingForm {...props} />;
-  ```
-- `HostManagedEditListingForm`'s PATCH body at `L298-307`:
-  ```ts
-  body: JSON.stringify({
-    expectedVersion: version,
-    openSlots: Number(openSlots),
-    totalSlots: Number(totalSlots),
-    moveInDate: moveInDate || null,
-    availableUntil: availableUntil || null,
-    minStayMonths: Number(minStayMonths),
-    status,
-  })
-  ```
-  — every key is in `HOST_MANAGED_PATCH_KEYS`; payload is "pure" so the
-  server dispatches to the dedicated branch.
-- `LegacyEditListingForm`'s PATCH body at `L979` does not include any of the
-  dedicated-only keys; it flows through the generic schema which allows
-  `moveInDate` / `availableUntil` / `minStayMonths` on LEGACY_BOOKING rows.
-- Client error handling: the form surfaces `code === "VERSION_CONFLICT"` as
-  a reload-required state at `L316-320`, matching the server contract.
-
-**No drift.** The UI is consistent with the server contract as of this
-audit. If the edit form is ever extended with new fields, update both this
-doc and `HOST_MANAGED_PATCH_KEYS`.
+- `src/__tests__/api/listings-host-managed-patch.test.ts` — availability branch
+  happy path, validation, and the in-tx dirty-mark assertion.
+- `src/__tests__/api/listings-idor.test.ts` — ownership/IDOR + the
+  `HOST_MANAGED_WRITE_PATH_REQUIRED` mixed-write rejection.
+- `src/__tests__/actions/listing-status.test.ts` — `updateListingStatus` /
+  `recoverHostManagedListing` transitions, CAS, and
+  `HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS`.
 
 ---
 
-## 9. Testing
+## Related docs
 
-- Unit tests for the helper: `src/__tests__/lib/listings/host-managed-write.test.ts`
-  — covers version CAS, invalid slots/dates, mixed-payload rejection, and
-  the CFM-504 extended guard (availableUntil/minStayMonths change detection).
-- Host-managed route integration:
-  `src/__tests__/api/listings-host-managed-patch.test.ts`
-  — dedicated branch happy path + `markListingDirtyInTx` assertion.
-- Mixed-write rejection:
-  `src/__tests__/api/listings-idor.test.ts`
-  — 409 + `HOST_MANAGED_WRITE_PATH_REQUIRED` for every tracked inventory
-  field on a `HOST_MANAGED` listing.
-
----
-
-## 10. Changelog
-
-| Date | Change |
-|---|---|
-| 2026-04-16 | Initial doc (CFM-302). Captures the contract as of CFM-504. |
-| 2026-04-16 | CFM-004: cross-link to `docs/migration/cfm-observability.md` for runtime monitoring of non-negotiable invariants #2 and #9. No contract change. |
-
----
-
-## 11. Related docs
-
-- `docs/search-contract.md` — normalized search input + response contract
-  (CFM-002). `PublicAvailability` is the reader counterpart to these writes.
-- `docs/plans/cfm-migration-plan.md` — full migration plan.
-- `docs/migration/cfm-observability.md` — migration observability spec
-  (CFM-004). Defines the host-managed invariant tripwires
-  (`cfm.listing.host_managed_invariant_violation_count`) and the
-  repair-loop clobber guard (`cfm.cron.host_managed_clobber_count`) that
-  enforce non-negotiable invariants #2 and #9 at runtime.
-- Source of truth:
-  `src/app/api/listings/[id]/route.ts` (schema + dispatch),
-  `src/lib/listings/host-managed-write.ts` (helper + error codes).
+- `docs/search-contract.md` — normalized search input/response contract;
+  `PublicAvailability` is the reader counterpart to these writes.
+- `docs/plans/cfm-migration-plan.md` — full contact-first migration plan.

--- a/docs/multislot-review-2026-07-02.md
+++ b/docs/multislot-review-2026-07-02.md
@@ -1,0 +1,210 @@
+# Multislot (CFM) Search & Listings — Deep Review
+
+**Date:** 2026-07-02 · **Method:** 8 parallel review agents (read-path SQL, orchestration/parsing, cache/cursor/ranking, projection write/sync, API routes, listings CRUD, UI, cross-cutting contract/flag/test) + lead adjudication of every high-severity and conflicting claim against the code. Review-only; no code changed.
+
+**Surface covered (~20k lines read in full):** `src/lib/search/*` (40 modules), `src/lib/projections/*`, `src/lib/identity/*`, `src/lib/listings/canonical-inventory.ts`, API routes (`search/v2`, `search/listings`, `search/facets`, `search-count`, `map-listings`, `nearby`, `listings`, `listings/[id]` + subroutes, `cron/refresh-search-docs`), projection Prisma models + raw-SQL migrations/indexes, `SlotBadge`/`ListingCard`/`SearchResultsClient`/`MobileBottomSheet`, and both contract docs.
+
+---
+
+## 1. Architecture snapshot (as verified, not as documented)
+
+Three read engines behind one service (`search-v2-service.ts` fallback ladder):
+
+| Engine | Table | When it serves |
+|---|---|---|
+| **Phase-04 projection** (`projection-search.ts`) | `inventory_search_projection` / `unit_public_projection` | `phase04ProjectionReads` = ON in dev/preview, **OFF in prod by default**; only for projection-eligible specs (no text query, no amenities, sort not in {recommended, rating, newest}); skipped when freshness holes detected |
+| **SearchDoc** (`search-doc-queries.ts`) | `listing_search_docs` (raw-SQL table, GIN/GIST indexed) | **Prod default engine** — `ENABLE_SEARCH_DOC=true` per `docs/DEPLOYMENT.md`; dev fallback for projection-ineligible queries |
+| **Legacy** (`data.ts`) | `Listing` + `Location` | Only if `ENABLE_SEARCH_DOC` unset (slow LIKE; not the documented prod config) |
+
+Write path: canonical listing writes mark `listing_search_doc_dirty` **in the same transaction** (verified — every mutating path is covered), the `refresh-search-docs` cron drains marks and re-projects docs, plus a TABLESAMPLE rescan backstop. CFM projections (`InventorySearchProjection`, `UnitPublicProjection`, `SemanticInventoryProjection`) are dark-written via outbox events; `multiSlotBooking`/`wholeUnitMode`/`softHolds`/`bookingAudit`/`bookingRetirementFreeze` are hard-coded `false` and their env schema entries are inert.
+
+**Safety net that changes several severities:** all three read engines JOIN live `Listing` and SQL-exclude `status != 'ACTIVE'`, `statusReason IN (MIGRATION_REVIEW, ADMIN_PAUSED, SUPPRESSED)`, and `lastConfirmedAt` older than 21 days (`projection-search.ts:87,96`, `search-doc-queries.ts:781-782`, `data.ts:180`). Stale search-doc rows therefore cannot resurrect suppressed/paused/stale listings — doc staleness corrupts *content and filter matching*, not moderation enforcement.
+
+## 2. Lead adjudications (where reviewers disagreed or needed verification)
+
+1. **`moderationWriteLocks` prod-OFF is NOT a security hole** (consistency reviewer's claim rejected). `getHostModerationWriteLockResult` (`src/lib/listings/moderation-write-lock.ts:70-90`) computes the ADMIN_PAUSED/SUPPRESSED lock *before* consulting the flag and returns it unconditionally; the flag-gated tail re-checks a predicate that already returned null — **dead code**. Locks are enforced in prod. The inert flag + dead branch is a P3 cleanup.
+2. **Prod read engine = SearchDoc**, not `data.ts` (consistency reviewer's flag matrix corrected). `ENABLE_SEARCH_DOC=true` is a documented prod requirement. *Ops follow-up: confirm the var is actually set in Vercel prod env.*
+3. **Dirty-mark race verified real** (see P1-1) — `markListingDirtyInTx` re-marks in place (`ON CONFLICT (listing_id) DO UPDATE SET marked_at = NOW()`), `clearDirtyFlags` deletes unconditionally (`cron/refresh-search-docs/route.ts:221-230`). Impact corrected per §1 safety net: staleness, not suppression leaks.
+4. **Count-vs-list engine mismatch verified real** (see P1-2) — `search-count/route.ts:102` passes `ignoreSort: true` on the stated theory that counts are sort-independent; the theory misses that skipping the sort gate switches *engines*, and the projection engine counts **units** while SearchDoc counts **listings**.
+
+## 3. Findings
+
+Severity: P1 = user-visible correctness/integrity, act now · P2 = correctness-adjacent, cost, privacy-contract, a11y · P3 = latent/robustness/docs. **Exposure** says where it bites today.
+
+### P1 — fix first
+
+**P1-1 · Lost dirty-mark race freezes live search-doc content — `src/app/api/cron/refresh-search-docs/route.ts:221-230` + `src/lib/search/search-doc-dirty.ts:125-131`.** Cron reads the dirty queue and listing snapshots, then `DELETE FROM listing_search_doc_dirty WHERE listing_id = ANY(...)` unconditionally. A host PATCH committing between the cron's snapshot read and the clear (its `ON CONFLICT ... DO UPDATE SET marked_at = NOW()` lands on the same row) has its mark deleted without its version ever being projected. Filter matching then runs on stale doc values indefinitely (e.g., price 800→1200 edit: listing keeps matching `maxPrice=1000`, card can show stale data) until the TABLESAMPLE rescan happens to resample that doc (unbounded delay). **Exposure: prod, live.** Fix: capture `marked_at` per row at read time and clear conditionally (`DELETE ... WHERE listing_id = ANY(...) AND marked_at <= <observed>`).
+
+**P1-2 · Count and list disagree — different engines, different units of counting.** `search-count/route.ts:102-104` uses projection eligibility with `ignoreSort: true` → `getProjectionSearchCount` counts **units** (GROUP BY `unit_id`); the list under the default `recommended` sort is projection-*ineligible* → SearchDoc counts **listings**. Multi-inventory units make "Show N listings" ≠ rendered list. Compounding: the count route has **no `hasProjectionFreshnessHoles` guard** while the list route falls back on holes (`search-v2-service.ts:672-690`) — divergence even for projection-eligible sorts. With `searchListingDedup` ON there's a third number (P2-6). **Exposure: dev/preview live; prod latent until `phase04ProjectionReads` flips.** Fix: derive the count from the same engine the list will use (apply the sort gate + freshness guard to count).
+
+**P1-3 · `/api/search/listings` swallows structured admission errors — `route.ts:153-155`.** `if (!result.response || result.error) throw` fires before the `admissionError` handler at `:196-211` (a result with `admissionError` has `response: null`), so the handler is **dead code**: occupants>20 / bounds-too-broad / deep-page requests silently fall back to the V1 engine instead of returning 400, diverging from `/api/search/v2` (`:123-138`) and `search-count` (`:108-121`) which return 400 correctly. **Exposure: dev/preview live (admission only exists on the projection path).** Fix: check `result.admissionError` before the throw-and-fallback wrapper.
+
+**P1-4 · Gender/household-gender filters have opposite NULL semantics across engines.** Projection includes unspecified: `(isp.gender_preference IS NULL OR isp.gender_preference = $N)` (`projection-search.ts:471-486`); SearchDoc excludes: `d.gender_preference = $N` (`search-doc-queries.ts:994-1003`). Same query flips membership when only the sort changes (sort=price → projection → NULL rows included; sort=recommended → SearchDoc → they vanish). A filter-fidelity flap, beyond ordering. **Exposure: dev/preview live; prod latent.** Fix: pick one semantic and align both builders (product call: does "female preferred" match "no preference stated"?).
+
+**P1-5 · Query-hash contract divergence makes the client DISCARD fresh results — `search-v2-service.ts:644-665`, `search-spec.ts:182-206`, `search-response.ts:70-90`, `SearchResultsClient.tsx:455-471`.** Three hash producers disagree: the client's `getSearchQueryHash` hashes filters only; the service's `generateQueryHash` adds `embeddingVersion` when semantic is active; the projection path's `getPhase04SearchSpecHash` adds `projectionEpoch + embeddingVersion + rankerProfileVersion + unitIdentityEpochFloor`. `/api/search/v2` returns `meta.queryHash` verbatim, and the client drops any response whose hash doesn't exactly equal its own bare hash (`if (data.meta.queryHash !== requestQueryHash …) return;` — emits `stale-query-hash` and keeps stale data). With the unified V2 client + semantic (or phase-04 reads), **every** fetch mismatches → the UI never updates. `fetchMoreListings` already papers over this for load-more by overriding `meta.queryHash` with the client hash (`actions.ts:230-232`) — proof the seam is real; the v2 route and `PersistentMapWrapper` don't. Also causes SSR↔CSR handoff divergence (consistency reviewer, same root cause). **Exposure: latent — client-side search flag is off today; becomes release-blocking the day the unified V2 client, semantic, or projection reads ship together.** Fix: make one canonical, version-token-free hash the client-facing contract (tokens stay in the dedicated meta/snapshot fields the cursor already carries), or have the client treat `meta.queryHash` as opaque.
+
+### P2 — correctness-adjacent, cost, privacy-contract, a11y
+
+**P2-1 · `viewer-state` leaks availability + existence of hidden/moderated listings to anonymous callers — `src/app/api/listings/[id]/viewer-state/route.ts` (~L78-141).** No visibility gate before returning `publicAvailability` (openSlots, availableFrom, lastConfirmedAt, freshnessBucket…) for SUPPRESSED/ADMIN_PAUSED/HOST_PAUSED/MIGRATION_REVIEW listings — the same listings the detail page `notFound()`s and `/status` redacts. ID enumeration partially defeats suppression. No PII, hence P2. **Exposure: prod, live.** Fix: mirror the detail/status gate (`resolvePublicListingVisibilityState(...).isPubliclyVisible` else `publicAvailability: null`).
+
+**P2-2 · PATCH address-change drops validated coordinates from canonical sync — `src/app/api/listings/[id]/route.ts:1250-1254`.** POST create threads `trustedCoordinates: coords` into `syncCanonicalAvailability` (`route.ts:560-566`); the PATCH profile branch, after writing `Location.coords` from the validated address, calls it **without** `trustedCoordinates` → novel canonical unit created `PENDING_GEOCODE`, listing drops out of projection-backed search until the async geocode worker completes, and pin vs search coordinates can diverge. **Exposure: prod live (write side runs in prod).** Fix: thread the resolved coords on PATCH like POST.
+
+**P2-3 · Admission caps exist only on the dev-default projection path — `search-spec.ts:95-164`.** occupants≤20 / maxGapDays≤180 / bounds-span / deep-page≤20 fire only inside `buildPhase04SearchSpec`. Prod (flag off) runs the SearchDoc path: page clamp is 100 not 20, and the **list** query's bounds span is not clamped (only the map query is, `search-v2-service.ts:906-912`). Requests 400-rejected in dev run expensive scans in prod. **Exposure: prod, live (cost/perf).** Fix: hoist admission validation above the engine branch.
+
+**P2-4 · `?occupants=` / `?guests=` honored only by the projection path.** `buildPhase04SearchSpec` accepts the aliases; `parseSearchParams`/`normalizeSearchFilters` don't know them (only `minAvailableSlots`/`minSlots`), so on the prod path (or the freshness-hole fallback) the capacity filter is **silently dropped**, and the projection spec hash diverges from `generateQueryHash` for the same URL (inconsistent snapshot/cache keys). **Exposure: prod live if any surface emits those params; dev/prod behavior differs regardless.** Fix: teach the parser the aliases or remove them from the spec.
+
+**P2-5 · Facets endpoint is a cost-amplification vector — `src/app/api/search/facets/route.ts:346` + `facet-where.ts`.** One anonymous GET = 5 heavy aggregations (3× unnest+GROUP BY, percentile_cont, histogram) in one tx. Its cache key rounds bounds `toFixed(4)` (~11 m) while the map path quantizes at 0.001 (~100 m) — a ~0.0001° pan per request busts the cache every time; rate limit is IP-only (no `getSearchRateLimitIdentifier`, unlike v2/list/map). Bounded by `statement_timeout=5000` + span clamps, hence P2 not P1. **Exposure: prod, live.** Fix: quantize the facets bounds key with the shared `quantizeBound`; add ip:userId identifier + tighter bucket. (Same-class residue of the #170 gender cache-key bug.)
+
+**P2-6 · With dedup ON, `total`/`totalPages` count raw listings while the page shows deduped canonicals — `search-doc-queries.ts:1605-1609,1686-1699`.** 40 raw → 22 canonicals still reports total=40, totalPages=4 → overstated counts, short/empty trailing pages. **Exposure: dev/preview live (`searchListingDedup` prod-OFF).** Fix: dedup-aware count.
+
+**P2-7 · Move-in matching diverges ~180 days between engines.** Projection: `available_from <= moveIn + gapDays·1day` with gapDays defaulting to 180 (`projection-search.ts:489-498`); SearchDoc requires availability on/before the requested date (`search-doc-queries.ts:738-761`). Same URL, wildly different result sets across engines. **Exposure: dev/preview live; prod latent.** Fix: align the window (or clamp default gap to 0 for parity) and document intended near-match semantics.
+
+**P2-8 · Identity MERGE/SPLIT strands projections at the old epoch — `src/lib/outbox/handlers.ts:298-357` + `identity/mutate-unit.ts:108-165`.** The mutation bumps `physicalUnit.unitIdentityEpoch` but nothing re-points `listing_inventories.unit_identity_epoch_written_at` or re-projects; `rebuildUnitPublicProjection` aggregates strictly at the new epoch (`unit-projection.ts:93`) → merged unit disappears from `unit_public_projection`, old-epoch `inventory_search_projection` rows orphan. **Exposure: latent until `phase04ProjectionReads` (reads) — but writes corrupt dark data today.** Fix: re-point inventories to `resultingEpoch` and enqueue per-inventory rebuilds in the handler.
+
+**P2-9 · Rescan cannot repair a MISSING search doc — `cron/refresh-search-docs/route.ts:189-219`.** `TABLESAMPLE ... FROM listing_search_docs` only re-evaluates docs that exist. If create-time `upsertSearchDocSync` failed AND the dirty mark was later lost (P1-1), the listing is invisible to search **permanently** until manually re-edited. **Exposure: prod, live (low probability, unbounded impact).** Fix: backstop pass over `Listing LEFT JOIN listing_search_docs ... WHERE doc.id IS NULL AND <publishable>`.
+
+**P2-10 · Unsanitized error logging in partial-failure branches — `search-v2-service.ts:965-970, 991-996`.** `Promise.allSettled` rejection handlers log `reason.message` verbatim (Prisma/pg errors can embed query values); the outer catch correctly uses `sanitizeErrorMessage`. Violates the no-raw-PII-in-logs non-negotiable. **Exposure: prod, live.** Fix: sanitize both branches.
+
+**P2-11 · Backend-dependent `publicAvailability` shape → dev/prod freshness-UI divergence.** SearchDoc path threads the **resolved** object (freshnessBucket, publicStatus, searchEligible — `search-doc-queries.ts:1204,1270`); projection path (`projection-search.ts:263-273,347`) and semantic path (`search-doc-queries.ts:2400-2426`) emit the **narrow** 7-field shape. SlotBadge degrades gracefully (fields optional) so nothing crashes, but freshness labels ("Needs reconfirmation") render on prod's engine and not on dev's — QA on dev doesn't see prod's badges and vice versa. Also falsifies contract §2.3's "present in every production payload." **Exposure: display divergence live in dev/preview.** Fix: one availability-resolution helper across all four row-mappers.
+
+**P2-12 · Public payloads over-expose availability lifecycle fields — `public-listing-payload.ts:139/166`, `transform.ts:102-273`.** `listing.publicAvailability ?? …` passes the *resolved* object through, so `staleAt`, `autoPauseAt`, `searchEligible`, `effectiveAvailableSlots`, `isValid` etc. serialize to anonymous clients beyond the declared 7-field `PublicAvailability` contract. Low sensitivity (derivable from public data) but a contract violation that widens silently. **Exposure: prod, live.** Fix: explicitly pick the 7 public fields at the payload boundary.
+
+**P2-13 · Dev/preview QA validates a different system than prod serves.** `phase04ProjectionReads`, `searchListingDedup`, `contactFirstListings`, `contactPaywall*`, `publicAutocompleteContract`, `listingCreateCollisionWarn` etc. all `phaseCutoverDefault` → ON in dev/preview, OFF in prod. Net: different read engine, different result grouping, different card shape (projection path emits empty `amenities`, `city:"Roomshare"` fallback titles), paywall on-vs-off. Any manual/E2E sign-off in dev does not validate prod. **Exposure: process risk, live.** Fix: pin flags per env explicitly; add a prod-flag Playwright config for the critical flows (see Test Gaps #1).
+
+**P2-14 · (Promoted — merged into P1-5 above.)** Cross-surface `meta.queryHash` divergence is the same root cause as P1-5; see there.
+
+**P2-15 · "Show more" terminal transition drops keyboard focus — `SearchResultsClient.tsx:1324-1354`.** When `nextCursor` becomes null (or the 60-cap trips) the focused button unmounts → focus falls to `document.body`, keyboard user restarts from page top (WCAG 2.4.3). **Exposure: prod, live.** Fix: move focus to a `tabIndex={-1}` terminal message or the first appended card.
+
+**P2-16 · Hot-path partial indexes are unusable — `search-doc-queries.ts:834-842` vs migrations.** `search_doc_active_available_price_idx` etc. are predicated on `d.status='ACTIVE' AND d.available_slots>0`, but the list/map/count WHERE never references `d.status`/`d.available_slots` (eligibility filters live `Listing` columns). The planner can't use the partial indexes; bounded searches heap-join and filter every candidate. **Exposure: prod perf, live.** Fix: add `d.status='ACTIVE'` to the shared eligibility conditions (with sync guarantees) or drop the dead indexes.
+
+**P2-18 · Search-cache event invalidation is dead code with mismatched tags — `search-cache.ts:23-33`.** `invalidateSearchCaches` has zero callers repo-wide, and its `revalidateTag("search-results"|"search-map"|"search-count")` targets match nothing: the three `unstable_cache` wrappers (`search-doc-queries.ts:1149,1493,1757`) declare **no `tags`**. So a capacity-affecting mutation never event-invalidates search caches; freshness is TTL-only (60s), contradicting the function's own doc and the client's "Results refreshed to keep public availability accurate" affordance. **Exposure: prod, live (bounded by 60s TTL).** Fix: add `tags:[…]` to the cache options and call `invalidateSearchCaches` from capacity-affecting mutations, or delete the dead function and document TTL-only.
+
+**P2-19 · `QuerySnapshot` rows are never reaped — `query-snapshots.ts:89-125`.** A row is written per first-page projection search and per snapshot-contract search (5-min TTL), but `loadValidQuerySnapshot` only checks `expiresAt`; there is no `querySnapshot.deleteMany` anywhere and daily-maintenance reaps rateLimit/idempotency/typing but not snapshots → unbounded table growth. **Exposure: dev live now; prod the day snapshot-writing flags flip.** Fix: add an expired-snapshot reaper to daily-maintenance (mirror the idempotency reaper).
+
+**P2-20 · Keyset cursors are not bound to the filter set — `cursor.ts:106-121`.** KeysetCursorV1/V2 encode sort+keys+id but no filter `queryHash`; the service applies a decoded keyset cursor against the *current* filterParams with no filter check (`search-v2-service.ts:854`). Snapshot cursors DO validate `cursor.queryHash` and reject. A valid keyset cursor from query A replayed with query B's filters (same sort) is honored → B's WHERE + A's boundary → duplicates/skips. Mitigated in the normal UI flow (cursor reset on param change), so this is a robustness gap for crafted/stale cursors. **Exposure: prod (keyset on via `CURSOR_SECRET`), crafted-input only.** Fix: add a `qh` field to keyset cursors and reject on mismatch (parity with snapshot cursors).
+
+**P2-21 · `host-managed-patch-contract.md` is wholesale stale.** Cites `src/lib/listings/host-managed-write.ts`, `HOST_MANAGED_PATCH_KEYS`, `availabilitySource` dispatch, server-derived status transitions, and an error taxonomy — none exist. Real implementation: payload-shape dispatch (`isHostManagedAvailabilityPatch` = body has `openSlots`|`status`, `route.ts:259-266`), required-fields schema, status codes relocated to `src/app/actions/listing-status.ts`. Invariants *are* enforced (CAS + row lock + mixed-write 409 + dirty-in-tx verified) — this is doc drift that will mislead the next maintainer. Fix: rewrite to the two-surface reality or delete.
+
+### P3 — latent, robustness, docs (grouped)
+
+**Query/engine semantics**
+- `vibeQuery` is silently inert unless `sort=recommended` — changes URL + cache key, affects zero rows/ordering on any other sort (`search-doc-queries.ts:856-872` never reads it; `search-v2-service.ts:719-720` gates rerank). Product decision needed: apply, warn, or strip.
+- Map vs list can filter by different text when the service routes text through `vibeQuery` (map applies FTS `query` only) — markers/list mismatch on the vibe path.
+- `sort` not in `generateQueryHash` → a snapshot cursor minted under one sort "matches" another; UI resets cursors on sort change so impact = crafted/stale cursors replay stale ordering (`search-v2-service.ts:644-665`).
+- Projection SQL bounds gate uses the coarse `public_cell_id` centroid; the JS post-filter uses `public_point` — edge units dropped inconsistently; rows with NULL/malformed cell id silently excluded (`projection-search.ts:507-525` vs `:237-249`).
+- Near-match expansion suppressed exactly when there are zero exact results (`items.length > 0` gate, `search-doc-queries.ts:1705-1711,2138-2143`) — confirm against product intent.
+- `d.move_in_date <= $N` lacks the `::date` cast its sibling condition uses (`search-doc-queries.ts:947-951`) — TZ-boundary off-by-one risk.
+- Facets add `d.status='ACTIVE'` (`facet-where.ts:83`) that the search WHERE doesn't — facet counts can be *narrower* than results when `d.status` lags `l.status`.
+- `price: row.fromPrice ?? 0` renders null price as "$0" on the projection path (`projection-search.ts:332`); type is `number|null` — pass null through.
+- Inverted-longitude bounds pass the parser by design (antimeridian) and **are** handled in all three engines' SQL (verified: `crossesAntimeridian` splits envelopes) — but `normalizeBounds` in `typed-location-resolver.ts:60-74` trusts upstream bbox order/ranges without validation (defense-in-depth).
+- "Studio City"-class NL mis-parse: bare "studio" → roomType="Entire Place", location="City" (`natural-language-parser.ts:71-76,156-170`).
+- `split-stay.ts:21-57` pairs by price only, ignores slot capacity vs requested occupants (documented stub; gate before de-stubbing).
+- `search-orchestrator.ts` is test-only dead code whose V1-direct branch lacks a bounds guard — delete or guard.
+- Point-fallback viewport is 0.27° (~30 km) while comments claim ~10 km (`location-bounds.ts:17-30` vs `validation.ts:200-211`) — reconcile.
+
+**Cache / dedup / cursors**
+- `buildBaseCacheFields` omits `vibeQuery` — safe today only because vibeQuery never reaches cached SearchDoc SQL (semantic path is uncached; soft-vibe rerank runs outside `unstable_cache`); one refactor away from cross-vibe cache collisions (`search-doc-queries.ts:286-307`). Add it defensively or assert the invariant.
+- Dedup group-key normalization both under- and over-merges: "Apt 4"→"unit 4" but "#4" stays "#4" (same unit shown twice under different spellings); owner+addr+price+title+roomType collisions hide distinct units as siblings; a sibling beyond `SEARCH_DEDUP_LOOK_AHEAD` resurfaces as a fresh canonical on the next page (client `seenGroupKeys` hides it, but combined-slot metadata splits) (`dedup.ts:164-180`, `normalize-address.ts`, `normalize-listing-title.ts`). Data-quality dependent; largely by-design.
+- Unsigned cursors are forgeable only when `CURSOR_SECRET` is unset (dev; prod throws) — bounded impact since keyset values are parameterized + NaN-guarded. Separately, `getCursorSecret()` accepts any non-empty secret while legacy cursors require `hasStrongSecret` — a weak dev secret signs keyset cursors but leaves legacy cursors unsigned (`cursor.ts:216-219`, `env.ts:544-566`).
+
+**Write path / projections**
+- `projection_epoch` is stamped but never used as a read/write fence — old-epoch worker with higher `source_version` can overwrite newer rows during a rolling deploy (`epoch.ts:17-22`; accepted 1-2 min window, but the fence is absent, not coarse).
+- Cross-unit advisory-lock ordering (tombstone prev-unit → rebuild new-unit) can deadlock under two inventories swapping units (`canonical-inventory.ts:489-529` via `unit-projection.ts:59-61`) — acquire unit locks in canonical order.
+- Dead dirty reasons `booking_hold_expired`/`reconcile_slots` (`search-doc-dirty.ts:38-39`) — a future holds system that decrements slots without `markListingDirty` goes silently stale; wire or remove.
+- `queryProjectionUnitRows` builds raw SQL without `joinWhereClauseWithSecurityInvariant` (all values parameterized today; add the assertion for defense-in-depth) (`projection-search.ts:428-578`).
+- Three sources of truth for the 21-day stale cutoff: `STALE_THRESHOLD_DAYS` constant vs hardcoded `INTERVAL '21 days'` literals in `search-doc-queries.ts:253` and `data.ts:76` — derive one from the other + parity test.
+- Parallel flag accessors: `features.phase04ProjectionReads` (env.ts) AND `isPhase04ProjectionReadsEnabled` (`@/lib/flags/phase02`) decide the same flag — collapse to one.
+
+**Listings / security hygiene**
+- JSON-LD via `dangerouslySetInnerHTML` relies solely on write-time `noHtmlTags` filtering; `JSON.stringify` doesn't escape `<` → any future writer bypassing the zod filter yields stored XSS (`app/listings/[id]/page.tsx:344-350`). Escape at output.
+- No DB CHECK constraints for slot invariants (openSlots≤totalSlots etc.) — app-layer-only enforcement; raw SQL/migrations can persist impossible states.
+- Create idempotency depends on client-supplied `X-Idempotency-Key`; with `listingCreateCollisionWarn` off, a double-submit creates duplicates (`api/listings/route.ts:640-649`).
+- `MIGRATION_REVIEW` is not write-locked (`moderation-write-lock.ts:27`) — hosts can edit migration-review listings (out of search regardless; confirm intent).
+- `status=RENTED, openSlots=5` accepted; stale `statusReason` can survive an ACTIVE flip (cosmetic) (`[id]/route.ts:214-229, 777-786`).
+- E2E scenario backdoor `ENABLE_SEARCH_TEST_SCENARIOS` lacks a `VERCEL_ENV !== "production"` guard and runs before rate limiting (`search-scenarios.ts:68`; scenario branches in listings + map-listings routes).
+- `x-search-query-hash` header is uncapped, echoed into `meta.queryHash`, and logged (`map-listings/route.ts:71-79`) — length-cap + charset-restrict.
+- Facets & search-count rate-limit on IP only (shared-NAT contention; see P2-5).
+- Inert moderation flag + dead branch in `getHostModerationWriteLockResult` (see Adjudication #1) — remove the flag plumbing or make it real.
+- `wholeUnitMode` block at `[id]/route.ts:1169` is unreachable (flag hard-false; bookingMode always derived from roomType) — dead code.
+- Dead `LEGACY_BOOKING` branches: read SQL hardcodes `'HOST_MANAGED'`; `resolvePublicAvailability` voids its `legacySnapshot` arg; `buildLegacyPublicAvailability` unreachable (`search-doc-sync.ts:123,371-375`, `public-availability.ts:358,399`) — delete.
+
+**UI (latent)**
+- Detail-page SlotBadge omits `publicAvailability` (`ListingPageClient.tsx:1189-1192`) — surfaces agree today only because search-eligible ⇒ ACTIVE+fresh; diverges the moment eligibility widens.
+- Non-overlay `toBadgeVariant` collapses warning/neutral to "info" (blue "Closed" badge with warning icon) — landmine for the first non-overlay caller with `publicAvailability` (`SlotBadge.tsx:121-130`).
+- "Drag down at list-top to collapse" is unreachable from listing cards (cards are `<a>`, interactive-element guard eats the gesture) (`MobileBottomSheet.tsx:304-309`).
+- `clientFetchedListings` not cleared on the SSR-fingerprint reset path (flag-gated, `SearchResultsClient.tsx:639-651`).
+- aria-live result-count region remounts with the keyed component — SRs may not announce post-filter counts (`SearchResultsClient.tsx:1109-1122`).
+
+**Docs**
+- `search-contract.md`: all three version constants drifted (`SEARCH_RESPONSE_VERSION` v1→v3, `SEARCH_QUERY_HASH_VERSION`, `SEARCH_DOC_PROJECTION_VERSION` 1→3); meta documented as 3 fields, actually 10; §2.4 default is PAUSED not AVAILABLE; §2.3 freshness claim false (P2-11); changelog stops 2026-04-17; nearly all line anchors off by 40-60.
+- `cfm-inventory.md` stale both directions: `booking.ts`/`BookingForm`/`SlotSelector`/`manage-booking` marked `not_started` but **deleted**; `ContactHostButton` marked `not_started` but shipped as primary CTA.
+
+## 4. Flag matrix (CFM-relevant, verified against `src/lib/env.ts`)
+
+`phaseCutoverDefault(env)` = `"true"`→true, `"false"`→false, else `NODE_ENV !== "production"` → **dev/preview ON, prod OFF unless env set**.
+
+| Flag | Dev | Prod default | Gates | Risk note |
+|---|---|---|---|---|
+| multiSlotBooking, wholeUnitMode, softHolds*, bookingAudit, bookingRetirementFreeze | false | false (hard-coded) | nothing live | env schema entries + cross-validation inert; dead branches |
+| phase04ProjectionReads | ON | **OFF** | entire projection read path + card shape | largest dev/prod gap (P2-13); dual accessors (P3) |
+| searchListingDedup | ON | **OFF** | result grouping + totals | P2-6 lives behind it |
+| contactFirstListings, contactPaywall(+Enforcement), searchAlertPaywall, entitlementState, publicAutocompleteContract, publicCacheCoherence, listingCreateCollisionWarn, privateFeedback | ON | **OFF** | user-visible behavior | QA parity hazard |
+| moderationWriteLocks | ON | OFF | *(nothing — inert)* | lock enforced regardless; dead branch |
+| searchDoc (`ENABLE_SEARCH_DOC`) | explicit | explicit (**docs mandate true**) | SearchDoc vs legacy LIKE engine | confirm set in prod |
+| searchKeyset | via `CURSOR_SECRET` | via `CURSOR_SECRET` | keyset pagination + HMAC cursors | — |
+| searchDocRescan | ON (default true) | ON (default true) | rescan backstop | only repairs existing docs (P2-9) |
+| staleAutoPause, freshnessNotifications | OFF | OFF | crons | safe: reads SQL-exclude stale |
+| semanticSearch | OFF unless env | OFF | semantic/vibe rerank | P2-14 latent behind it |
+
+## 5. Test gaps (prioritized, consolidated)
+
+1. **Prod-flag E2E config** — run critical search/listing Playwright flows with prod-effective flags (`phase04ProjectionReads=false`, `searchListingDedup=false`, paywalls off). Today every dev-default E2E validates the non-prod engine.
+2. **Count/list parity** — same URL through `search-count` and `search/listings` must agree, incl. default sort + projection-on + freshness holes (P1-2).
+3. **Dirty-race regression** — concurrent re-mark between cron snapshot-read and `clearDirtyFlags` must survive (P1-1); plus rescan-recreates-missing-doc (P2-9).
+4. **Cross-engine filter equivalence** — gender NULL semantics, move-in gap window, occupants aliases: assert projection and SearchDoc builders produce equivalent membership for the same parsed query (P1-4, P2-4, P2-7).
+5. **Two concurrent host PATCHes** — exercise the `FOR UPDATE` + version CAS with real concurrency, not just stale `expectedVersion`; add action-level tests for `listing-status.ts` (`HOST_MANAGED_ACTIVE_REQUIRES_OPEN_SLOTS`).
+6. **viewer-state redaction** — hidden/moderated listing returns null availability to non-owner (P2-1).
+7. **PATCH address-change coordinate coherence** — `Location.coords` vs canonical unit geocode (P2-2).
+8. **Serialized `publicAvailability` = exactly 7 fields** on list + geojson (P2-12); SlotBadge tolerates the narrow shape (P2-11).
+9. **Cache-key/limiter hardening** — facets jittered-bounds burst stays coalesced (P2-5); `ENABLE_SEARCH_TEST_SCENARIOS` inert in prod; oversized `x-search-query-hash` truncated.
+10. **Stale-threshold parity** — assert the SQL read-exclusion interval equals `STALE_THRESHOLD_DAYS` across all three engines.
+11. **Client-hash vs `meta.queryHash` parity for SEMANTIC and PROJECTION responses** — the exact P1-5 gap; `query-hash-semantic-equivalence.test` covers URL→hash only, not client-vs-service agreement.
+12. **UI**: load-more terminal focus (P2-15); warning/neutral badge variants; aria-live announcement after keyed remount; 0-value/array URL round-trip from the UI layer.
+13. **Identity merge/split projection coherence** at the new epoch (P2-8); mixed-epoch overwrite; cross-unit lock-order deadlock.
+14. **Index-usage (EXPLAIN) regression** for the hot list/map queries (would have caught P2-16).
+15. **Cache/cursor hardening** — a capacity-affecting mutation invalidates the list/map/count `unstable_cache` entries (P2-18); expired `QuerySnapshot` rows get reaped (P2-19); a keyset cursor minted under filter set A is rejected under filter set B (P2-20); a pinned snapshot listing that turned paused/filled is dropped as a hole by the JS eligibility gate, not shown with a stale label.
+
+## 6. Verified solid (checked and confirmed — don't re-litigate)
+
+- **No SQL injection anywhere in scope**: every user value is a `$N` parameter; `joinWhereClauseWithSecurityInvariant` runs a real runtime assertion; sort/enum clauses are hard-coded maps. NaN/Infinity/negative/huge numerics cannot reach SQL unclamped (all normalizers finite-check + clamp).
+- **Cursor integrity**: HMAC-signed (with `CURSOR_SECRET`), zod `.strict()` per-sort validation, forged/malformed → null, legacy page clamped; keyset snapshot pins response/projection/embedding versions and rejects mismatches; no unbounded OFFSET from crafted cursors.
+- **Coordinate privacy**: deterministic 2-dp rounding (~1.1 km) applied at the data layer on every public path; no per-call jitter → no averaging attack; `(0,0)` guards; exact coords only owner/admin; `exact_point` never leaves `physical_units`.
+- **AuthZ on mutations**: no IDOR found; every mutation re-reads under `SELECT … FOR UPDATE` + version CAS in one tx; non-owner → 404; suspended/moderation locks enforced (flag-independent); create serialized per-user via advisory lock (TOCTOU-safe); trusted-address validation on POST and PATCH (signed suggestion token, fails closed).
+- **Mixed-state guard real**: retired availability keys on the profile branch → 409 `HOST_MANAGED_WRITE_PATH_REQUIRED`; `.strict()` schemas prevent cross-branch smuggling; multislot invariants (openSlots≤totalSlots, ACTIVE⇒openSlots>0+moveInDate) enforced in zod AND canonical sync.
+- **Every mutating path marks the search doc dirty in the same tx** (create, both PATCH branches, delete/suppress, admin moderation, view-count) — the P1 race is on the *clear* side only.
+- **Moderation/stale exclusion at read time** in all three engines (the §1 safety net).
+- **Tombstone/resurrection defenses**: source-version CAS no-ops stale events; hidden-status guard under `FOR UPDATE`; semantic requires `PUBLISHED`; suppress path tombstones canonical inventory in-tx; hard delete cascades the doc.
+- **Outbox drain**: `FOR UPDATE SKIP LOCKED` disjoint claims, per-row try/catch (no batch poisoning), time-box + stale-in-flight recovery; emergency stop (`FEATURE_PHASE01_CANONICAL_WRITES=false`) degrades all-or-nothing per call; **Invariant #9 upheld** (no repair loop writes host-managed availability).
+- **Duplicate PhysicalUnit prevented** under concurrency (advisory lock + unique constraint).
+- **Rate-limit identity**: `getClientIP` prefers unspoofable `x-real-ip` on Vercel; XFF only trusted in dev/explicit proxy; search v2/list/map keyed ip:userId.
+- **Telemetry PII-safe**: queryHash not raw text, HMAC'd owner hashes, sanitized error strings (except P2-10), free-text reasons never logged; metrics sink strictly allowlisted.
+- **All four CLAUDE.md search-UI invariants hold** with line evidence: keyed remount resets cursor/accumulation; `seenIdsRef` dedups before append; `MAX_ACCUMULATED=60` enforced; no cursor in URL. Mobile-sheet spec (snap points, drag guards, Escape, body-lock) matches. Stale-response races defended (AbortController + double query-hash gating); load-more re-entry guarded; `ListingCard` memo includes all `publicAvailability` fields.
+- **Legacy booking surface is gone**: `BookingForm`/`SlotSelector` deleted (zero bundle cost), no booking/hold mutation routes exist, `bookingMode` server-derived.
+- **Query-hash semantic equivalence** (modulo P2-14) via `normalizeHashableSearchQuery` with regression tests; legacy URL aliases parse with parity tests; unbounded browse capped (48) with page clamps; text-query-without-bounds throws.
+- **Price units consistent** (dollars, Decimal(10,2)) end-to-end; date-only→UTC-midnight conversion explicit; `ListingStatus` enum fully handled.
+- **Keyset pagination order-parity**: WHERE OR-chains match the ORDER BY exactly (`… DESC NULLS LAST, listing_created_at DESC, id ASC`), stable id tiebreak, and `ts_rank_cd` is skipped on BOTH keyset pages so page-1↔page-N ordering can't diverge on FTS rank.
+- **Ranking is deterministic where it matters**: `rankListings` tie-breaks by id; the time/distance-dependent runtime score only tiers map pins, never orders the keyset list — cursor pagination cannot drift.
+- **SearchDoc list/map/count cache keys cover every WHERE dimension** (`buildBaseCacheFields` audited field-by-field vs the WHERE builder); the #170 facets gender fix is present and complete.
+- **Projection snapshot pagination slices frozen `orderedUnitKeys`** and maps to live rows — an earlier-page hole can't shift a later listing into an already-served page.
+
+## 7. Suggested fix order
+
+1. **Same-day, small diffs:** P1-1 conditional clear (one SQL predicate); P1-3 reorder admission check; P2-10 sanitize two log lines; P2-1 viewer-state visibility gate; P2-2 thread coords on PATCH; P2-19 snapshot reaper (copy the idempotency reaper).
+2. **Next:** P1-2 count engine alignment + freshness guard; P1-4 + P2-7 + P2-4 cross-engine filter parity (one "engine-parity" PR + equivalence tests); P2-5 facets cache-key quantization + limiter identity; P2-18 wire cache tags or delete the dead invalidator; P2-20 bind keyset cursors to the filter hash.
+3. **Then:** P2-9 missing-doc backstop; P2-15 focus management; P2-16 index alignment; P2-12 payload field-pick; P2-11 unified availability resolution.
+4. **Pre-cutover gates (before flipping `phase04ProjectionReads`/`searchListingDedup`/unified V2 client/semantic in prod):** **P1-5 hash contract** (release-blocking for those flags), P2-6, P2-8, P2-13 prod-flag E2E, epoch fence (P3), cell-id vs point bounds (P3).
+5. **Cleanups/docs batch:** dead flags + LEGACY branches + orchestrator; rewrite/delete `host-managed-patch-contract.md`; refresh `search-contract.md` + `cfm-inventory.md`.
+
+---
+
+*All eight reviewer reports are integrated, including the cache/cursor/ranking pass (P1-5, P2-18/19/20, and the cache/dedup/cursor P3 group).*

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 import dns from "node:dns";
 import dotenv from "dotenv";
 import path from "path";
+import { PROD_EFFECTIVE_FLAG_ENV } from "./tests/e2e/helpers/prod-flags-env";
 
 // Node.js >=17 defaults to IPv6-first DNS resolution.
 // GitHub Actions runners resolve "localhost" to ::1 (IPv6) but Next.js
@@ -31,6 +32,18 @@ process.env.CURSOR_SECRET =
 const runningDedupeSuite = process.argv.some(
   (arg) => arg.includes("tests/e2e/dedupe") || arg.includes("/dedupe/")
 );
+
+// Prod-flag parity run (docs/multislot-review-2026-07-02.md · P2-13): launch the
+// server with prod-effective feature flags so the smoke validates the engine +
+// card shape prod actually serves. Triggered by E2E_PROD_FLAGS=true or by
+// scoping to the prod-flags-smoke project. Normalize both into the env var so the
+// spec's runtime guard (isProdFlagsRun) agrees with this process.
+const runningProdFlagsSuite =
+  process.env.E2E_PROD_FLAGS === "true" ||
+  process.argv.some((arg) => arg.includes("prod-flags-smoke"));
+if (runningProdFlagsSuite) {
+  process.env.E2E_PROD_FLAGS = "true";
+}
 const enableDedupeFeatures =
   runningDedupeSuite ||
   process.env.CI === "true" ||
@@ -54,6 +67,13 @@ webServerEnv.NEXT_PUBLIC_SUPABASE_URL =
   webServerEnv.NEXT_PUBLIC_SUPABASE_URL || "https://fake.supabase.co";
 webServerEnv.TURNSTILE_ENABLED = "false";
 webServerEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY = "";
+
+// Pin every CFM cutover flag to its prod-effective value (applied last so it
+// wins over the dev-default dedupe overrides above). Single source of truth:
+// tests/e2e/helpers/prod-flags-env.ts.
+if (runningProdFlagsSuite) {
+  Object.assign(webServerEnv, PROD_EFFECTIVE_FLAG_ENV);
+}
 
 /**
  * Playwright configuration for RoomShare E2E tests
@@ -245,6 +265,19 @@ export default defineConfig({
         ...devices["Desktop Safari"],
       },
     },
+
+    /* Prod-flag parity smoke (anonymous). Runs the critical search/listing flows
+       against a server launched with prod-effective feature flags — see
+       docs/multislot-review-2026-07-02.md P2-13 and tests/e2e/helpers/prod-flags-env.ts.
+       Dedicated run only: E2E_PROD_FLAGS=true pnpm exec playwright test --project=prod-flags-smoke
+       (the spec self-skips under any dev-default invocation). */
+    {
+      name: "prod-flags-smoke",
+      testMatch: /prod-flags-smoke\.anon\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
   ],
 
   /* Start dev server locally; skip in CI where server is started manually */
@@ -253,7 +286,8 @@ export default defineConfig({
     : {
         command: "pnpm run dev",
         url: "http://localhost:3000/api/health/ready",
-        reuseExistingServer: !runningDedupeSuite,
+        // Never reuse a dev-flag server for the flag-sensitive dedupe / prod-flag runs.
+        reuseExistingServer: !runningDedupeSuite && !runningProdFlagsSuite,
         timeout: 180000,
         stdout: "pipe",
         stderr: "pipe",

--- a/prisma/migrations/20260702000000_drop_dead_search_doc_partial_indexes/migration.sql
+++ b/prisma/migrations/20260702000000_drop_dead_search_doc_partial_indexes/migration.sql
@@ -1,0 +1,44 @@
+-- Drop three unusable partial indexes on listing_search_docs (review P2-16).
+--
+-- Why they are dead weight:
+--   The hot list/map/count queries filter status and slots on the LIVE "Listing"
+--   table (l.status = 'ACTIVE', l."openSlots" >= $N), never on the denormalized
+--   doc columns d.status / d.available_slots (see buildPublicSearchEligibilityConditions
+--   in src/lib/search/search-doc-queries.ts). A Postgres partial index is only
+--   usable when the query WHERE provably implies the index predicate, so an index
+--   predicated on d.status = 'ACTIVE' AND d.available_slots > 0 can never be chosen
+--   by any hot query. Confirmed by static analysis of every hot WHERE builder.
+--
+-- Why no replacement index is added:
+--   Every real access path is already covered by existing indexes —
+--     * bounds (the selective driver): search_doc_location_geog_idx (GIST location_geog)
+--     * price range: search_doc_price_idx (price)
+--     * per-sort keyset pagination: search_doc_keyset_recommended / _price_asc /
+--       _price_desc / _newest / _rating (all leading with the sort column +
+--       listing_created_at DESC + id)
+--   A new (price, listing_created_at) btree would duplicate search_doc_price_idx and
+--   the price keyset indexes — pure write amplification with no read benefit, i.e.
+--   exactly the anti-pattern this finding flags. So we drop and add nothing.
+--
+-- LEAD DECISION: do NOT add d.status = 'ACTIVE' to the search WHERE to "revive"
+--   these indexes — the doc status can lag the live listing (sync delay), so keying
+--   search on d.status could hide a just-unpaused listing. Eligibility stays on the
+--   live "Listing" row; the dead doc-side indexes are removed instead.
+--
+-- Data safety: dropping an index takes a brief ACCESS EXCLUSIVE lock on the index
+--   only; on this pre-launch dataset (dummy data) the risk is nil. Plain DROP INDEX
+--   (not CONCURRENTLY) so the statement stays inside Prisma's migration transaction.
+--
+-- Rollback (reversible — recreate exactly as originally defined):
+--   CREATE INDEX "search_doc_status_idx"
+--     ON "listing_search_docs" ("status") WHERE "status" = 'ACTIVE';
+--   CREATE INDEX "search_doc_available_idx"
+--     ON "listing_search_docs" ("available_slots")
+--     WHERE "available_slots" > 0 AND "status" = 'ACTIVE';
+--   CREATE INDEX "search_doc_active_available_price_idx"
+--     ON "listing_search_docs" ("price", "listing_created_at" DESC)
+--     WHERE "status" = 'ACTIVE' AND "available_slots" > 0;
+
+DROP INDEX IF EXISTS "search_doc_status_idx";
+DROP INDEX IF EXISTS "search_doc_available_idx";
+DROP INDEX IF EXISTS "search_doc_active_available_price_idx";

--- a/src/__tests__/api/cron/daily-maintenance.test.ts
+++ b/src/__tests__/api/cron/daily-maintenance.test.ts
@@ -26,6 +26,7 @@ jest.mock("@/lib/prisma", () => ({
     rateLimitEntry: { deleteMany: jest.fn() },
     idempotencyKey: { deleteMany: jest.fn() },
     typingStatus: { deleteMany: jest.fn() },
+    querySnapshot: { deleteMany: jest.fn() },
   },
 }));
 
@@ -89,6 +90,7 @@ describe("GET /api/cron/daily-maintenance", () => {
     (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
     (prisma.idempotencyKey.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
     (prisma.typingStatus.deleteMany as jest.Mock).mockResolvedValue({ count: 3 });
+    (prisma.querySnapshot.deleteMany as jest.Mock).mockResolvedValue({ count: 4 });
     fetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ success: true }),
@@ -198,6 +200,49 @@ describe("GET /api/cron/daily-maintenance", () => {
     expect(cleanupTerminalOutboxEventsOnce).toHaveBeenCalledTimes(1);
     expect(compactSupersededOutboxEventsOnce).toHaveBeenCalledTimes(1);
     expect(cleanupConsumedCacheInvalidationsOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it("reaps expired query snapshots inside the daily window (P2-19)", async () => {
+    jest.setSystemTime(new Date("2026-04-17T09:03:00.000Z"));
+    (prisma.querySnapshot.deleteMany as jest.Mock).mockResolvedValue({
+      count: 7,
+    });
+
+    const response = await GET(createRequest() as any);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(prisma.querySnapshot.deleteMany).toHaveBeenCalledWith({
+      where: { expiresAt: { lt: expect.any(Date) } },
+    });
+    expect(payload.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task: "cleanup-query-snapshots",
+          success: true,
+          detail: { deleted: 7 },
+        }),
+      ])
+    );
+  });
+
+  it("skips the query-snapshot reaper outside the daily window", async () => {
+    jest.setSystemTime(new Date("2026-04-17T15:00:00.000Z"));
+
+    const response = await GET(createRequest() as any);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(prisma.querySnapshot.deleteMany).not.toHaveBeenCalled();
+    expect(payload.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task: "cleanup-query-snapshots",
+          skipped: true,
+          detail: { skipped: true, reason: "outside_daily_window" },
+        }),
+      ])
+    );
   });
 
   it("marks outbox retention skipped outside the daily window", async () => {

--- a/src/__tests__/api/cron/refresh-search-docs.test.ts
+++ b/src/__tests__/api/cron/refresh-search-docs.test.ts
@@ -180,7 +180,10 @@ describe("GET /api/cron/refresh-search-docs", () => {
   });
 
   it("returns zero counters when there is no dirty or rescan work", async () => {
-    mockQueryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockQueryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
 
     const response = await getRefreshSearchDocs(createRequest("Bearer valid"));
     const data = await response.json();
@@ -216,6 +219,7 @@ describe("GET /api/cron/refresh-search-docs", () => {
         buildDirtyEntry("listing-b", new Date(now - 20_000)),
         buildDirtyEntry("listing-c", new Date(now - 30_000)),
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
     mockProjectSearchDocument
       .mockResolvedValueOnce({
@@ -278,6 +282,7 @@ describe("GET /api/cron/refresh-search-docs", () => {
         buildDirtyEntry("host-1", new Date(now - 10_000)),
         buildDirtyEntry("gone-1", new Date(now - 20_000)),
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
     mockProjectSearchDocument
       .mockResolvedValueOnce({
@@ -326,6 +331,7 @@ describe("GET /api/cron/refresh-search-docs", () => {
       .mockResolvedValueOnce([
         buildDirtyEntry("listing-1", new Date(now - 10_000)),
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
     mockProjectSearchDocument.mockResolvedValue({
       listingId: "listing-1",
@@ -365,6 +371,7 @@ describe("GET /api/cron/refresh-search-docs", () => {
         buildDirtyEntry("suppress-1", new Date(now - 30_000)),
         buildDirtyEntry("error-1", new Date(now - 40_000)),
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
     mockProjectSearchDocument
       .mockResolvedValueOnce({
@@ -431,7 +438,8 @@ describe("GET /api/cron/refresh-search-docs", () => {
         buildDirtyEntry("stale-1", new Date(now - 20_000)),
         buildDirtyEntry("skew-1", new Date(now - 100_000)),
       ])
-      .mockResolvedValueOnce([{ id: "rescan-1" }]);
+      .mockResolvedValueOnce([{ id: "rescan-1" }])
+      .mockResolvedValueOnce([]);
     mockProjectSearchDocument
       .mockResolvedValueOnce({
         listingId: "missing-1",
@@ -614,10 +622,13 @@ describe("GET /api/cron/refresh-search-docs", () => {
   it("tracks CAS-suppressed writes by reason and exposes the counter series", async () => {
     const now = Date.parse("2026-04-17T18:00:00.000Z");
     jest.spyOn(Date, "now").mockReturnValue(now);
-    mockQueryRaw.mockResolvedValueOnce([
-      buildDirtyEntry("projection-1", new Date(now - 10_000)),
-      buildDirtyEntry("source-1", new Date(now - 20_000)),
-    ]);
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        buildDirtyEntry("projection-1", new Date(now - 10_000)),
+        buildDirtyEntry("source-1", new Date(now - 20_000)),
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
     mockProjectSearchDocument
       .mockResolvedValueOnce({
         listingId: "projection-1",
@@ -772,7 +783,8 @@ describe("GET /api/cron/refresh-search-docs", () => {
         { id: "rescan-8" },
         { id: "rescan-9" },
         { id: "rescan-10" },
-      ]);
+      ])
+      .mockResolvedValueOnce([]);
     mockProjectSearchDocument
       .mockResolvedValueOnce({
         listingId: "dirty-1",
@@ -822,5 +834,87 @@ describe("GET /api/cron/refresh-search-docs", () => {
       })
     );
     expect(getSearchDocCronTelemetrySnapshot().lastRunPartial).toBe(true);
+  });
+
+  it("clears dirty flags conditionally on the observed marked_at so a concurrent re-mark survives (P1-1)", async () => {
+    const now = Date.parse("2026-04-17T18:00:00.000Z");
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    const observedMarkedAt = new Date(now - 10_000);
+    mockQueryRaw
+      .mockResolvedValueOnce([buildDirtyEntry("listing-1", observedMarkedAt)])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockProjectSearchDocument.mockResolvedValueOnce({
+      listingId: "listing-1",
+      outcome: "upsert",
+      divergenceReason: "stale_doc",
+      casSuppressionReason: null,
+      hadExistingDoc: true,
+      listingVersion: 4,
+      docSourceVersion: 3,
+      docProjectionVersion: 3,
+      writeApplied: true,
+    });
+
+    await getRefreshSearchDocs(createRequest("Bearer valid"));
+
+    // The clear must bind the marked_at observed at queue-read time and gate the
+    // DELETE on `marked_at <= observed`. A writer that re-marks the row with a
+    // newer NOW() between the read and this delete lands a strictly greater
+    // marked_at, so the predicate skips it and the mark survives to the next run
+    // instead of being deleted with a version that was never projected.
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    const clearCall = mockExecuteRaw.mock.calls[0];
+    expect(clearCall[1]).toEqual(["listing-1"]);
+    expect(clearCall[2]).toEqual([observedMarkedAt.toISOString()]);
+
+    const clearSql = getQueryText(mockExecuteRaw, 0);
+    expect(clearSql).toContain("unnest");
+    expect(clearSql).toContain("marked_at <=");
+    // The old unconditional clear used `WHERE listing_id = ANY(...)`.
+    expect(clearSql).not.toContain("= ANY(");
+  });
+
+  it("repairs listings that have no search doc via the missing-doc backstop (P2-9)", async () => {
+    const now = Date.parse("2026-04-17T18:00:00.000Z");
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    // No dirty work, empty TABLESAMPLE rescan, one listing with no doc at all.
+    mockQueryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "no-doc-1" }]);
+    mockProjectSearchDocument.mockResolvedValueOnce({
+      listingId: "no-doc-1",
+      outcome: "upsert",
+      divergenceReason: "missing_doc",
+      casSuppressionReason: null,
+      hadExistingDoc: false,
+      listingVersion: 2,
+      docSourceVersion: null,
+      docProjectionVersion: null,
+      writeApplied: true,
+    });
+
+    const response = await getRefreshSearchDocs(createRequest("Bearer valid"));
+    const data = await response.json();
+
+    expect(data).toMatchObject({
+      success: true,
+      processed: 1,
+      repaired: 1,
+      divergentMissingDoc: 1,
+      errors: 0,
+    });
+    expect(
+      mockProjectSearchDocument.mock.calls.map(([listingId]) => listingId)
+    ).toEqual(["no-doc-1"]);
+
+    // The backstop is the third query: an anti-join over Listing/Location that
+    // finds publishable listings with no listing_search_docs row.
+    const backstopSql = getQueryText(mockQueryRaw, 2);
+    expect(backstopSql).toContain("listing_search_docs");
+    expect(backstopSql).toContain("NOT EXISTS");
+    expect(backstopSql).toContain('"Listing"');
+    expect(backstopSql).toContain('"Location"');
   });
 });

--- a/src/__tests__/api/listings-host-managed-patch.test.ts
+++ b/src/__tests__/api/listings-host-managed-patch.test.ts
@@ -55,6 +55,10 @@ jest.mock("@/lib/search/search-doc-dirty", () => ({
   markListingDirtyInTx: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock("@/lib/search/search-cache", () => ({
+  invalidateSearchCaches: jest.fn(),
+}));
+
 jest.mock("@/lib/api-error-handler", () => ({
   captureApiError: jest
     .fn()
@@ -151,6 +155,7 @@ import { prisma } from "@/lib/prisma";
 import { verifyAddressSuggestionToken } from "@/lib/geocoding/address-suggestion-token";
 import { syncCanonicalListingInventory } from "@/lib/listings/canonical-inventory";
 import { markListingDirtyInTx } from "@/lib/search/search-doc-dirty";
+import { invalidateSearchCaches } from "@/lib/search/search-cache";
 import { createClient } from "@supabase/supabase-js";
 
 const ownerSession = {
@@ -868,6 +873,130 @@ describe("PATCH /api/listings/[id] contact-first availability contract", () => {
       expect(mockValidateAddressForPublish).not.toHaveBeenCalled();
       expect(update).toHaveBeenCalled();
     });
+  });
+
+  it("threads the validated coordinates into canonical sync on an address change (P2-2)", async () => {
+    (verifyAddressSuggestionToken as jest.Mock).mockReturnValue({
+      valid: true,
+      coords: { lat: 40.7128, lng: -74.006 },
+    });
+    mockTransaction({
+      lockedRows: [
+        lockedListing({
+          normalizedAddress: "123 main st san francisco ca 94102",
+          physicalUnitId: "unit-123",
+        }),
+      ],
+    });
+
+    const response = await PATCH(
+      new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify(
+          validPatchPayload({
+            address: "456 Oak Ave",
+            city: "San Francisco",
+            state: "CA",
+            zip: "94103",
+            addressSuggestionToken: "valid-token",
+          })
+        ),
+      }),
+      { params: Promise.resolve({ id: "listing-abc" }) }
+    );
+
+    expect(response.status).toBe(200);
+    // The just-validated coords must reach canonical sync so the unit is not
+    // recreated PENDING_GEOCODE (parity with POST create).
+    expect(syncCanonicalListingInventory).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        trustedCoordinates: { lat: 40.7128, lng: -74.006 },
+      })
+    );
+  });
+
+  it("does not thread trustedCoordinates when a profile edit leaves the address unchanged", async () => {
+    mockTransaction();
+
+    const response = await PATCH(
+      new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify(validPatchPayload()),
+      }),
+      { params: Promise.resolve({ id: "listing-abc" }) }
+    );
+
+    expect(response.status).toBe(200);
+    const syncArgs = (syncCanonicalListingInventory as jest.Mock).mock
+      .calls[0][1];
+    expect(syncArgs.trustedCoordinates).toBeUndefined();
+  });
+
+  it("invalidates search caches after a successful availability PATCH (P2-18)", async () => {
+    mockTransaction();
+
+    const response = await PATCH(
+      new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          expectedVersion: 3,
+          openSlots: 1,
+          totalSlots: 2,
+          moveInDate: "2026-05-01",
+          availableUntil: "2026-09-01",
+          minStayMonths: 2,
+          status: "ACTIVE",
+        }),
+      }),
+      { params: Promise.resolve({ id: "listing-abc" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(invalidateSearchCaches).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fail the availability PATCH when search-cache revalidation throws (P2-18)", async () => {
+    (invalidateSearchCaches as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("revalidateTag boom");
+    });
+    const { update } = mockTransaction();
+
+    const response = await PATCH(
+      new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify({
+          expectedVersion: 3,
+          openSlots: 1,
+          totalSlots: 2,
+          moveInDate: "2026-05-01",
+          availableUntil: "2026-09-01",
+          minStayMonths: 2,
+          status: "ACTIVE",
+        }),
+      }),
+      { params: Promise.resolve({ id: "listing-abc" }) }
+    );
+
+    expect(response.status).toBe(200);
+    // The write committed even though revalidation threw.
+    expect(update).toHaveBeenCalled();
+    expect(invalidateSearchCaches).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate search caches for a non-availability profile edit (P2-18 scope)", async () => {
+    mockTransaction();
+
+    const response = await PATCH(
+      new Request("http://localhost/api/listings/listing-abc", {
+        method: "PATCH",
+        body: JSON.stringify(validPatchPayload()),
+      }),
+      { params: Promise.resolve({ id: "listing-abc" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(invalidateSearchCaches).not.toHaveBeenCalled();
   });
 
   it("survives a phase01 canonical-sync skip: PATCH succeeds, physicalUnitId falls back, dirty mark still fires (H2)", async () => {

--- a/src/__tests__/api/listings-viewer-state-visibility.test.ts
+++ b/src/__tests__/api/listings-viewer-state-visibility.test.ts
@@ -1,0 +1,181 @@
+/**
+ * P2-1 — viewer-state must not leak availability (or existence) of
+ * hidden/moderated listings.
+ *
+ * The route resolves visibility with the real
+ * resolvePublicListingVisibilityState helper. A listing that is not publicly
+ * visible must return the same shape as a missing listing to a non-owner /
+ * non-admin caller (publicAvailability: null, indistinguishable from
+ * not-found). Owners and admins keep full data; ACTIVE listings are unchanged.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (
+      data: unknown,
+      init?: { status?: number; headers?: Record<string, string> }
+    ) => ({
+      status: init?.status || 200,
+      json: async () => data,
+      headers: new Map(Object.entries(init?.headers || {})),
+    }),
+  },
+}));
+
+jest.mock("@/auth", () => ({ auth: jest.fn() }));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    listing: { findUnique: jest.fn() },
+    review: { findFirst: jest.fn().mockResolvedValue(null) },
+    conversation: { findFirst: jest.fn().mockResolvedValue(null) },
+    report: { findFirst: jest.fn().mockResolvedValue(null) },
+  },
+}));
+
+jest.mock("@/lib/with-rate-limit", () => ({
+  withRateLimit: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { sync: { error: jest.fn(), warn: jest.fn(), info: jest.fn() } },
+  sanitizeErrorMessage: (value: unknown) => String(value),
+}));
+
+jest.mock("@/lib/env", () => ({
+  features: {
+    privateFeedback: false,
+    contactPaywallEnforcement: false,
+  },
+}));
+
+jest.mock("@/lib/payments/contact-paywall", () => ({
+  evaluateMessageStartPaywall: jest
+    .fn()
+    .mockResolvedValue({ summary: null }),
+}));
+
+// Real availability resolution keys off status; moderation statusReasons are
+// gated independently of searchEligible by the real visibility helper.
+jest.mock("@/lib/search/public-availability", () => ({
+  resolvePublicAvailability: jest.fn(
+    (listing: { status?: string | null }) => ({
+      availabilitySource: "HOST_MANAGED",
+      publicStatus: listing?.status === "ACTIVE" ? "AVAILABLE" : "PAUSED",
+      searchEligible: listing?.status === "ACTIVE",
+      openSlots: 1,
+      totalSlots: 1,
+      effectiveAvailableSlots: 1,
+      freshnessBucket: "FRESH",
+      lastConfirmedAt: null,
+    })
+  ),
+}));
+
+import { GET } from "@/app/api/listings/[id]/viewer-state/route";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+const LISTING_ID = "listing-viewer-state";
+const OWNER_ID = "owner-1";
+
+function listingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ownerId: OWNER_ID,
+    status: "ACTIVE",
+    availableSlots: 1,
+    totalSlots: 1,
+    openSlots: 1,
+    moveInDate: new Date("2026-05-01T00:00:00.000Z"),
+    availableUntil: null,
+    minStayMonths: 1,
+    lastConfirmedAt: new Date("2026-07-01T00:00:00.000Z"),
+    statusReason: null,
+    physicalUnitId: "unit-1",
+    ...overrides,
+  };
+}
+
+function invoke() {
+  return GET(
+    new Request(`http://localhost/api/listings/${LISTING_ID}/viewer-state`),
+    { params: Promise.resolve({ id: LISTING_ID }) }
+  );
+}
+
+const suppressedRow = () =>
+  listingRow({ status: "PAUSED", statusReason: "SUPPRESSED" });
+
+describe("GET /api/listings/[id]/viewer-state visibility gate (P2-1)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null availability for a SUPPRESSED listing to an anonymous viewer", async () => {
+    (auth as jest.Mock).mockResolvedValue(null);
+    (prisma.listing.findUnique as jest.Mock).mockResolvedValue(suppressedRow());
+
+    const response = await invoke();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.publicAvailability).toBeNull();
+    // No availability leak, no existence oracle.
+    expect(payload.paywallSummary).toBeNull();
+  });
+
+  it("is byte-for-byte indistinguishable from a not-found listing for an anonymous viewer", async () => {
+    (auth as jest.Mock).mockResolvedValue(null);
+
+    (prisma.listing.findUnique as jest.Mock).mockResolvedValueOnce(
+      suppressedRow()
+    );
+    const suppressedPayload = await (await invoke()).json();
+
+    (prisma.listing.findUnique as jest.Mock).mockResolvedValueOnce(null);
+    const missingPayload = await (await invoke()).json();
+
+    expect(suppressedPayload).toEqual(missingPayload);
+  });
+
+  it("still returns availability to the owner of a SUPPRESSED listing", async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: OWNER_ID, emailVerified: new Date("2026-04-01T00:00:00Z") },
+    });
+    (prisma.listing.findUnique as jest.Mock).mockResolvedValue(suppressedRow());
+
+    const response = await invoke();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.publicAvailability).not.toBeNull();
+    expect(payload.publicAvailability.openSlots).toBe(1);
+  });
+
+  it("still returns availability to an admin viewing a SUPPRESSED listing", async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: {
+        id: "admin-9",
+        isAdmin: true,
+        emailVerified: new Date("2026-04-01T00:00:00Z"),
+      },
+    });
+    (prisma.listing.findUnique as jest.Mock).mockResolvedValue(suppressedRow());
+
+    const payload = await (await invoke()).json();
+
+    expect(payload.publicAvailability).not.toBeNull();
+  });
+
+  it("leaves an ACTIVE listing unchanged for an anonymous viewer", async () => {
+    (auth as jest.Mock).mockResolvedValue(null);
+    (prisma.listing.findUnique as jest.Mock).mockResolvedValue(listingRow());
+
+    const response = await invoke();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.publicAvailability).not.toBeNull();
+    expect(payload.publicAvailability.openSlots).toBe(1);
+  });
+});

--- a/src/__tests__/api/search-count.test.ts
+++ b/src/__tests__/api/search-count.test.ts
@@ -55,6 +55,7 @@ jest.mock("@/lib/flags/phase04", () => ({
 
 jest.mock("@/lib/search/projection-search", () => ({
   getProjectionSearchCount: jest.fn(),
+  hasProjectionFreshnessHoles: jest.fn(),
 }));
 
 jest.mock("@/lib/public-cache/headers", () => ({
@@ -69,6 +70,7 @@ jest.mock("@/lib/logger", () => ({
   logger: {
     debug: jest.fn(),
     error: jest.fn(),
+    sync: { warn: jest.fn() },
   },
   sanitizeErrorMessage: jest.fn((err: unknown) =>
     err instanceof Error ? err.message : String(err)
@@ -82,7 +84,10 @@ import { withRateLimitRedis } from "@/lib/with-rate-limit-redis";
 import { parseSearchParams, hasActiveFilters } from "@/lib/search-params";
 import { getLimitedCount } from "@/lib/data";
 import { isPhase04ProjectionReadsEnabled } from "@/lib/flags/phase04";
-import { getProjectionSearchCount } from "@/lib/search/projection-search";
+import {
+  getProjectionSearchCount,
+  hasProjectionFreshnessHoles,
+} from "@/lib/search/projection-search";
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest } from "next/server";
 
@@ -103,6 +108,8 @@ const mockWithRateLimitRedis = withRateLimitRedis as jest.Mock;
 const mockIsPhase04ProjectionReadsEnabled =
   isPhase04ProjectionReadsEnabled as jest.Mock;
 const mockGetProjectionSearchCount = getProjectionSearchCount as jest.Mock;
+const mockHasProjectionFreshnessHoles =
+  hasProjectionFreshnessHoles as jest.Mock;
 
 // --- Test suite ---
 
@@ -113,6 +120,8 @@ describe("GET /api/search-count", () => {
     mockWithRateLimitRedis.mockResolvedValue(null);
     mockIsPhase04ProjectionReadsEnabled.mockReturnValue(false);
     mockGetProjectionSearchCount.mockResolvedValue({ ok: true, count: 0 });
+    // Default: no projection freshness holes → projection count path stays live
+    mockHasProjectionFreshnessHoles.mockResolvedValue(false);
     // Default: no active filters, no query, no bounds
     mockParseSearchParams.mockReturnValue({ filterParams: {} });
     mockHasActiveFilters.mockReturnValue(false);
@@ -284,6 +293,136 @@ describe("GET /api/search-count", () => {
     expect(mockGetLimitedCount).toHaveBeenCalledWith(
       expect.objectContaining({ query: "sunny room" })
     );
+  });
+
+  // P1-2: count/list engine parity. Under the default "recommended" sort the
+  // list is projection-INELIGIBLE (SearchDoc, counts listings). The count must
+  // use the SAME engine, not the projection unit-count fast-path — otherwise
+  // "Show N listings" mismatches the rendered list for multi-inventory units.
+  // (Before the fix, { ignoreSort: true } forced this onto getProjectionSearchCount.)
+  it("uses the SearchDoc count (not projection) for a projection-eligible-except-sort query under the default recommended sort", async () => {
+    mockIsPhase04ProjectionReadsEnabled.mockReturnValue(true);
+    mockParseSearchParams.mockReturnValue({
+      filterParams: {
+        // Projection-eligible on every dimension EXCEPT sort. "recommended" is
+        // the default sort and is not projection-rankable, so the list falls to
+        // SearchDoc — and the count must follow it.
+        sort: "recommended",
+        bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.4 },
+        minPrice: 500,
+      },
+    });
+    mockGetLimitedCount.mockResolvedValue(23);
+
+    const request = createRequest({
+      minLat: "37.7",
+      maxLat: "37.8",
+      minLng: "-122.5",
+      maxLng: "-122.4",
+      minPrice: "500",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ count: 23 });
+    expect(mockGetProjectionSearchCount).not.toHaveBeenCalled();
+    expect(mockGetLimitedCount).toHaveBeenCalled();
+    // Sort-ineligible: never even reaches the freshness guard.
+    expect(mockHasProjectionFreshnessHoles).not.toHaveBeenCalled();
+  });
+
+  // P1-2: freshness-hole parity. A projection-ELIGIBLE query (no query/amenities,
+  // projection-rankable sort) whose bounds contain freshness holes is served by
+  // SearchDoc on the list (search-v2-service.ts:672-690), so the count must fall
+  // back to the SearchDoc count too.
+  it("falls back to the SearchDoc count when a projection-eligible query has freshness holes", async () => {
+    mockIsPhase04ProjectionReadsEnabled.mockReturnValue(true);
+    mockParseSearchParams.mockReturnValue({
+      filterParams: {
+        // Projection-eligible: no unsupported sort/query/amenities.
+        bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.4 },
+        minPrice: 500,
+      },
+    });
+    mockHasProjectionFreshnessHoles.mockResolvedValue(true);
+    mockGetLimitedCount.mockResolvedValue(13);
+
+    const request = createRequest({
+      minLat: "37.7",
+      maxLat: "37.8",
+      minLng: "-122.5",
+      maxLng: "-122.4",
+      minPrice: "500",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ count: 13 });
+    expect(mockHasProjectionFreshnessHoles).toHaveBeenCalled();
+    expect(mockGetProjectionSearchCount).not.toHaveBeenCalled();
+    expect(mockGetLimitedCount).toHaveBeenCalled();
+  });
+
+  // Positive parity: projection-eligible + rankable sort + no holes → projection
+  // count (units), the same engine the list uses for this query. Locks in that
+  // the freshness guard is consulted before committing to the projection count.
+  it("uses the projection count when eligible with no freshness holes", async () => {
+    mockIsPhase04ProjectionReadsEnabled.mockReturnValue(true);
+    mockParseSearchParams.mockReturnValue({
+      filterParams: {
+        sort: "price_asc",
+        bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.4 },
+        minPrice: 500,
+      },
+    });
+    mockHasProjectionFreshnessHoles.mockResolvedValue(false);
+    mockGetProjectionSearchCount.mockResolvedValueOnce({ ok: true, count: 9 });
+
+    const request = createRequest({
+      minLat: "37.7",
+      maxLat: "37.8",
+      minLng: "-122.5",
+      maxLng: "-122.4",
+      minPrice: "500",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ count: 9 });
+    expect(mockHasProjectionFreshnessHoles).toHaveBeenCalled();
+    expect(mockGetProjectionSearchCount).toHaveBeenCalled();
+    expect(mockGetLimitedCount).not.toHaveBeenCalled();
+  });
+
+  // Guard-failure parity with the list path's catch branch: if the freshness
+  // guard query itself throws, stay on the projection engine (do NOT 500).
+  it("stays on the projection count when the freshness guard throws", async () => {
+    mockIsPhase04ProjectionReadsEnabled.mockReturnValue(true);
+    mockParseSearchParams.mockReturnValue({
+      filterParams: {
+        sort: "price_asc",
+        bounds: { minLat: 37.7, maxLat: 37.8, minLng: -122.5, maxLng: -122.4 },
+        minPrice: 500,
+      },
+    });
+    mockHasProjectionFreshnessHoles.mockRejectedValue(
+      new Error("freshness probe failed")
+    );
+    mockGetProjectionSearchCount.mockResolvedValueOnce({ ok: true, count: 4 });
+
+    const request = createRequest({
+      minLat: "37.7",
+      maxLat: "37.8",
+      minLng: "-122.5",
+      maxLng: "-122.4",
+      minPrice: "500",
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ count: 4 });
+    expect(mockGetProjectionSearchCount).toHaveBeenCalled();
+    expect(mockGetLimitedCount).not.toHaveBeenCalled();
   });
 
   // 7. Rate limit exceeded → 429

--- a/src/__tests__/api/search-listings-route.test.ts
+++ b/src/__tests__/api/search-listings-route.test.ts
@@ -1,0 +1,231 @@
+/**
+ * P1-3 regression tests for GET /api/search/listings
+ *
+ * A SearchV2Result carrying a structured signal (admissionError / snapshotExpired)
+ * has response:null and no error. The circuit-breaker wrapper must surface those
+ * to their dedicated handlers (400 admission_rejected / 409 snapshot_expired)
+ * instead of throwing them into the generic V1 fallback. Genuine failures (thrown
+ * errors) must still fall back to V1.
+ */
+
+// --- Mocks (must come before imports) ---
+
+jest.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (
+      data: unknown,
+      init?: { status?: number; headers?: Record<string, string> }
+    ) => {
+      const headersMap = new Map<string, string>();
+      if (init?.headers) {
+        Object.entries(init.headers).forEach(([k, v]) => headersMap.set(k, v));
+      }
+      return {
+        status: init?.status || 200,
+        json: async () => data,
+        headers: {
+          get: (key: string) => headersMap.get(key) ?? null,
+          entries: () => headersMap.entries(),
+        },
+      };
+    },
+  },
+}));
+
+jest.mock("@/lib/env", () => ({
+  __esModule: true,
+  features: {
+    clientSideSearch: true,
+    searchV2: true,
+  },
+}));
+
+jest.mock("@/lib/search-params", () => ({
+  buildRawParamsFromSearchParams: jest.fn().mockReturnValue({}),
+  parseSearchParams: jest.fn().mockReturnValue({
+    requestedPage: 1,
+    filterParams: {},
+  }),
+}));
+
+jest.mock("@/lib/with-rate-limit-redis", () => ({
+  withRateLimitRedis: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/timeout-wrapper", () => ({
+  withTimeout: jest.fn((promise: Promise<unknown>) => promise),
+  DEFAULT_TIMEOUTS: { DATABASE: 10000 },
+}));
+
+jest.mock("@/lib/request-context", () => ({
+  createContextFromHeaders: jest
+    .fn()
+    .mockReturnValue({ requestId: "test-req-id" }),
+  runWithRequestContext: jest.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  getRequestId: jest.fn().mockReturnValue("test-req-id"),
+}));
+
+jest.mock("@/lib/search/search-v2-service", () => ({
+  executeSearchV2: jest.fn(),
+}));
+
+jest.mock("@/lib/data", () => ({
+  getListingsPaginated: jest.fn(),
+}));
+
+// Circuit breaker runs the wrapper callback inline so the route's own
+// admission/snapshot-vs-throw logic is exercised.
+jest.mock("@/lib/circuit-breaker", () => ({
+  circuitBreakers: {
+    searchV2: {
+      execute: jest.fn((fn: () => unknown) => fn()),
+    },
+  },
+  isCircuitOpenError: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock("@/lib/constants", () => ({
+  DEFAULT_PAGE_SIZE: 24,
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    sync: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+  },
+  sanitizeErrorMessage: jest.fn().mockReturnValue("sanitized"),
+}));
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock("@/lib/search-rate-limit-identifier", () => ({
+  getSearchRateLimitIdentifier: jest.fn().mockResolvedValue("127.0.0.1"),
+}));
+
+jest.mock("@/lib/search/search-response", () => ({
+  createSearchResponseMeta: jest.fn((_q: unknown, backendSource: string) => ({
+    queryHash: "test-hash",
+    backendSource,
+    responseVersion: "3",
+  })),
+  getSearchQueryHash: jest.fn().mockReturnValue("test-hash"),
+  SEARCH_RESPONSE_VERSION: "3",
+}));
+
+jest.mock("@/lib/search/search-query", () => ({
+  normalizeSearchQuery: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock("@/lib/search/testing/search-scenarios", () => ({
+  resolveSearchScenario: jest.fn().mockReturnValue(null),
+  buildScenarioSearchListState: jest.fn(),
+  SEARCH_SCENARIO_HEADER: "x-search-scenario",
+}));
+
+jest.mock("@/lib/search/search-telemetry", () => ({
+  recordSearchRequestLatency: jest.fn(),
+  recordSearchV2Fallback: jest.fn(),
+  recordSearchZeroResults: jest.fn(),
+}));
+
+jest.mock("@/lib/public-cache/headers", () => ({
+  buildPublicCacheHeadersForListings: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock("@/lib/search/public-listing-payload", () => ({
+  toPublicSearchListings: jest.fn((items: unknown) => items),
+}));
+
+// --- Imports (after mocks) ---
+
+import { GET } from "@/app/api/search/listings/route";
+import { executeSearchV2 } from "@/lib/search/search-v2-service";
+import { getListingsPaginated } from "@/lib/data";
+import { recordSearchV2Fallback } from "@/lib/search/search-telemetry";
+
+// --- Helpers ---
+
+function createGetRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/search/listings");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const req = new Request(url.toString(), { method: "GET" });
+  (req as any).nextUrl = url;
+  return req as any;
+}
+
+describe("GET /api/search/listings — P1-3 structured signals vs V1 fallback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getListingsPaginated as jest.Mock).mockResolvedValue({
+      items: [{ id: "listing-1" }],
+      total: 1,
+    });
+  });
+
+  it("returns 400 admission_rejected and does NOT fall back to V1 on an admission error", async () => {
+    (executeSearchV2 as jest.Mock).mockResolvedValue({
+      response: null,
+      paginatedResult: null,
+      admissionError: {
+        code: "requested_occupants_too_high",
+        message: "Too many occupants requested",
+        status: 400,
+      },
+    });
+
+    const res = await GET(createGetRequest());
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("admission_rejected");
+    expect(body.admissionError).toEqual(
+      expect.objectContaining({
+        code: "requested_occupants_too_high",
+        status: 400,
+      })
+    );
+    // V1 fallback must NOT run — the dedicated handler owns this response.
+    expect(getListingsPaginated).not.toHaveBeenCalled();
+    expect(recordSearchV2Fallback).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 snapshot_expired and does NOT fall back to V1 on an expired snapshot", async () => {
+    (executeSearchV2 as jest.Mock).mockResolvedValue({
+      response: null,
+      paginatedResult: null,
+      snapshotExpired: {
+        queryHash: "test-hash",
+        reason: "search_contract_changed",
+      },
+    });
+
+    const res = await GET(createGetRequest());
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("snapshot_expired");
+    expect(body.snapshotExpired).toEqual(
+      expect.objectContaining({ reason: "search_contract_changed" })
+    );
+    expect(getListingsPaginated).not.toHaveBeenCalled();
+    expect(recordSearchV2Fallback).not.toHaveBeenCalled();
+  });
+
+  it("falls back to V1 when the V2 search genuinely throws", async () => {
+    (executeSearchV2 as jest.Mock).mockRejectedValue(
+      new Error("boom: connection lost")
+    );
+
+    const res = await GET(createGetRequest());
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.kind).toBe("degraded");
+    expect(body.source).toBe("v1-fallback");
+    // Genuine failures still reach V1.
+    expect(getListingsPaginated).toHaveBeenCalledTimes(1);
+    expect(recordSearchV2Fallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/api/search/facets/route.test.ts
+++ b/src/__tests__/api/search/facets/route.test.ts
@@ -37,6 +37,14 @@ jest.mock("@/lib/with-rate-limit-redis", () => ({
   withRateLimitRedis: jest.fn().mockResolvedValue(null),
 }));
 
+// Mock the rate-limit identifier so the route (and this test) don't pull in
+// @/auth (next-auth ESM breaks the Jest transform). Both the route and the
+// top-level test import resolve to this same mock, so reference-equality
+// assertions on getIdentifier still hold.
+jest.mock("@/lib/search-rate-limit-identifier", () => ({
+  getSearchRateLimitIdentifier: jest.fn().mockResolvedValue("127.0.0.1"),
+}));
+
 // Mock request context
 jest.mock("@/lib/request-context", () => ({
   createContextFromHeaders: jest.fn().mockReturnValue({}),
@@ -77,6 +85,7 @@ const preImportListenerCount = process.listeners("unhandledRejection").length;
 
 import { GET } from "@/app/api/search/facets/route";
 import { prisma } from "@/lib/prisma";
+import { getSearchRateLimitIdentifier } from "@/lib/search-rate-limit-identifier";
 import type { NextRequest } from "next/server";
 
 const mockQueryRawUnsafe = prisma.$queryRawUnsafe as jest.Mock;
@@ -817,5 +826,96 @@ describe("cache key regression (gender filters)", () => {
     const none = await cacheKeyFor(boundsParams);
 
     expect(explicitAny).toBe(none);
+  });
+});
+
+describe("cache key bounds quantization (P2-5 cost amplification)", () => {
+  function queueEmptyFacetResults() {
+    // 4 queries when no price data (histogram skipped on null min/max):
+    // amenities, houseRules, roomTypes, priceRanges
+    mockQueryRawUnsafe
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ min: null, max: null, median: null }]);
+  }
+
+  // Runs one GET and returns the serialized filter portion of the
+  // unstable_cache key (["search-facets", <key>]) it was invoked with.
+  async function cacheKeyFor(params: Record<string, string>): Promise<string> {
+    const { unstable_cache } = await import("next/cache");
+    const mockUnstableCache = jest.mocked(unstable_cache);
+    const callsBefore = mockUnstableCache.mock.calls.length;
+    queueEmptyFacetResults();
+    await GET(createRequest(params));
+    const call = mockUnstableCache.mock.calls[callsBefore];
+    expect(call).toBeDefined();
+    const keyParts = call[1] as unknown as string[];
+    return keyParts[1];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecuteRawUnsafe.mockResolvedValue(undefined);
+  });
+
+  it("coalesces sub-quantization-step pans onto one cache entry", async () => {
+    // Two bounds differing only in the 4th decimal (< BOUNDS_EPSILON=0.001,
+    // ~100m). The old toFixed(4) key (~11m) treated these as distinct and
+    // busted the cache on every jitter; the quantized key must coalesce them.
+    const a = await cacheKeyFor({
+      minLng: "-97.8003",
+      maxLng: "-97.6003",
+      minLat: "30.2003",
+      maxLat: "30.4003",
+    });
+    const b = await cacheKeyFor({
+      minLng: "-97.8001",
+      maxLng: "-97.6001",
+      minLat: "30.2001",
+      maxLat: "30.4001",
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it("keys a full-quantization-step pan to a distinct cache entry", async () => {
+    const base = await cacheKeyFor({
+      minLng: "-97.8003",
+      maxLng: "-97.6003",
+      minLat: "30.2003",
+      maxLat: "30.4003",
+    });
+    // minLng shifted by a full BOUNDS_EPSILON step → different ~100m cell
+    const shifted = await cacheKeyFor({
+      minLng: "-97.8013",
+      maxLng: "-97.6003",
+      minLat: "30.2003",
+      maxLat: "30.4003",
+    });
+
+    expect(shifted).not.toBe(base);
+  });
+});
+
+describe("rate limit identity (P2-5 shared-NAT starvation)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keys the search-count bucket by ip:userId via getSearchRateLimitIdentifier", async () => {
+    const { withRateLimitRedis } = await import("@/lib/with-rate-limit-redis");
+
+    // Empty request hits the unbounded early-return, but the rate-limit check
+    // runs first and unconditionally — that's what we assert on.
+    await GET(createRequest());
+
+    expect(withRateLimitRedis).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: "search-count",
+        getIdentifier: getSearchRateLimitIdentifier,
+      })
+    );
   });
 });

--- a/src/__tests__/components/search/SearchResultsClient.test.tsx
+++ b/src/__tests__/components/search/SearchResultsClient.test.tsx
@@ -1087,6 +1087,74 @@ describe("SearchResultsClient", () => {
     });
   });
 
+  describe("load-more terminal focus (P2-15, WCAG 2.4.3)", () => {
+    it("moves focus to the end-of-results message when the focused button unmounts", async () => {
+      const mockFetch = fetchMoreListings as jest.Mock;
+      mockFetch.mockResolvedValueOnce({
+        items: [createMockListing("3")],
+        nextCursor: null,
+        hasNextPage: false,
+      });
+
+      render(<SearchResultsClient {...defaultProps} />);
+
+      const loadMoreButton = screen.getByRole("button", { name: /show more/i });
+      loadMoreButton.focus();
+      expect(loadMoreButton).toHaveFocus();
+
+      fireEvent.click(loadMoreButton);
+
+      const terminal = await screen.findByText(/you've seen all/i);
+      expect(terminal).toHaveFocus();
+    });
+
+    it("moves focus to the refine nudge when the cap is reached with the button focused", async () => {
+      const initialListings = Array.from({ length: 55 }, (_, i) =>
+        createMockListing(`initial-${i}`)
+      );
+      const mockFetch = fetchMoreListings as jest.Mock;
+      mockFetch.mockResolvedValueOnce({
+        items: Array.from({ length: 10 }, (_, i) => createMockListing(`new-${i}`)),
+        nextCursor: "cursor-2",
+        hasNextPage: true,
+      });
+
+      render(
+        <SearchResultsClient
+          {...defaultProps}
+          initialListings={initialListings}
+          initialTotal={100}
+        />
+      );
+
+      const loadMoreButton = screen.getByRole("button", { name: /show more/i });
+      loadMoreButton.focus();
+      fireEvent.click(loadMoreButton);
+
+      const nudge = await screen.findByText(/adjusting your filters/i);
+      expect(nudge).toHaveFocus();
+    });
+
+    it("does not move focus when the button was not the active element", async () => {
+      const mockFetch = fetchMoreListings as jest.Mock;
+      mockFetch.mockResolvedValueOnce({
+        items: [createMockListing("3")],
+        nextCursor: null,
+        hasNextPage: false,
+      });
+
+      render(<SearchResultsClient {...defaultProps} />);
+
+      // Simulate a mouse user: click without the button holding keyboard focus.
+      const loadMoreButton = screen.getByRole("button", { name: /show more/i });
+      expect(loadMoreButton).not.toHaveFocus();
+      fireEvent.click(loadMoreButton);
+
+      const terminal = await screen.findByText(/you've seen all/i);
+      expect(terminal).not.toHaveFocus();
+    });
+  });
+
   describe("loading state", () => {
     it("shows loading indicator while fetching", async () => {
       const mockFetch = fetchMoreListings as jest.Mock;

--- a/src/__tests__/lib/outbox/handlers.test.ts
+++ b/src/__tests__/lib/outbox/handlers.test.ts
@@ -418,6 +418,227 @@ describe("HANDLERS.IDENTITY_MUTATION", () => {
   });
 });
 
+describe("HANDLERS.IDENTITY_MUTATION reprojection (P2-8)", () => {
+  // Seed the post-mutation stranded state: physical_units already at `newEpoch`
+  // (recordIdentityMutation bumped it) while the inventory + projection rows are
+  // still at `oldEpoch`. When oldEpoch === newEpoch the unit is fully consistent.
+  async function seedStrandedUnit(opts: {
+    unitId: string;
+    newEpoch: number;
+    oldEpoch: number;
+    sourceVersion?: bigint;
+  }): Promise<string> {
+    const { unitId, newEpoch, oldEpoch } = opts;
+    const sourceVersion = opts.sourceVersion ?? BigInt(5);
+    const canonHash = `hash-${unitId}`;
+    await fixture.insertPhysicalUnit({
+      id: unitId,
+      canonicalAddressHash: canonHash,
+      unitIdentityEpoch: newEpoch,
+    });
+    const invId = await fixture.insertListingInventory({
+      unitId,
+      canonicalAddressHash: canonHash,
+      roomCategory: "PRIVATE_ROOM",
+      capacityGuests: 2,
+    });
+    await fixture.query(
+      `UPDATE listing_inventories
+         SET publish_status = 'PUBLISHED',
+             source_version = $2,
+             unit_identity_epoch_written_at = $3
+       WHERE id = $1`,
+      [invId, Number(sourceVersion), oldEpoch]
+    );
+    await fixture.insertInventorySearchProjection({
+      id: invId,
+      inventoryId: invId,
+      unitId,
+      unitIdentityEpoch: oldEpoch,
+      publishStatus: "PUBLISHED",
+      sourceVersion,
+    });
+    await fixture.insertUnitPublicProjection({
+      unitId,
+      unitIdentityEpoch: oldEpoch,
+      fromPrice: 1000,
+      roomCategories: ["PRIVATE_ROOM"],
+      matchingInventoryCount: 1,
+      sourceVersion,
+    });
+    return invId;
+  }
+
+  function mergeEvent(opts: {
+    id: string;
+    fromUnitIds: string[];
+    toUnitIds: string[];
+    epoch: number;
+  }): OutboxRow {
+    return makeEvent({
+      kind: "IDENTITY_MUTATION",
+      aggregateType: "IDENTITY_MUTATION",
+      aggregateId: opts.id,
+      payload: {
+        kind: "MERGE",
+        fromUnitIds: opts.fromUnitIds,
+        toUnitIds: opts.toUnitIds,
+      },
+      unitIdentityEpoch: opts.epoch,
+    });
+  }
+
+  it("re-points a merged unit's inventories to the new epoch and rebuilds its public projection there", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const fromUnitId = `unit-rp-from-${suffix}`;
+    const toUnitId = `unit-rp-to-${suffix}`;
+    const fromInv = await seedStrandedUnit({
+      unitId: fromUnitId,
+      newEpoch: 2,
+      oldEpoch: 1,
+    });
+    const toInv = await seedStrandedUnit({
+      unitId: toUnitId,
+      newEpoch: 2,
+      oldEpoch: 1,
+    });
+
+    const result = await withTx((tx) =>
+      HANDLERS.IDENTITY_MUTATION(
+        tx,
+        mergeEvent({
+          id: `mutation-rp-${suffix}`,
+          fromUnitIds: [fromUnitId],
+          toUnitIds: [toUnitId],
+          epoch: 2,
+        })
+      )
+    );
+    expect(result.outcome).toBe("completed");
+
+    const isp = await fixture.getInventorySearchProjections();
+    expect(isp.find((r) => r.inventoryId === fromInv)?.unitIdentityEpoch).toBe(2);
+    expect(isp.find((r) => r.inventoryId === toInv)?.unitIdentityEpoch).toBe(2);
+    // No inventory projection rows left stranded at the old epoch.
+    expect(
+      isp.filter(
+        (r) =>
+          (r.unitId === fromUnitId || r.unitId === toUnitId) &&
+          r.unitIdentityEpoch === 1
+      )
+    ).toHaveLength(0);
+
+    const upp = await fixture.getUnitPublicProjections();
+    const fromRows = upp.filter((r) => r.unitId === fromUnitId);
+    const toRows = upp.filter((r) => r.unitId === toUnitId);
+    // Exactly one unit row each, at the new epoch, aggregating the inventory —
+    // the pre-mutation epoch-1 row is gone (not orphaned).
+    expect(fromRows).toHaveLength(1);
+    expect(fromRows[0].unitIdentityEpoch).toBe(2);
+    expect(fromRows[0].matchingInventoryCount).toBe(1);
+    expect(toRows).toHaveLength(1);
+    expect(toRows[0].unitIdentityEpoch).toBe(2);
+    expect(toRows[0].matchingInventoryCount).toBe(1);
+  });
+
+  it("is idempotent when the identity mutation event is retried", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const unitId = `unit-rp-idem-${suffix}`;
+    const invId = await seedStrandedUnit({
+      unitId,
+      newEpoch: 2,
+      oldEpoch: 1,
+      sourceVersion: BigInt(5),
+    });
+    const event = mergeEvent({
+      id: `mutation-idem-${suffix}`,
+      fromUnitIds: [unitId],
+      toUnitIds: [unitId],
+      epoch: 2,
+    });
+
+    await withTx((tx) => HANDLERS.IDENTITY_MUTATION(tx, event));
+    const afterFirst = await fixture.query<{
+      unit_identity_epoch_written_at: number | string;
+      source_version: number | string;
+      row_version: number | string;
+    }>(
+      `SELECT unit_identity_epoch_written_at, source_version, row_version
+       FROM listing_inventories WHERE id = $1`,
+      [invId]
+    );
+
+    // Retry the same event — must not churn versions or duplicate rows.
+    await withTx((tx) => HANDLERS.IDENTITY_MUTATION(tx, event));
+    const afterRetry = await fixture.query<{
+      unit_identity_epoch_written_at: number | string;
+      source_version: number | string;
+      row_version: number | string;
+    }>(
+      `SELECT unit_identity_epoch_written_at, source_version, row_version
+       FROM listing_inventories WHERE id = $1`,
+      [invId]
+    );
+
+    expect(Number(afterRetry[0].unit_identity_epoch_written_at)).toBe(2);
+    // Host-version counter is never bumped by the re-point.
+    expect(Number(afterFirst[0].source_version)).toBe(5);
+    expect(Number(afterRetry[0].source_version)).toBe(5);
+    // row_version advanced once (the re-point) and stays put on retry.
+    expect(Number(afterRetry[0].row_version)).toBe(
+      Number(afterFirst[0].row_version)
+    );
+
+    const isp = (await fixture.getInventorySearchProjections()).filter(
+      (r) => r.unitId === unitId
+    );
+    expect(isp).toHaveLength(1);
+    expect(isp[0].unitIdentityEpoch).toBe(2);
+    expect(isp[0].sourceVersion).toBe(BigInt(5));
+
+    const upp = (await fixture.getUnitPublicProjections()).filter(
+      (r) => r.unitId === unitId
+    );
+    expect(upp).toHaveLength(1);
+    expect(upp[0].unitIdentityEpoch).toBe(2);
+    expect(upp[0].matchingInventoryCount).toBe(1);
+  });
+
+  it("skips a unit that has already advanced past the event epoch", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const unitId = `unit-rp-stale-${suffix}`;
+    // Unit + projections already consistent at epoch 3 (a later mutation ran).
+    await seedStrandedUnit({ unitId, newEpoch: 3, oldEpoch: 3 });
+
+    // A stale IDENTITY_MUTATION event from the earlier epoch-2 mutation.
+    const result = await withTx((tx) =>
+      HANDLERS.IDENTITY_MUTATION(
+        tx,
+        mergeEvent({
+          id: `mutation-stale-${suffix}`,
+          fromUnitIds: [unitId],
+          toUnitIds: [unitId],
+          epoch: 2,
+        })
+      )
+    );
+    expect(result.outcome).toBe("completed");
+
+    // Nothing re-pointed: no epoch-2 rows created, epoch-3 state untouched.
+    const isp = (await fixture.getInventorySearchProjections()).filter(
+      (r) => r.unitId === unitId
+    );
+    expect(isp).toHaveLength(1);
+    expect(isp[0].unitIdentityEpoch).toBe(3);
+
+    const upp = (await fixture.getUnitPublicProjections()).filter(
+      (r) => r.unitId === unitId
+    );
+    expect(upp).toHaveLength(1);
+    expect(upp[0].unitIdentityEpoch).toBe(3);
+  });
+});
+
 describe("HANDLERS error branches", () => {
   it("INVENTORY_UPSERTED returns transient_error when DB throws", async () => {
     // Use a broken tx that throws

--- a/src/__tests__/lib/search-params.test.ts
+++ b/src/__tests__/lib/search-params.test.ts
@@ -398,6 +398,32 @@ describe("parseSearchParams - booking mode cases", () => {
   });
 });
 
+describe("parseSearchParams - occupants/capacity cases (P2-4)", () => {
+  const cases: Array<[string, Record<string, string>, number | undefined]> = [
+    ["minSlots", { minSlots: "3" }, 3],
+    ["minAvailableSlots legacy alias", { minAvailableSlots: "3" }, 3],
+    ["occupants alias", { occupants: "3" }, 3],
+    ["guests alias", { guests: "3" }, 3],
+    ["requestedOccupants alias", { requestedOccupants: "3" }, 3],
+    ["requested_occupants alias", { requested_occupants: "3" }, 3],
+    // Occupants aliases take precedence over minSlots when both present.
+    ["occupants beats minSlots", { occupants: "4", minSlots: "2" }, 4],
+    // >20 is clamped away by the normalizer (admission layer 400s it separately).
+    ["above cap dropped", { occupants: "21" }, undefined],
+  ];
+
+  test.each(cases)("%s", (_label, raw, expected) => {
+    const result = parseSearchParams(raw);
+    expect(result.filterParams.minAvailableSlots).toBe(expected);
+  });
+
+  it("occupants=3 and minSlots=3 resolve to the same canonical capacity", () => {
+    expect(parseSearchParams({ occupants: "3" }).filterParams.minAvailableSlots).toBe(
+      parseSearchParams({ minSlots: "3" }).filterParams.minAvailableSlots
+    );
+  });
+});
+
 describe("parseSearchParams - date cases", () => {
   const cases: Array<[string, string | undefined, string | undefined]> = [
     ["today valid", today, today],

--- a/src/__tests__/lib/search/cursor.test.ts
+++ b/src/__tests__/lib/search/cursor.test.ts
@@ -67,6 +67,24 @@ describe("search/cursor", () => {
       expect(decoded).toEqual(cursor);
     });
 
+    it("should round-trip a V2 cursor carrying a filter-bound qh (P2-20)", () => {
+      const cursor: KeysetCursor = {
+        v: 2,
+        s: "recommended",
+        k: ["85.50", "2024-01-15T10:00:00.000Z"],
+        id: "clxqh",
+        snapshot: { ...snapshot, qh: "abcdef1234567890" },
+      };
+
+      const encoded = encodeKeysetCursor(cursor);
+      const decoded = decodeKeysetCursor(encoded);
+
+      expect(decoded).toEqual(cursor);
+      expect(decoded?.v === 2 ? decoded.snapshot.qh : undefined).toBe(
+        "abcdef1234567890"
+      );
+    });
+
     it("should encode and decode snapshot cursor", () => {
       const cursor = {
         v: 3 as const,

--- a/src/__tests__/lib/search/hybrid-count-threshold.test.ts
+++ b/src/__tests__/lib/search/hybrid-count-threshold.test.ts
@@ -42,6 +42,22 @@ const mockExecuteRawUnsafe = prisma.$executeRawUnsafe as jest.Mock;
 
 // Note: HYBRID_COUNT_THRESHOLD = 100 in source (see file header for details)
 
+// This suite validates the raw LIMIT-101 count contract — the dedup-off path
+// prod runs. Pin FEATURE_SEARCH_LISTING_DEDUP off so the dev-default dedup-aware
+// count (canonical grouping) doesn't reshape the raw counts under test. Dedup
+// counting is covered separately in search-doc-queries.test.ts.
+const ORIGINAL_DEDUP_FLAG = process.env.FEATURE_SEARCH_LISTING_DEDUP;
+beforeAll(() => {
+  process.env.FEATURE_SEARCH_LISTING_DEDUP = "false";
+});
+afterAll(() => {
+  if (ORIGINAL_DEDUP_FLAG === undefined) {
+    delete process.env.FEATURE_SEARCH_LISTING_DEDUP;
+  } else {
+    process.env.FEATURE_SEARCH_LISTING_DEDUP = ORIGINAL_DEDUP_FLAG;
+  }
+});
+
 describe("hybrid-count-threshold", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -316,5 +332,70 @@ describe("hybrid-count-threshold", () => {
       expect(queryCall).toContain("LIMIT 101");
       expect(queryCall).toContain("SELECT COUNT(*)");
     });
+  });
+});
+
+describe("dedup-aware limited count (P2-6)", () => {
+  const validBounds = {
+    minLat: 37.7,
+    maxLat: 37.8,
+    minLng: -122.5,
+    maxLng: -122.4,
+  };
+
+  function dedupCountRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "row-1",
+      ownerId: "owner-1",
+      normalizedAddress: "123 main st, sf, ca 94102",
+      price: 1500,
+      title: "Bright Room",
+      roomType: "private",
+      address: "123 Main St",
+      city: "San Francisco",
+      state: "CA",
+      zip: "94102",
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FEATURE_SEARCH_LISTING_DEDUP = "true";
+  });
+
+  afterEach(() => {
+    process.env.FEATURE_SEARCH_LISTING_DEDUP = "false";
+  });
+
+  it("counts distinct canonicals — total is <= raw row count when siblings collapse", async () => {
+    // Three raw rows, two of which share owner+address+price+title+roomType
+    // (canonical + sibling) → two distinct canonical groups.
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([
+      dedupCountRow({ id: "a" }),
+      dedupCountRow({ id: "b" }),
+      dedupCountRow({ id: "c", ownerId: "owner-2", title: "Loft", price: 2400 }),
+    ]);
+
+    const result = await getSearchDocLimitedCount({ bounds: validBounds });
+
+    expect(result).toBe(2);
+
+    // Confirms it took the dedup path, not the raw COUNT(*) subquery.
+    const sql = (prisma.$queryRawUnsafe as jest.Mock).mock.calls[0][0];
+    expect(sql).not.toContain("SELECT COUNT(*)");
+    expect(sql).toContain('l."ownerId"');
+    expect(sql).toContain("LIMIT 101");
+  });
+
+  it("returns null (100+) when raw rows exceed the threshold", async () => {
+    const overflow = Array.from({ length: 101 }, (_, i) =>
+      dedupCountRow({ id: `row-${i}`, ownerId: `owner-${i}`, title: `T${i}` })
+    );
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue(overflow);
+
+    const result = await getSearchDocLimitedCount({ bounds: validBounds });
+
+    expect(result).toBeNull();
   });
 });

--- a/src/__tests__/lib/search/projection-search.test.ts
+++ b/src/__tests__/lib/search/projection-search.test.ts
@@ -79,6 +79,10 @@ function projectionRow(overrides: Record<string, unknown> = {}) {
     display_title: overrides.display_title ?? `Room in ${unitId}`,
     display_subtitle: overrides.display_subtitle ?? "Projection-safe summary",
     hero_image_url: overrides.hero_image_url ?? null,
+    representative_status: overrides.representative_status ?? "ACTIVE",
+    representative_status_reason:
+      overrides.representative_status_reason ?? null,
+    last_confirmed_at: overrides.last_confirmed_at ?? null,
     projection_epoch: overrides.projection_epoch ?? BigInt(1),
     source_version: overrides.source_version ?? BigInt(1),
   };
@@ -822,6 +826,108 @@ describe("Phase 04 projection search", () => {
         code: "projection_read_unsupported",
         unsupportedReasons: ["amenities"],
       },
+    });
+  });
+
+  // Regression (P1-4): gender/household-gender filters must use strict equality
+  // (matching the SearchDoc engine), so a row with an unspecified (NULL)
+  // preference is excluded rather than included. Cross-engine parity.
+  it("filters gender/household-gender with strict equality (excludes NULL-preference rows)", async () => {
+    mockQueryRawUnsafe.mockResolvedValueOnce([projectionRow()]);
+
+    await executeProjectionSearchV2({
+      parsed: parsed({
+        sortOption: "price_asc",
+        filterParams: {
+          sort: "price_asc",
+          genderPreference: "female",
+          householdGender: "female",
+        },
+      }),
+      params: { rawParams: {}, limit: 12 },
+    });
+
+    const sql = String(mockQueryRawUnsafe.mock.calls[0][0]);
+    expect(sql).toContain("isp.gender_preference = $");
+    expect(sql).toContain("isp.household_gender = $");
+    expect(sql).not.toContain("isp.gender_preference IS NULL");
+    expect(sql).not.toContain("isp.household_gender IS NULL");
+  });
+
+  // Regression (P2-7): the default move-in match is exact (0-day gap), matching
+  // the SearchDoc engine; an explicit max_gap_days is honored as a near-match
+  // window. The gap-days value is bound as the SQL param following the move-in
+  // date param.
+  it("uses an exact move-in match by default and honors an explicit max_gap_days", async () => {
+    mockQueryRawUnsafe.mockResolvedValueOnce([projectionRow()]);
+    await executeProjectionSearchV2({
+      parsed: parsed({
+        sortOption: "price_asc",
+        filterParams: { sort: "price_asc", moveInDate: "2026-05-01" },
+      }),
+      params: { rawParams: {}, limit: 12 },
+    });
+    const defaultArgs = mockQueryRawUnsafe.mock.calls[0].slice(1);
+    const defaultMoveInIdx = defaultArgs.indexOf("2026-05-01");
+    expect(defaultMoveInIdx).toBeGreaterThanOrEqual(0);
+    expect(defaultArgs[defaultMoveInIdx + 1]).toBe(0);
+
+    jest.clearAllMocks();
+    createSnapshotMock();
+    mockQueryRawUnsafe.mockResolvedValueOnce([projectionRow()]);
+    await executeProjectionSearchV2({
+      parsed: parsed({
+        sortOption: "price_asc",
+        filterParams: { sort: "price_asc", moveInDate: "2026-05-01" },
+      }),
+      params: { rawParams: { max_gap_days: "45" }, limit: 12 },
+    });
+    const explicitArgs = mockQueryRawUnsafe.mock.calls[0].slice(1);
+    const explicitMoveInIdx = explicitArgs.indexOf("2026-05-01");
+    expect(explicitMoveInIdx).toBeGreaterThanOrEqual(0);
+    expect(explicitArgs[explicitMoveInIdx + 1]).toBe(45);
+  });
+
+  // Regression (P2-11): projection list items must carry the RESOLVED
+  // public-availability shape (freshnessBucket/publicStatus/searchEligible), the
+  // same object the SearchDoc engine emits, so dev and prod render identical
+  // freshness UI.
+  it("emits the resolved public-availability shape for projection list items", async () => {
+    mockQueryRawUnsafe.mockResolvedValueOnce([
+      projectionRow({
+        unit_id: "unit-a",
+        representative_inventory_id: "inv-a1",
+        representative_status: "ACTIVE",
+        last_confirmed_at: null,
+      }),
+    ]);
+
+    const result = await executeProjectionSearchV2({
+      parsed: parsed({
+        sortOption: "price_asc",
+        filterParams: { sort: "price_asc" },
+      }),
+      params: { rawParams: {}, limit: 12 },
+    });
+
+    // Raw ListingData (pre public-payload boundary) carries the FULL resolved
+    // read-model, including the internal searchEligible flag.
+    const resolved = result.paginatedResult?.items?.[0]?.publicAvailability;
+    expect(resolved).toMatchObject({
+      availabilitySource: "HOST_MANAGED",
+      publicStatus: "AVAILABLE",
+      freshnessBucket: "UNCONFIRMED",
+      searchEligible: true,
+    });
+
+    // The public payload keeps the UI-consumed display fields
+    // (freshnessBucket/publicStatus) so dev renders the same freshness UI as prod.
+    const publicAvailability =
+      result.response?.list.fullItems?.[0]?.publicAvailability;
+    expect(publicAvailability).toMatchObject({
+      availabilitySource: "HOST_MANAGED",
+      publicStatus: "AVAILABLE",
+      freshnessBucket: "UNCONFIRMED",
     });
   });
 });

--- a/src/__tests__/lib/search/public-availability.test.ts
+++ b/src/__tests__/lib/search/public-availability.test.ts
@@ -1,8 +1,10 @@
 import {
+  buildHostManagedPublicAvailability,
   buildPublicAvailability,
   isListingEligibleForPublicSearch,
   resolvePublicAvailability,
   resolvePublicAvailabilityForListings,
+  toPublicAvailabilityPayload,
 } from "@/lib/search/public-availability";
 
 describe("search/public-availability", () => {
@@ -459,5 +461,54 @@ describe("search/public-availability", () => {
     expect(resolved.get("legacy-1")?.searchEligible).toBe(false);
     expect(resolved.get("host-1")?.availabilitySource).toBe("HOST_MANAGED");
     expect(resolved.get("host-1")?.effectiveAvailableSlots).toBe(2);
+  });
+
+  describe("toPublicAvailabilityPayload", () => {
+    it("keeps only the nine public fields from a fully resolved availability", () => {
+      const resolved = buildHostManagedPublicAvailability(
+        {
+          status: "ACTIVE",
+          statusReason: null,
+          availabilitySource: "HOST_MANAGED",
+          openSlots: 2,
+          totalSlots: 4,
+          moveInDate: "2026-06-01",
+          availableUntil: "2026-12-01",
+          minStayMonths: 3,
+          lastConfirmedAt: "2026-04-15T12:30:00.000Z",
+        },
+        new Date("2026-04-20T00:00:00.000Z")
+      );
+
+      // Guard the premise: the resolved object carries the internal fields.
+      expect(resolved.searchEligible).toBe(true);
+      expect(resolved.staleAt).not.toBeNull();
+
+      expect(toPublicAvailabilityPayload(resolved)).toEqual({
+        availabilitySource: "HOST_MANAGED",
+        openSlots: 2,
+        totalSlots: 4,
+        availableFrom: "2026-06-01",
+        availableUntil: "2026-12-01",
+        minStayMonths: 3,
+        lastConfirmedAt: "2026-04-15T12:30:00.000Z",
+        freshnessBucket: "NORMAL",
+        publicStatus: "AVAILABLE",
+      });
+    });
+
+    it("passes a narrow availability through without adding freshness fields", () => {
+      const narrow = buildPublicAvailability({
+        availableSlots: 1,
+        totalSlots: 2,
+      });
+      const payload = toPublicAvailabilityPayload(narrow);
+
+      expect(payload).toEqual(narrow);
+      expect(payload.freshnessBucket).toBeUndefined();
+      expect(payload.publicStatus).toBeUndefined();
+      expect(Object.keys(payload)).not.toContain("freshnessBucket");
+      expect(Object.keys(payload)).not.toContain("publicStatus");
+    });
   });
 });

--- a/src/__tests__/lib/search/public-listing-payload.test.ts
+++ b/src/__tests__/lib/search/public-listing-payload.test.ts
@@ -5,7 +5,10 @@ import {
   toPublicSearchListing,
 } from "@/lib/search/public-listing-payload";
 import type { ListingData, MapListingData } from "@/lib/search-types";
-import { buildPublicAvailability } from "@/lib/search/public-availability";
+import {
+  buildHostManagedPublicAvailability,
+  buildPublicAvailability,
+} from "@/lib/search/public-availability";
 
 function makeListing(overrides: Partial<ListingData> = {}): ListingData {
   const listing: ListingData = {
@@ -155,5 +158,84 @@ describe("public listing payload sanitizer", () => {
     expect(publicMapListing.groupKey).not.toContain("unit-secret-map");
     expect(publicMapListing.hostIdentityStatus).toBe("unverified");
     expect(publicMapListing.statusReason).toBeNull();
+  });
+
+  describe("public availability payload boundary (P2-12)", () => {
+    const PUBLIC_AVAILABILITY_KEYS = [
+      "availabilitySource",
+      "openSlots",
+      "totalSlots",
+      "availableFrom",
+      "availableUntil",
+      "minStayMonths",
+      "lastConfirmedAt",
+      "freshnessBucket",
+      "publicStatus",
+    ];
+    const INTERNAL_AVAILABILITY_KEYS = [
+      "staleAt",
+      "autoPauseAt",
+      "searchEligible",
+      "isValid",
+      "isPubliclyAvailable",
+      "effectiveAvailableSlots",
+    ];
+
+    const resolvedAvailability = () =>
+      buildHostManagedPublicAvailability(
+        {
+          status: "ACTIVE",
+          statusReason: null,
+          availabilitySource: "HOST_MANAGED",
+          openSlots: 2,
+          totalSlots: 4,
+          moveInDate: "2026-06-01",
+          availableUntil: "2026-12-01",
+          minStayMonths: 3,
+          lastConfirmedAt: "2026-04-15T12:30:00.000Z",
+        },
+        new Date("2026-04-20T00:00:00.000Z")
+      );
+
+    it("keeps only public availability fields on browser-visible search cards", () => {
+      const serialized = JSON.parse(
+        JSON.stringify(
+          toPublicSearchListing(
+            makeListing({ publicAvailability: resolvedAvailability() })
+          )
+        )
+      );
+
+      expect(Object.keys(serialized.publicAvailability).sort()).toEqual(
+        [...PUBLIC_AVAILABILITY_KEYS].sort()
+      );
+      for (const key of INTERNAL_AVAILABILITY_KEYS) {
+        expect(serialized.publicAvailability[key]).toBeUndefined();
+      }
+    });
+
+    it("keeps only public availability fields on map listings", () => {
+      const mapListing: MapListingData = {
+        id: "map-resolved-1",
+        title: "Map resolved",
+        price: 1400,
+        availableSlots: 2,
+        totalSlots: 4,
+        images: ["map.jpg"],
+        location: { lat: 30.26721, lng: -97.74312 },
+        publicAvailability: resolvedAvailability(),
+      };
+
+      const serialized = JSON.parse(
+        JSON.stringify(toPublicMapListing(mapListing))
+      );
+
+      expect(Object.keys(serialized.publicAvailability).sort()).toEqual(
+        [...PUBLIC_AVAILABILITY_KEYS].sort()
+      );
+      for (const key of INTERNAL_AVAILABILITY_KEYS) {
+        expect(serialized.publicAvailability[key]).toBeUndefined();
+      }
+    });
   });
 });

--- a/src/__tests__/lib/search/query-hash-semantic-equivalence.test.ts
+++ b/src/__tests__/lib/search/query-hash-semantic-equivalence.test.ts
@@ -19,6 +19,11 @@ import {
   generateSearchQueryHash,
   type HashableSearchQuery,
 } from "@/lib/search/query-hash";
+import {
+  parseSearchParams,
+  buildRawParamsFromSearchParams,
+  type RawSearchParams,
+} from "@/lib/search-params";
 
 const FUTURE_MOVE_IN_DATE = "2027-02-01";
 const CFM_604_URL_PARITY_CASES = [
@@ -140,6 +145,69 @@ describe("query-hash semantic equivalence (CFM-403)", () => {
         expect(canonicalize(legacy)).toBe(canonicalize(canonical));
       }
     );
+
+    it.each([
+      ["occupants=3", "minSlots=3"],
+      ["guests=3", "minSlots=3"],
+      ["requested_occupants=3", "minSlots=3"],
+      ["requestedOccupants=3", "minSlots=3"],
+    ])(
+      "occupants alias %s hashes identically to canonical %s (P2-4)",
+      (alias, canonical) => {
+        expect(hashOf(alias)).toBe(hashOf(canonical));
+      }
+    );
+  });
+
+  describe("cross-surface hash parity — service vs client (P1-5)", () => {
+    // The service used to fold embeddingVersion into meta.queryHash for semantic
+    // searches; the client hashes bare filters, so every semantic response was
+    // discarded as a hash mismatch. The service now hashes the SAME bare filter
+    // set the client does. Rebuild the service-side hash input here (bare, no
+    // version tokens) and assert it equals the client's getSearchQueryHash.
+    function serviceQueryHash(url: string): string {
+      const params = new URLSearchParams(url.startsWith("?") ? url : `?${url}`);
+      const parsed = parseSearchParams(
+        buildRawParamsFromSearchParams(params) as RawSearchParams
+      );
+      return generateSearchQueryHash({
+        query: parsed.filterParams.query,
+        vibeQuery: parsed.filterParams.vibeQuery,
+        minPrice: parsed.filterParams.minPrice,
+        maxPrice: parsed.filterParams.maxPrice,
+        amenities: parsed.filterParams.amenities,
+        houseRules: parsed.filterParams.houseRules,
+        languages: parsed.filterParams.languages,
+        roomType: parsed.filterParams.roomType,
+        leaseDuration: parsed.filterParams.leaseDuration,
+        moveInDate: parsed.filterParams.moveInDate,
+        endDate: parsed.filterParams.endDate,
+        genderPreference: parsed.filterParams.genderPreference,
+        householdGender: parsed.filterParams.householdGender,
+        bookingMode: parsed.filterParams.bookingMode,
+        minAvailableSlots: parsed.filterParams.minAvailableSlots,
+        bounds: parsed.filterParams.bounds,
+        nearMatches: parsed.filterParams.nearMatches,
+      });
+    }
+
+    it.each([
+      "what=cozy+sunlit+loft&minLat=37.7&maxLat=37.85&minLng=-122.52&maxLng=-122.35",
+      "q=boston&minPrice=1000&roomType=private&minLat=42.3&maxLat=42.4&minLng=-71.1&maxLng=-71.0",
+      "occupants=2&minLat=37.7&maxLat=37.85&minLng=-122.52&maxLng=-122.35",
+    ])("service hash equals client getSearchQueryHash for %s", (url) => {
+      expect(serviceQueryHash(url)).toBe(hashOf(url));
+    });
+
+    it("an embeddingVersion token would change the hash (so the service must not add it)", () => {
+      const base: HashableSearchQuery = {
+        vibeQuery: "cozy loft",
+        bounds: { minLat: 37.7, maxLat: 37.85, minLng: -122.52, maxLng: -122.35 },
+      };
+      expect(generateSearchQueryHash(base)).not.toBe(
+        generateSearchQueryHash({ ...base, embeddingVersion: "embed-v1" })
+      );
+    });
   });
 
   describe("counter cases — MUST hash differently", () => {

--- a/src/__tests__/lib/search/query-snapshots.test.ts
+++ b/src/__tests__/lib/search/query-snapshots.test.ts
@@ -3,6 +3,7 @@ jest.mock("@/lib/prisma", () => ({
     querySnapshot: {
       create: jest.fn(),
       findUnique: jest.fn(),
+      deleteMany: jest.fn(),
     },
   },
 }));
@@ -10,6 +11,7 @@ jest.mock("@/lib/prisma", () => ({
 import { prisma } from "@/lib/prisma";
 import {
   createQuerySnapshot,
+  deleteExpiredQuerySnapshots,
   loadValidQuerySnapshot,
   PHASE04_SNAPSHOT_VERSION,
   QUERY_SNAPSHOT_MAX_LISTING_IDS,
@@ -19,6 +21,7 @@ import {
 
 const mockCreate = (prisma.querySnapshot.create as jest.Mock);
 const mockFindUnique = (prisma.querySnapshot.findUnique as jest.Mock);
+const mockDeleteMany = (prisma.querySnapshot.deleteMany as jest.Mock);
 
 describe("query snapshots", () => {
   beforeEach(() => {
@@ -152,6 +155,20 @@ describe("query snapshots", () => {
     await expect(loadValidQuerySnapshot("expired")).resolves.toEqual({
       ok: false,
       reason: "snapshot_expired",
+    });
+  });
+
+  it("reaps only snapshots whose TTL has elapsed, keeping unexpired rows (P2-19)", async () => {
+    const now = new Date("2026-07-02T00:00:00.000Z");
+    mockDeleteMany.mockResolvedValue({ count: 3 });
+
+    const deleted = await deleteExpiredQuerySnapshots(now);
+
+    expect(deleted).toBe(3);
+    // `expiresAt < now` deletes expired rows and leaves any row whose expiry is
+    // still in the future (expiresAt >= now) untouched.
+    expect(mockDeleteMany).toHaveBeenCalledWith({
+      where: { expiresAt: { lt: now } },
     });
   });
 });

--- a/src/__tests__/lib/search/search-doc-cache-tags.test.ts
+++ b/src/__tests__/lib/search/search-doc-cache-tags.test.ts
@@ -1,0 +1,88 @@
+/**
+ * P2-18: the three SearchDoc unstable_cache wrappers must declare `tags`
+ * aligned with the tag constants in search-cache.ts, so invalidateSearchCaches'
+ * revalidateTag calls actually match a cache entry (instead of being dead code).
+ *
+ * We mock next/cache's unstable_cache to capture the options object passed by
+ * each wrapper, without invoking the wrapped (DB-bound) function.
+ */
+
+interface Captured {
+  keys: string[];
+  options: { revalidate?: number; tags?: string[] } | undefined;
+}
+
+jest.mock("next/cache", () => {
+  const calls: Captured[] = [];
+  return {
+    __cacheCalls: calls,
+    unstable_cache: (
+      _fn: (...args: unknown[]) => unknown,
+      keys: string[],
+      options: { revalidate?: number; tags?: string[] } | undefined
+    ) => {
+      calls.push({ keys, options });
+      // Return a stub so the wrapper never executes the DB-bound closure.
+      return async () => undefined;
+    },
+    revalidatePath: () => {},
+    revalidateTag: () => {},
+  };
+});
+
+import * as nextCache from "next/cache";
+import {
+  SEARCH_COUNT_CACHE_TAG,
+  SEARCH_MAP_CACHE_TAG,
+  SEARCH_RESULTS_CACHE_TAG,
+} from "@/lib/search/search-cache";
+import {
+  getSearchDocLimitedCount,
+  getSearchDocMapListings,
+  getSearchDocListingsPaginated,
+} from "@/lib/search/search-doc-queries";
+
+const cacheCalls = (
+  nextCache as unknown as { __cacheCalls: Captured[] }
+).__cacheCalls;
+
+function findByKey(prefix: string): Captured | undefined {
+  return cacheCalls.find((call) => call.keys[0] === prefix);
+}
+
+describe("SearchDoc cache wrappers declare invalidation tags (P2-18)", () => {
+  beforeAll(async () => {
+    cacheCalls.length = 0;
+    await getSearchDocLimitedCount({});
+    await getSearchDocMapListings({ bounds: { minLng: -1, minLat: -1, maxLng: 1, maxLat: 1 } });
+    await getSearchDocListingsPaginated({});
+  });
+
+  it("tags the limited-count wrapper with the count cache tag", () => {
+    const call = findByKey("searchdoc-limited-count");
+    expect(call).toBeDefined();
+    expect(call?.options?.tags).toContain(SEARCH_COUNT_CACHE_TAG);
+  });
+
+  it("tags the map-listings wrapper with the map cache tag", () => {
+    const call = findByKey("searchdoc-map-listings");
+    expect(call).toBeDefined();
+    expect(call?.options?.tags).toContain(SEARCH_MAP_CACHE_TAG);
+  });
+
+  it("tags the paginated-listings wrapper with the results cache tag", () => {
+    const call = findByKey("searchdoc-listings-paginated");
+    expect(call).toBeDefined();
+    expect(call?.options?.tags).toContain(SEARCH_RESULTS_CACHE_TAG);
+  });
+
+  it("keeps the 60s TTL alongside the new tags", () => {
+    for (const prefix of [
+      "searchdoc-limited-count",
+      "searchdoc-map-listings",
+      "searchdoc-listings-paginated",
+    ]) {
+      expect(findByKey(prefix)?.options?.revalidate).toBe(60);
+    }
+  });
+});

--- a/src/__tests__/lib/search/search-doc-queries.test.ts
+++ b/src/__tests__/lib/search/search-doc-queries.test.ts
@@ -10,8 +10,10 @@ import {
   buildOrderByClause,
   buildSearchDocListWhereConditions,
   buildSearchDocWhereConditions,
+  countDedupCanonicalGroups,
   mapRawListingsToPublic,
   mapRawMapListingsToPublic,
+  mapSemanticRowsToListingData,
 } from "@/lib/search/search-doc-queries";
 import { buildPublicAvailability } from "@/lib/search/public-availability";
 import { joinWhereClauseWithSecurityInvariant } from "@/lib/sql-safety";
@@ -683,5 +685,118 @@ describe("search-doc-queries", () => {
         expect(isSearchDocEnabled(" ")).toBe(true);
       });
     });
+  });
+});
+
+describe("countDedupCanonicalGroups (P2-6 dedup-aware total)", () => {
+  function dedupCountRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "row-1",
+      ownerId: "owner-1",
+      normalizedAddress: "123 main st, springfield, il 62704",
+      price: 1000,
+      title: "Cozy Room",
+      roomType: "private",
+      address: "123 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62704",
+      ...overrides,
+    };
+  }
+
+  it("returns 0 for empty input", () => {
+    expect(countDedupCanonicalGroups([])).toBe(0);
+  });
+
+  it("counts distinct canonical groups, not raw rows (never exceeds raw count)", () => {
+    const rows = [
+      dedupCountRow({ id: "a" }),
+      // Same owner + address + price + title + roomType → sibling of `a`.
+      dedupCountRow({ id: "b" }),
+      // Distinct owner → its own canonical group.
+      dedupCountRow({ id: "c", ownerId: "owner-2", title: "Sunny Loft", price: 1800 }),
+    ];
+
+    const count = countDedupCanonicalGroups(rows);
+
+    expect(count).toBe(2);
+    expect(count).toBeLessThanOrEqual(rows.length);
+  });
+
+  it("counts each row as its own group when nothing collapses", () => {
+    const rows = [
+      dedupCountRow({ id: "a", ownerId: "o1", title: "A", price: 1000 }),
+      dedupCountRow({ id: "b", ownerId: "o2", title: "B", price: 2000 }),
+      dedupCountRow({ id: "c", ownerId: "o3", title: "C", price: 3000 }),
+    ];
+
+    expect(countDedupCanonicalGroups(rows)).toBe(rows.length);
+  });
+});
+
+describe("mapSemanticRowsToListingData (P2-11 resolved availability)", () => {
+  function semanticRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "listing-1",
+      title: "Semantic Room",
+      description: "Cozy",
+      price: 1200,
+      images: ["img-1.jpg"],
+      room_type: "private",
+      lease_duration: "6_months",
+      available_slots: 2,
+      total_slots: 4,
+      amenities: ["wifi"],
+      house_rules: ["no smoking"],
+      household_languages: ["english"],
+      primary_home_language: "english",
+      gender_preference: null,
+      household_gender: null,
+      booking_mode: "SHARED",
+      move_in_date: new Date("2026-09-01T00:00:00.000Z"),
+      address: "1 Market St",
+      city: "San Francisco",
+      state: "CA",
+      zip: "94105",
+      lat: 37.7749,
+      lng: -122.4194,
+      owner_id: "owner-1",
+      avg_rating: 4.5,
+      review_count: 8,
+      view_count: 10,
+      listing_created_at: new Date("2026-01-15T00:00:00.000Z"),
+      recommended_score: 12.4,
+      semantic_similarity: 0.9,
+      keyword_rank: 0.1,
+      combined_score: 0.7,
+      ...overrides,
+    };
+  }
+
+  it("emits the resolved freshness read model, not the narrow 7-field shape", () => {
+    const [result] = mapSemanticRowsToListingData([semanticRow()]);
+
+    // Fields that only exist on ResolvedPublicAvailability — proof the mapper
+    // no longer emits the narrow buildPublicAvailability shape. Asserted via
+    // toHaveProperty(key, value) because ListingData types publicAvailability as
+    // the narrow PublicAvailability, so direct `.publicStatus` access would not
+    // type-check.
+    expect(result.publicAvailability).toHaveProperty("publicStatus", "AVAILABLE");
+    expect(result.publicAvailability).toHaveProperty("searchEligible", true);
+    // No lastConfirmedAt is returned by the semantic SQL function.
+    expect(result.publicAvailability).toHaveProperty(
+      "freshnessBucket",
+      "UNCONFIRMED"
+    );
+    expect(result.publicAvailability.lastConfirmedAt).toBeNull();
+  });
+
+  it("carries effective slots consistent with the resolved availability", () => {
+    const [result] = mapSemanticRowsToListingData([semanticRow()]);
+
+    expect(result.availableSlots).toBe(result.publicAvailability.openSlots);
+    expect(result.totalSlots).toBe(result.publicAvailability.totalSlots);
+    expect(result.availableSlots).toBe(2);
   });
 });

--- a/src/__tests__/lib/search/search-spec.test.ts
+++ b/src/__tests__/lib/search/search-spec.test.ts
@@ -25,10 +25,14 @@ const versions = {
 };
 
 describe("Phase 04 SearchSpec", () => {
-  it("derives requested occupants from legacy minSlots aliases", () => {
+  it("derives requested occupants from the parsed canonical capacity (P2-4)", () => {
+    // P2-4: the parser is the single source of truth. Every occupants alias
+    // (occupants/guests/requested_occupants/minSlots) is resolved into
+    // filterParams.minAvailableSlots upstream; the spec reads that canonical
+    // value rather than re-reading raw aliases.
     const result = buildPhase04SearchSpec({
-      parsed: parsed(),
-      rawParams: { minSlots: "3" },
+      parsed: parsed({ filterParams: { minAvailableSlots: 3 } }),
+      rawParams: {},
       pageSize: 12,
       versions,
     });

--- a/src/__tests__/lib/search/search-v2-service.test.ts
+++ b/src/__tests__/lib/search/search-v2-service.test.ts
@@ -210,7 +210,7 @@ import { loadValidQuerySnapshot } from "@/lib/search/query-snapshots";
 import { parseSearchParams } from "@/lib/search-params";
 import { clampBoundsToMaxSpan } from "@/lib/validation";
 import { features } from "@/lib/env";
-import { logger } from "@/lib/logger";
+import { logger, sanitizeErrorMessage } from "@/lib/logger";
 import { withTimeout } from "@/lib/timeout-wrapper";
 import type { ListingData, MapListingData } from "@/lib/data";
 import { buildPublicAvailability } from "@/lib/search/public-availability";
@@ -317,6 +317,8 @@ const mockClampBoundsToMaxSpan = clampBoundsToMaxSpan as jest.MockedFunction<
   typeof clampBoundsToMaxSpan
 >;
 const mockWithTimeout = withTimeout as jest.MockedFunction<typeof withTimeout>;
+const mockSanitizeErrorMessage =
+  sanitizeErrorMessage as jest.MockedFunction<typeof sanitizeErrorMessage>;
 const mockPrismaListingFindMany = prisma.listing
   .findMany as jest.MockedFunction<typeof prisma.listing.findMany>;
 const mockGetAvailabilityForListings =
@@ -1199,7 +1201,7 @@ describe("search-v2-service", () => {
       expect(result.response?.meta.embeddingVersion).toBeUndefined();
     });
 
-    it("adds embeddingVersion to meta when semantic search powers the list response", async () => {
+    it("adds embeddingVersion to the meta field — but NOT the query hash — when semantic search powers the list response", async () => {
       (features as Record<string, unknown>).semanticSearch = true;
       setupDefaultMocks({ useSearchDoc: false });
       mockParseSearchParams.mockReturnValue(
@@ -1268,16 +1270,17 @@ describe("search-v2-service", () => {
       expect(result.response?.meta.projectionVersion).toBe(
         SEARCH_DOC_PROJECTION_VERSION
       );
+      // The version token still surfaces in the dedicated meta field...
       expect(result.response?.meta.embeddingVersion).toBe(
         "gemini-embedding-2.search-result.nosensitive-v1.d768"
       );
       expect(result.response?.list.items[0]?.id).toBe("semantic-1");
       expect(mockGetListingsPaginated).not.toHaveBeenCalled();
-      expect(mockGetReadEmbeddingVersion).toHaveBeenCalled();
+      // ...but P1-5 requires the client-facing query hash to stay bare so the
+      // client doesn't discard every semantic response as a hash mismatch.
       expect(mockGenerateQueryHash).toHaveBeenCalledWith(
-        expect.objectContaining({
-          embeddingVersion:
-            "gemini-embedding-2.search-result.nosensitive-v1.d768",
+        expect.not.objectContaining({
+          embeddingVersion: expect.anything(),
         })
       );
     });
@@ -1934,6 +1937,15 @@ describe("search-v2-service", () => {
         })
       );
 
+      // P2-10: the raw rejection reason is routed through sanitizeErrorMessage
+      // (which redacts PII in prod) rather than logged verbatim.
+      expect(
+        mockSanitizeErrorMessage.mock.calls.some(
+          ([arg]) =>
+            arg instanceof Error && arg.message === "search-map-query timed out"
+        )
+      ).toBe(true);
+
       // Response should have warnings about map failure (spread dynamically, not in TS type)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((result.response!.meta as any).warnings).toContain(
@@ -1976,6 +1988,16 @@ describe("search-v2-service", () => {
           error: expect.any(String),
         })
       );
+
+      // P2-10: the raw rejection reason is routed through sanitizeErrorMessage
+      // (which redacts PII in prod) rather than logged verbatim.
+      expect(
+        mockSanitizeErrorMessage.mock.calls.some(
+          ([arg]) =>
+            arg instanceof Error &&
+            arg.message === "search-list-query timed out"
+        )
+      ).toBe(true);
     });
 
     it("returns list results even when map query fails (C1.1)", async () => {
@@ -2638,6 +2660,151 @@ describe("search-v2-service", () => {
         },
       });
       expect(mockGetSearchDocListingsWithKeyset).not.toHaveBeenCalled();
+    });
+
+    it("returns snapshotExpired when a keyset cursor's filter hash (qh) no longer matches (P2-20)", async () => {
+      (features as Record<string, unknown>).searchKeyset = true;
+      setupDefaultMocks({ useSearchDoc: true });
+      mockIsSearchDocEnabled.mockReturnValue(true);
+
+      // Cursor matches engine/version snapshot but was minted under a DIFFERENT
+      // filter set (mockGenerateQueryHash returns "abcdef1234567890").
+      mockDecodeCursorAny.mockReturnValue({
+        type: "keyset" as const,
+        cursor: {
+          v: 2 as const,
+          s: "recommended" as const,
+          k: ["85.50", "2024-01-15T10:00:00.000Z"],
+          id: "abc",
+          snapshot: {
+            engine: "searchdoc-keyset" as const,
+            responseVersion: `${SEARCH_RESPONSE_VERSION}.searchdoc-keyset`,
+            projectionVersion: SEARCH_DOC_PROJECTION_VERSION,
+            embeddingVersion: null,
+            qh: "filter-set-a-hash",
+          },
+        },
+      });
+
+      const result = await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+          cursor: "keyset-cursor-token",
+        },
+      });
+
+      expect(result.snapshotExpired).toEqual({
+        queryHash: "abcdef1234567890",
+        reason: "search_contract_changed",
+      });
+      expect(mockGetSearchDocListingsWithKeyset).not.toHaveBeenCalled();
+    });
+
+    it("applies a keyset cursor whose filter hash (qh) matches the current request (P2-20)", async () => {
+      (features as Record<string, unknown>).searchKeyset = true;
+      setupDefaultMocks({ useSearchDoc: true });
+      mockIsSearchDocEnabled.mockReturnValue(true);
+
+      const keysetCursor = {
+        v: 2 as const,
+        s: "recommended" as const,
+        k: ["85.50", "2024-01-15T10:00:00.000Z"],
+        id: "abc",
+        snapshot: {
+          engine: "searchdoc-keyset" as const,
+          responseVersion: `${SEARCH_RESPONSE_VERSION}.searchdoc-keyset`,
+          projectionVersion: SEARCH_DOC_PROJECTION_VERSION,
+          embeddingVersion: null,
+          qh: "abcdef1234567890",
+        },
+      };
+      mockDecodeCursorAny.mockReturnValue({
+        type: "keyset" as const,
+        cursor: keysetCursor,
+      });
+      mockGetSearchDocListingsWithKeyset.mockResolvedValue({
+        items: [makeListingData()],
+        total: 10,
+        page: 1,
+        limit: 12,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPrevPage: false,
+        nextCursor: null,
+      });
+
+      await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+          cursor: "keyset-cursor-token",
+        },
+      });
+
+      // Matching qh => cursor honored (not rejected as a contract change).
+      expect(mockGetSearchDocListingsWithKeyset).toHaveBeenCalledWith(
+        expect.any(Object),
+        keysetCursor,
+        expect.objectContaining({ qh: "abcdef1234567890" })
+      );
+    });
+  });
+
+  describe("admission caps (P2-3)", () => {
+    it("rejects occupants>20 on the non-projection path with a 400 admissionError", async () => {
+      setupDefaultMocks({ useSearchDoc: true });
+      mockIsSearchDocEnabled.mockReturnValue(true);
+
+      const result = await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+          occupants: "21",
+        },
+      });
+
+      expect(result.admissionError).toEqual({
+        code: "requested_occupants_too_high",
+        message: "requested_occupants must be <= 20",
+        status: 400,
+      });
+      expect(result.response).toBeNull();
+      // Rejected ahead of the engine branch — no SearchDoc query runs.
+      expect(mockGetSearchDocListingsPaginated).not.toHaveBeenCalled();
+      expect(mockGetSearchDocListingsFirstPage).not.toHaveBeenCalled();
+    });
+
+    it("rejects deep paging (page>20) on the non-projection path with a 400 admissionError", async () => {
+      setupDefaultMocks({ useSearchDoc: true });
+      mockIsSearchDocEnabled.mockReturnValue(true);
+      mockParseSearchParams.mockReturnValue(
+        defaultParsedSearchParams({ requestedPage: 21 })
+      );
+
+      const result = await executeSearchV2({
+        rawParams: {
+          minLat: "37.7",
+          maxLat: "37.85",
+          minLng: "-122.52",
+          maxLng: "-122.35",
+          page: "21",
+        },
+      });
+
+      expect(result.admissionError).toEqual({
+        code: "deep_paging_capped",
+        message: "page must be <= 20",
+        status: 400,
+      });
+      expect(result.response).toBeNull();
+      expect(mockGetSearchDocListingsPaginated).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/lib/search/transform.test.ts
+++ b/src/__tests__/lib/search/transform.test.ts
@@ -15,7 +15,10 @@ import {
 } from "@/lib/search/transform";
 import { CLUSTER_THRESHOLD } from "@/lib/search/types";
 import type { ListingData, MapListingData } from "@/lib/data";
-import { buildPublicAvailability } from "@/lib/search/public-availability";
+import {
+  buildHostManagedPublicAvailability,
+  buildPublicAvailability,
+} from "@/lib/search/public-availability";
 
 // Mock marker-utils to control pin limit
 jest.mock("@/lib/maps/marker-utils", () => ({
@@ -749,6 +752,154 @@ describe("search/transform", () => {
       );
       expect(response.geojson.features[0].properties.availableSlots).toBe(2);
       expect(response.pins?.[0].publicAvailability).toEqual(publicAvailability);
+    });
+  });
+
+  describe("public availability payload boundary (P2-12)", () => {
+    const PUBLIC_AVAILABILITY_KEYS = [
+      "availabilitySource",
+      "openSlots",
+      "totalSlots",
+      "availableFrom",
+      "availableUntil",
+      "minStayMonths",
+      "lastConfirmedAt",
+      "freshnessBucket",
+      "publicStatus",
+    ];
+    const INTERNAL_AVAILABILITY_KEYS = [
+      "staleAt",
+      "autoPauseAt",
+      "searchEligible",
+      "isValid",
+      "isPubliclyAvailable",
+      "effectiveAvailableSlots",
+    ];
+
+    const resolvedAvailability = () =>
+      buildHostManagedPublicAvailability(
+        {
+          status: "ACTIVE",
+          statusReason: null,
+          availabilitySource: "HOST_MANAGED",
+          openSlots: 2,
+          totalSlots: 4,
+          moveInDate: "2026-06-01",
+          availableUntil: "2026-12-01",
+          minStayMonths: 3,
+          lastConfirmedAt: "2026-04-15T12:30:00.000Z",
+        },
+        new Date("2026-04-20T00:00:00.000Z")
+      );
+
+    const listItemListing = (
+      publicAvailability: ListingData["publicAvailability"]
+    ): ListingData => ({
+      id: "resolved-1",
+      title: "Resolved listing",
+      description: "",
+      price: 1500,
+      images: ["img.jpg"],
+      availableSlots: 2,
+      totalSlots: 4,
+      amenities: [],
+      houseRules: [],
+      householdLanguages: [],
+      location: {
+        address: "123 Test St",
+        city: "San Francisco",
+        state: "CA",
+        zip: "94102",
+        lat: 37.7749,
+        lng: -122.4194,
+      },
+      isNearMatch: false,
+      publicAvailability,
+    });
+
+    const mapListing = (
+      publicAvailability: MapListingData["publicAvailability"]
+    ): MapListingData => ({
+      id: "resolved-map-1",
+      title: "Resolved map listing",
+      price: 1500,
+      images: ["img.jpg"],
+      location: { lat: 37.7749, lng: -122.4194 },
+      availableSlots: 2,
+      totalSlots: 4,
+      publicAvailability,
+    });
+
+    it("serializes exactly the nine public fields for list items", () => {
+      const resolved = resolvedAvailability();
+      // Sanity: the resolved object really does carry the internal fields.
+      expect(Object.keys(resolved)).toEqual(
+        expect.arrayContaining(INTERNAL_AVAILABILITY_KEYS)
+      );
+
+      const serialized = JSON.parse(
+        JSON.stringify(transformToListItem(listItemListing(resolved)))
+      );
+
+      expect(Object.keys(serialized.publicAvailability).sort()).toEqual(
+        [...PUBLIC_AVAILABILITY_KEYS].sort()
+      );
+      for (const key of INTERNAL_AVAILABILITY_KEYS) {
+        expect(serialized.publicAvailability[key]).toBeUndefined();
+      }
+      expect(serialized.publicAvailability.freshnessBucket).toBe("NORMAL");
+      expect(serialized.publicAvailability.publicStatus).toBe("AVAILABLE");
+    });
+
+    it("serializes exactly the nine public fields in geojson feature properties", () => {
+      const serialized = JSON.parse(
+        JSON.stringify(transformToGeoJSON([mapListing(resolvedAvailability())]))
+      );
+      const props = serialized.features[0].properties;
+
+      expect(Object.keys(props.publicAvailability).sort()).toEqual(
+        [...PUBLIC_AVAILABILITY_KEYS].sort()
+      );
+      for (const key of INTERNAL_AVAILABILITY_KEYS) {
+        expect(props.publicAvailability[key]).toBeUndefined();
+      }
+    });
+
+    it("serializes exactly the nine public fields on pins", () => {
+      const serialized = JSON.parse(
+        JSON.stringify(transformToPins([mapListing(resolvedAvailability())]))
+      );
+
+      expect(Object.keys(serialized[0].publicAvailability).sort()).toEqual(
+        [...PUBLIC_AVAILABILITY_KEYS].sort()
+      );
+      for (const key of INTERNAL_AVAILABILITY_KEYS) {
+        expect(serialized[0].publicAvailability[key]).toBeUndefined();
+      }
+    });
+
+    it("passes a narrow seven-field availability through with undefined freshness fields", () => {
+      const narrow = buildPublicAvailability({
+        availableSlots: 1,
+        totalSlots: 2,
+      });
+      const serialized = JSON.parse(
+        JSON.stringify(transformToListItem(listItemListing(narrow)))
+      );
+
+      expect(Object.keys(serialized.publicAvailability).sort()).toEqual(
+        [
+          "availabilitySource",
+          "openSlots",
+          "totalSlots",
+          "availableFrom",
+          "availableUntil",
+          "minStayMonths",
+          "lastConfirmedAt",
+        ].sort()
+      );
+      expect(serialized.publicAvailability.freshnessBucket).toBeUndefined();
+      expect(serialized.publicAvailability.publicStatus).toBeUndefined();
     });
   });
 });

--- a/src/__tests__/lib/search/unbounded-browse-protection.test.ts
+++ b/src/__tests__/lib/search/unbounded-browse-protection.test.ts
@@ -50,6 +50,22 @@ import {
 
 const mockExecuteRawUnsafe = prisma.$executeRawUnsafe as jest.Mock;
 
+// These tests validate the raw count/list contract (the dedup-off path prod
+// runs). Pin FEATURE_SEARCH_LISTING_DEDUP off so the dev-default dedup-aware
+// count query doesn't consume the raw-count mock. Dedup counting is covered in
+// search-doc-queries.test.ts.
+const ORIGINAL_DEDUP_FLAG = process.env.FEATURE_SEARCH_LISTING_DEDUP;
+beforeAll(() => {
+  process.env.FEATURE_SEARCH_LISTING_DEDUP = "false";
+});
+afterAll(() => {
+  if (ORIGINAL_DEDUP_FLAG === undefined) {
+    delete process.env.FEATURE_SEARCH_LISTING_DEDUP;
+  } else {
+    process.env.FEATURE_SEARCH_LISTING_DEDUP = ORIGINAL_DEDUP_FLAG;
+  }
+});
+
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const freshLastConfirmedAt = () => new Date(Date.now() - ONE_DAY_MS);
 

--- a/src/app/api/cron/daily-maintenance/route.ts
+++ b/src/app/api/cron/daily-maintenance/route.ts
@@ -44,6 +44,7 @@ import {
   compactSupersededOutboxEventsOnce,
 } from "@/lib/outbox/retention";
 import { cleanupExpiredVerificationDocumentsOnce } from "@/lib/verification/retention";
+import { deleteExpiredQuerySnapshots } from "@/lib/search/query-snapshots";
 
 interface TaskResult {
   task: string;
@@ -252,6 +253,14 @@ export async function GET(request: NextRequest) {
       return { deleted: result.count };
     });
 
+    await runTask(results, "cleanup-query-snapshots", async () => {
+      const deleted = await withRetry(() => deleteExpiredQuerySnapshots(), {
+        context: "cleanup-query-snapshots",
+      });
+
+      return { deleted };
+    });
+
     await runTask(results, "cleanup-typing-status", async () => {
       const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
       const result = await withRetry(
@@ -316,6 +325,11 @@ export async function GET(request: NextRequest) {
     markSkippedTask(
       results,
       "cleanup-idempotency-keys",
+      "outside_daily_window"
+    );
+    markSkippedTask(
+      results,
+      "cleanup-query-snapshots",
       "outside_daily_window"
     );
     markSkippedTask(results, "cleanup-typing-status", "outside_daily_window");

--- a/src/app/api/cron/refresh-search-docs/route.ts
+++ b/src/app/api/cron/refresh-search-docs/route.ts
@@ -28,6 +28,7 @@ export const maxDuration = 30;
 
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_RESCAN_SAMPLE_SIZE = 50;
+const DEFAULT_MISSING_DOC_BACKSTOP_SIZE = 25;
 const DEFAULT_TIME_BUDGET_MS = 20_000;
 const MAX_DURATION_MS = maxDuration * 1000;
 const RESCAN_CHUNK_SAFETY_MARGIN_MS = 3_000;
@@ -71,6 +72,13 @@ function getRescanSampleSize(): number {
   return parsePositiveIntEnv(
     process.env.SEARCH_DOC_RESCAN_SAMPLE_SIZE,
     DEFAULT_RESCAN_SAMPLE_SIZE
+  );
+}
+
+function getMissingDocBackstopSize(): number {
+  return parsePositiveIntEnv(
+    process.env.SEARCH_DOC_MISSING_DOC_BACKSTOP_SIZE,
+    DEFAULT_MISSING_DOC_BACKSTOP_SIZE
   );
 }
 
@@ -218,14 +226,84 @@ async function fetchRescanListingIds(
   return rescanEntries.map((entry) => entry.id);
 }
 
-async function clearDirtyFlags(listingIds: string[]): Promise<number> {
-  if (listingIds.length === 0) {
+/**
+ * Backstop for listings that have NO search doc at all (P2-9). The TABLESAMPLE
+ * rescan above only re-evaluates rows that already exist in
+ * listing_search_docs, so a listing whose create-time upsert failed AND whose
+ * dirty mark was later lost (see P1-1) is invisible to search indefinitely.
+ * This anti-join finds publishable listings — ACTIVE, fully addressed, geocoded
+ * (mirrors `canProjectSearchDocument` in search-doc-sync) — that have no doc and
+ * no pending dirty mark, and feeds them through the same projection path so the
+ * cron creates the missing doc. `projectSearchDocument` remains authoritative:
+ * anything not truly projectable defers/suppresses and simply gets re-sampled.
+ */
+async function fetchMissingDocListingIds(
+  limit: number,
+  excludedListingIds: string[]
+): Promise<string[]> {
+  if (limit <= 0) {
+    return [];
+  }
+
+  const excludedListingClause =
+    excludedListingIds.length > 0
+      ? Prisma.sql`AND l.id <> ALL(${excludedListingIds})`
+      : Prisma.empty;
+
+  const rows = await prisma.$queryRaw<{ id: string }[]>(
+    Prisma.sql`
+      SELECT l.id
+      FROM "Listing" l
+      JOIN "Location" loc ON loc."listingId" = l.id
+      WHERE l.status::text = 'ACTIVE'
+        AND loc.address IS NOT NULL
+        AND loc.city IS NOT NULL
+        AND loc.state IS NOT NULL
+        AND loc.zip IS NOT NULL
+        AND loc.coords IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM listing_search_docs sd WHERE sd.id = l.id
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM listing_search_doc_dirty dirty
+          WHERE dirty.listing_id = l.id
+        )
+        ${excludedListingClause}
+      ORDER BY l."createdAt" DESC
+      LIMIT ${limit}
+    `
+  );
+
+  return rows.map((row) => row.id);
+}
+
+async function clearDirtyFlags(
+  entries: { listingId: string; markedAt: Date | null }[]
+): Promise<number> {
+  if (entries.length === 0) {
     return 0;
   }
 
+  const listingIds = entries.map((entry) => entry.listingId);
+  const observedMarkedAt = entries.map((entry) =>
+    entry.markedAt ? entry.markedAt.toISOString() : null
+  );
+
+  // Conditional clear closes the lost-dirty-mark race (P1-1). A writer that
+  // re-marks a listing via `ON CONFLICT ... SET marked_at = NOW()` after the
+  // cron read the queue lands a strictly newer marked_at, so its row is
+  // preserved (dirty.marked_at > observed) and reprocessed next run instead of
+  // being deleted with a version that was never projected. Comparison is
+  // against the marked_at observed at read time, never NOW(). A NULL observed
+  // timestamp (never written — the column is NOT NULL DEFAULT NOW()) degrades to
+  // an unconditional clear for that row.
   return prisma.$executeRaw`
-    DELETE FROM listing_search_doc_dirty
-    WHERE listing_id = ANY(${listingIds})
+    DELETE FROM listing_search_doc_dirty AS dirty
+    USING unnest(${listingIds}::text[], ${observedMarkedAt}::timestamptz[])
+      AS observed(listing_id, marked_at)
+    WHERE dirty.listing_id = observed.listing_id
+      AND (observed.marked_at IS NULL OR dirty.marked_at <= observed.marked_at)
   `;
 }
 
@@ -358,16 +436,30 @@ export async function GET(request: NextRequest) {
     dirtyIds = dirtyEntries.map((entry) => entry.listing_id);
     dirtyQueueAgeSeconds = computeDirtyQueueAgeSeconds(dirtyEntries, Date.now());
 
+    // Capture the marked_at observed at queue-read time so the clear can be
+    // conditional. A concurrent writer that re-marks a listing between now and
+    // the DELETE lands a strictly newer marked_at and must survive (P1-1).
+    const observedMarkedAtByListingId = new Map<string, Date | null>();
+    for (const entry of dirtyEntries) {
+      observedMarkedAtByListingId.set(
+        entry.listing_id,
+        toMarkedAtDate(entry.marked_at)
+      );
+    }
+
     const dirtyPhase = await processWithConcurrency(
       dirtyIds,
       async (listingId) => projectSearchDocument(listingId),
       UPSERT_CONCURRENCY
     );
 
-    const clearableIds = dirtyPhase.fulfilled
+    const clearableEntries = dirtyPhase.fulfilled
       .filter(shouldClearDirtyFlag)
-      .map((result) => result.listingId);
-    await clearDirtyFlags(clearableIds);
+      .map((result) => ({
+        listingId: result.listingId,
+        markedAt: observedMarkedAtByListingId.get(result.listingId) ?? null,
+      }));
+    await clearDirtyFlags(clearableEntries);
 
     const dirtyCounts = countProjectionResults(dirtyPhase.fulfilled);
     addOutcomeCounters(totalOutcomes, dirtyCounts.outcomes);
@@ -390,10 +482,15 @@ export async function GET(request: NextRequest) {
           getRescanSampleSize(),
           dirtyIds
         );
-        rescanned = rescanIds.length;
+        const missingDocIds = await fetchMissingDocListingIds(
+          getMissingDocBackstopSize(),
+          dirtyIds
+        );
+        const backstopIds = rescanIds.concat(missingDocIds);
+        rescanned = backstopIds.length;
 
         const rescanPhase = await processWithConcurrency(
-          rescanIds,
+          backstopIds,
           async (listingId) => projectSearchDocument(listingId),
           RESCAN_CONCURRENCY,
           () =>
@@ -416,7 +513,7 @@ export async function GET(request: NextRequest) {
             event: "search_doc_cron_rescan_truncated",
             processed: rescanPhase.fulfilled.length,
             dropped:
-              rescanIds.length -
+              backstopIds.length -
               rescanPhase.fulfilled.length -
               rescanPhase.rejected.length,
             durationMs: Date.now() - cronStartMs,

--- a/src/app/api/listings/[id]/route.ts
+++ b/src/app/api/listings/[id]/route.ts
@@ -19,6 +19,7 @@ import { VALID_AMENITIES, VALID_HOUSE_RULES } from "@/lib/filter-schema";
 import { checkListingLanguageCompliance } from "@/lib/listing-language-guard";
 import { isValidLanguageCode } from "@/lib/languages";
 import { markListingDirtyInTx } from "@/lib/search/search-doc-dirty";
+import { invalidateSearchCaches } from "@/lib/search/search-cache";
 import { withRateLimit } from "@/lib/with-rate-limit";
 import { captureApiError } from "@/lib/api-error-handler";
 import { validateCsrf } from "@/lib/csrf";
@@ -845,6 +846,26 @@ export async function PATCH(
         }
 
         result = availabilityPatchResult.updatedListing;
+
+        // Capacity/openSlots changes affect search results; refresh the
+        // SearchDoc list/map/count/facet caches. Best-effort — a revalidation
+        // failure must never fail the availability write.
+        try {
+          invalidateSearchCaches();
+        } catch (revalidateError) {
+          logger.sync.warn(
+            "Failed to invalidate search caches after availability patch",
+            {
+              route: "/api/listings/[id]",
+              method: "PATCH",
+              listingId: id,
+              error:
+                revalidateError instanceof Error
+                  ? revalidateError.message
+                  : String(revalidateError),
+            }
+          );
+        }
       } catch (error) {
         if (error instanceof Error) {
           if (error.message === "NOT_FOUND") {
@@ -1251,6 +1272,7 @@ export async function PATCH(
             listing: updatedListing,
             address: { address, city, state, zip },
             actor: { role: "host", id: userId },
+            trustedCoordinates: coords ?? undefined,
           });
 
           return {

--- a/src/app/api/listings/[id]/viewer-state/route.ts
+++ b/src/app/api/listings/[id]/viewer-state/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/search/public-availability";
 import {
   buildPrivacyFirstViewerContract,
+  resolvePublicListingVisibilityState,
   type ContactDisabledReason,
 } from "@/lib/listings/public-contact-contract";
 import {
@@ -75,7 +76,7 @@ export async function GET(request: Request, { params }: RouteContext) {
   const { id } = await params;
   const session = await auth();
 
-  const listing = await prisma.listing.findUnique({
+  const rawListing = await prisma.listing.findUnique({
     where: { id },
     select: {
       ownerId: true,
@@ -92,7 +93,21 @@ export async function GET(request: Request, { params }: RouteContext) {
     },
   });
 
-  const isOwner = !!session?.user?.id && listing?.ownerId === session.user.id;
+  const isOwner = !!session?.user?.id && rawListing?.ownerId === session.user.id;
+  const isAdmin = session?.user?.isAdmin === true;
+
+  // P2-1: viewer-state must not leak the availability (or existence) of
+  // hidden/moderated listings. Mirror the detail-page/status gate: when the
+  // listing is not publicly visible and the viewer can't manage it, treat it
+  // as not-found so the response is indistinguishable from a missing listing.
+  const rawVisibility = rawListing
+    ? resolvePublicListingVisibilityState(rawListing)
+    : null;
+  const listing =
+    rawListing && (isOwner || isAdmin || rawVisibility?.isPubliclyVisible)
+      ? rawListing
+      : null;
+
   const isEmailVerified = !!session?.user?.emailVerified;
   const needsMigrationReview = false;
   const paywallSummaryPromise = listing

--- a/src/app/api/search-count/route.ts
+++ b/src/app/api/search-count/route.ts
@@ -33,12 +33,45 @@ import {
   MAP_FETCH_MAX_LNG_SPAN,
 } from "@/lib/constants";
 import { isPhase04ProjectionReadsEnabled } from "@/lib/flags/phase04";
-import { getProjectionSearchCount } from "@/lib/search/projection-search";
+import {
+  getProjectionSearchCount,
+  hasProjectionFreshnessHoles,
+} from "@/lib/search/projection-search";
 import { getProjectionReadEligibility } from "@/lib/search/projection-read-eligibility";
 import { buildPublicCacheHeaders } from "@/lib/public-cache/headers";
 
 // Disable static caching - counts must be fresh
 export const dynamic = "force-dynamic";
+
+/**
+ * Freshness guard for the projection count, mirroring the list path in
+ * search-v2-service.ts (:672-690). A projection-eligible query whose bounds
+ * contain freshness holes is served by the SearchDoc engine on the list, so
+ * the count must fall back to the SearchDoc count as well. If the guard query
+ * itself throws, we match the list path's catch branch and stay on the
+ * projection engine (returns true).
+ */
+async function canUseProjectionCount(
+  parsed: ReturnType<typeof parseSearchParams>,
+  requestId: string | undefined
+): Promise<boolean> {
+  try {
+    if (await hasProjectionFreshnessHoles({ parsed })) {
+      logger.sync.warn("phase04_projection_count_freshness_fallback", {
+        requestId,
+        reason: "projection_freshness_hole",
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    logger.sync.warn("phase04_projection_count_freshness_guard_failed", {
+      requestId,
+      error: sanitizeErrorMessage(err),
+    });
+    return true;
+  }
+}
 
 export async function GET(request: NextRequest) {
   const context = createContextFromHeaders(request.headers);
@@ -94,40 +127,55 @@ export async function GET(request: NextRequest) {
         );
       }
 
+      // Use the SAME sort-aware eligibility gate the list path uses
+      // (search-v2-service.ts) so the count is produced by the same engine the
+      // list will render. Previously this passed { ignoreSort: true }, which
+      // diverged the engines: under the default "recommended" sort the list is
+      // projection-INELIGIBLE (served by SearchDoc, counting listings) but
+      // ignoreSort forced the count onto the projection engine (counting
+      // units) — so "Show N listings" mismatched the rendered list for
+      // multi-inventory units (review P1-2).
       if (
         isPhase04ProjectionReadsEnabled() &&
-        // Count is sort-independent — don't let the recommended/rating/newest
-        // sort gate (ordering-only) disable the projection count fast-path,
-        // which would otherwise be dead for the default "recommended" sort (#2 review).
-        getProjectionReadEligibility(parsed, { ignoreSort: true }).supported
+        getProjectionReadEligibility(parsed).supported
       ) {
-        const projectionCount = await getProjectionSearchCount({
-          parsed,
-          rawParams,
-        });
-        if (!projectionCount.ok) {
+        // Mirror the list path's freshness guard: a projection-eligible query
+        // with freshness holes is served by SearchDoc, so the count must be too
+        // (search-v2-service.ts:672-690). When there are no holes (or the guard
+        // itself throws — matching the list path's catch), stay on projection;
+        // otherwise fall through to the SearchDoc count below.
+        if (await canUseProjectionCount(parsed, requestId)) {
+          const projectionCount = await getProjectionSearchCount({
+            parsed,
+            rawParams,
+          });
+          if (!projectionCount.ok) {
+            return NextResponse.json(
+              {
+                error: "admission_rejected",
+                admissionError: projectionCount.error,
+              },
+              {
+                status: projectionCount.error.status,
+                headers: {
+                  "Cache-Control": "private, no-store",
+                },
+              }
+            );
+          }
           return NextResponse.json(
+            { count: projectionCount.count },
             {
-              error: "admission_rejected",
-              admissionError: projectionCount.error,
-            },
-            {
-              status: projectionCount.error.status,
               headers: {
-                "Cache-Control": "private, no-store",
+                "Cache-Control":
+                  "public, s-maxage=15, stale-while-revalidate=30",
+                ...buildPublicCacheHeaders(),
               },
             }
           );
         }
-        return NextResponse.json(
-          { count: projectionCount.count },
-          {
-            headers: {
-              "Cache-Control": "public, s-maxage=15, stale-while-revalidate=30",
-              ...buildPublicCacheHeaders(),
-            },
-          }
-        );
+        // Projection freshness holes → fall back to the SearchDoc count below,
+        // the same engine the list will use for this query.
       }
 
       // Clamp oversized bounds for consistency with /api/search/facets and /api/map-listings.
@@ -145,6 +193,9 @@ export async function GET(request: NextRequest) {
 
       // Get count using existing getLimitedCount function
       // Returns exact count if ≤100, null if >100
+      // Dedup parity: getLimitedCount dispatches to getSearchDocLimitedCount,
+      // which counts distinct canonical groups when searchListingDedup is on
+      // (review P2-6), so this count matches the list's rendered total.
       const count = await getLimitedCount(effectiveFilterParams);
 
       logger.debug("Search count request", {

--- a/src/app/api/search/facets/route.ts
+++ b/src/app/api/search/facets/route.ts
@@ -21,6 +21,7 @@ import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { parseSearchParams } from "@/lib/search-params";
 import { unstable_cache } from "next/cache";
+import { SEARCH_FACETS_CACHE_TAG } from "@/lib/search/search-cache";
 import { withRateLimitRedis } from "@/lib/with-rate-limit-redis";
 import {
   createContextFromHeaders,
@@ -30,9 +31,11 @@ import {
 import { crossesAntimeridian } from "@/lib/data";
 import { clampBoundsToMaxSpan } from "@/lib/validation";
 import {
+  BOUNDS_EPSILON,
   MAP_FETCH_MAX_LAT_SPAN,
   MAP_FETCH_MAX_LNG_SPAN,
 } from "@/lib/constants";
+import { getSearchRateLimitIdentifier } from "@/lib/search-rate-limit-identifier";
 import { logger, sanitizeErrorMessage } from "@/lib/logger";
 import { withTimeout, DEFAULT_TIMEOUTS } from "@/lib/timeout-wrapper";
 import { features } from "@/lib/env";
@@ -334,6 +337,17 @@ async function getPriceHistogram(
 }
 
 /**
+ * Quantize a coordinate value for cache key consistency.
+ * Uses the shared BOUNDS_EPSILON (~100m precision) so the facets cache key
+ * tolerates the same tiny pans the map/list cache keys do (createSearchDoc*
+ * CacheKey in search-doc-queries.ts). Previously used toFixed(4) (~11m), which
+ * busted the facets cache on ~0.0001° jitter and amplified DB cost (P2-5).
+ */
+function quantizeBound(value: number): number {
+  return Math.round(value / BOUNDS_EPSILON) * BOUNDS_EPSILON;
+}
+
+/**
  * Generate cache key for facets request
  */
 function generateFacetsCacheKey(
@@ -343,7 +357,7 @@ function generateFacetsCacheKey(
   const normalized: Record<string, string | number | boolean> = {
     amenities: [...(filterParams.amenities || [])].sort().join(","),
     bounds: filterParams.bounds
-      ? `${filterParams.bounds.minLng.toFixed(4)},${filterParams.bounds.minLat.toFixed(4)},${filterParams.bounds.maxLng.toFixed(4)},${filterParams.bounds.maxLat.toFixed(4)}`
+      ? `${quantizeBound(filterParams.bounds.minLng)},${quantizeBound(filterParams.bounds.minLat)},${quantizeBound(filterParams.bounds.maxLng)},${quantizeBound(filterParams.bounds.maxLat)}`
       : "",
     houseRules: [...(filterParams.houseRules || [])].sort().join(","),
     languages: [...(filterParams.languages || [])].sort().join(","),
@@ -421,9 +435,12 @@ export async function GET(request: NextRequest) {
   const context = createContextFromHeaders(request.headers);
 
   return runWithRequestContext(context, async () => {
-    // Rate limiting (uses search-count bucket as they serve similar purposes)
+    // Rate limiting (uses search-count bucket as they serve similar purposes).
+    // getSearchRateLimitIdentifier keys by ip:userId (same as v2/list/map) so
+    // authenticated users behind shared NAT aren't starved by IP-only limiting (P2-5).
     const rateLimitResponse = await withRateLimitRedis(request, {
       type: "search-count",
+      getIdentifier: getSearchRateLimitIdentifier,
     });
     if (rateLimitResponse) {
       return rateLimitResponse;
@@ -579,7 +596,7 @@ export async function GET(request: NextRequest) {
         unstable_cache(
           async () => getFacetsInternal(effectiveFilterParams),
           ["search-facets", cacheKey],
-          { revalidate: CACHE_TTL }
+          { revalidate: CACHE_TTL, tags: [SEARCH_FACETS_CACHE_TAG] }
         )(),
         DEFAULT_TIMEOUTS.DATABASE,
         "search-facets-getFacetsInternal"

--- a/src/app/api/search/listings/route.ts
+++ b/src/app/api/search/listings/route.ts
@@ -150,6 +150,10 @@ export async function GET(request: NextRequest) {
               "api-search-listings-v2"
             );
             if (result.unboundedSearch) return result;
+            // Structured signals (admission caps, expired snapshot) carry
+            // response:null with no error. Surface them so their dedicated
+            // handlers below run instead of throwing into the V1 fallback.
+            if (result.admissionError || result.snapshotExpired) return result;
             if (!result.response || result.error) {
               throw new Error(result.error || "V2 search returned no response");
             }

--- a/src/app/search/actions.ts
+++ b/src/app/search/actions.ts
@@ -189,11 +189,11 @@ export async function fetchMoreListings(
         });
 
         if (v2Result.snapshotExpired) {
-          const meta = createSearchResponseMeta(normalizedQuery, "v2");
-          const finalMeta =
-            queryHash && queryHash.trim().length > 0
-              ? { ...meta, queryHash }
-              : meta;
+          // P1-5: meta is built from the same normalized query the client uses,
+          // so meta.queryHash already equals the client's bare hash — the old
+          // client-hash override was papering over the pre-fix service divergence
+          // and is now redundant.
+          const finalMeta = createSearchResponseMeta(normalizedQuery, "v2");
           recordSearchLoadMoreError({
             route: "search-load-more",
             queryHash: finalMeta.queryHash,
@@ -218,7 +218,11 @@ export async function fetchMoreListings(
 
         if (v2Result.paginatedResult) {
           const responseMeta = v2Result.response?.meta;
-          const meta = responseMeta
+          // P1-5: meta.queryHash is the bare client-facing hash derived from the
+          // same normalized query the client computed, so it already matches the
+          // client's request hash — no client-hash override needed. Version tokens
+          // still flow through the dedicated meta fields below.
+          const finalMeta = responseMeta
             ? createSearchResponseMeta(normalizedQuery, "v2", {
                 querySnapshotId: responseMeta.querySnapshotId,
                 projectionVersion: responseMeta.projectionVersion,
@@ -226,10 +230,6 @@ export async function fetchMoreListings(
                 rankerProfileVersion: responseMeta.rankerProfileVersion,
               })
             : createSearchResponseMeta(normalizedQuery, "v2");
-          const finalMeta =
-            queryHash && queryHash.trim().length > 0
-              ? { ...meta, queryHash }
-              : meta;
           recordSearchRequestLatency({
             route: "search-load-more",
             durationMs: performance.now() - requestStartTime,
@@ -296,10 +296,8 @@ export async function fetchMoreListings(
         items: toPublicSearchListings(paginatedResult.items),
         nextCursor: hasNextPage ? encodeCursor(requestedPage + 1) : null,
         hasNextPage,
-        meta:
-          queryHash && queryHash.trim().length > 0
-            ? { ...fallbackMeta, queryHash }
-            : fallbackMeta,
+        // P1-5: fallbackMeta.queryHash is already the bare client-facing hash.
+        meta: fallbackMeta,
       };
     }
 
@@ -327,10 +325,8 @@ export async function fetchMoreListings(
       nextCursor: null,
       hasNextPage: false,
       degraded: true,
-      meta:
-        queryHash && queryHash.trim().length > 0
-          ? { ...fallbackMeta, queryHash }
-          : fallbackMeta,
+      // P1-5: fallbackMeta.queryHash is already the bare client-facing hash.
+      meta: fallbackMeta,
     };
   } catch (error) {
     recordSearchLoadMoreError({

--- a/src/components/search/SearchResultsClient.tsx
+++ b/src/components/search/SearchResultsClient.tsx
@@ -202,6 +202,14 @@ export function SearchResultsClient({
   );
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const isLoadingRef = useRef(false);
+  // P2-15: Focus management for the "Show more" terminal transition. When the
+  // button unmounts (all results seen / client cap) native focus falls to
+  // <body>; if the load was started while the button held focus we move focus to
+  // whichever terminal message rendered so keyboard users aren't reset to the top.
+  const loadMoreButtonRef = useRef<HTMLButtonElement>(null);
+  const seenAllMessageRef = useRef<HTMLParagraphElement>(null);
+  const refineNudgeRef = useRef<HTMLParagraphElement>(null);
+  const pendingLoadMoreFocusRef = useRef(false);
   // F2 FIX: Ref for total count avoids allListings in handleLoadMore deps
   const totalCountRef = useRef(
     dedupeListingsForDisplay(initialListings).length
@@ -747,6 +755,13 @@ export function SearchResultsClient({
   const handleLoadMore = useCallback(async () => {
     if (!nextCursor || isLoadingRef.current) return;
 
+    // P2-15: Record whether this load was initiated while the "Show more" button
+    // held focus, so a terminal transition can move focus rather than yanking it
+    // from elsewhere (e.g. a mouse user typing in a filter, or the "Try again"
+    // link which is a different element).
+    pendingLoadMoreFocusRef.current =
+      document.activeElement === loadMoreButtonRef.current;
+
     isLoadingRef.current = true;
     setIsLoadingMore(true);
     setLoadError(null);
@@ -948,6 +963,30 @@ export function SearchResultsClient({
     }
     // F2 FIX: Removed allListings dep — count read from totalCountRef instead
   }, [nextCursor, rawParams, effectiveTotal, router, testScenario]);
+
+  // P2-15: Single source of truth for the load-more/terminal render conditions so
+  // the focus effect and the JSX below can never disagree about what is on screen.
+  const showLoadMoreButton =
+    isHydrated && !!nextCursor && !reachedCap && !isDegraded && !loadError;
+  const showSeenAllMessage =
+    !nextCursor && allListings.length > 0 && extraListings.length > 0;
+  const showRefineNudge = reachedCap && !!nextCursor;
+
+  // P2-15: After the terminal transition renders, move focus to the message that
+  // replaced the button — but only when the load was started from the focused
+  // button (pending flag) so we never steal focus from a mouse user elsewhere.
+  useEffect(() => {
+    if (!pendingLoadMoreFocusRef.current) return;
+    const target = showSeenAllMessage
+      ? seenAllMessageRef.current
+      : showRefineNudge
+        ? refineNudgeRef.current
+        : null;
+    if (target) {
+      target.focus({ preventScroll: true });
+      pendingLoadMoreFocusRef.current = false;
+    }
+  }, [showSeenAllMessage, showRefineNudge]);
 
   const total = effectiveTotal;
   const effectiveLocationRequired = searchStateKind === "location-required";
@@ -1321,13 +1360,14 @@ export function SearchResultsClient({
           {/* Load more section with progress indicator.
               Hidden whenever a load error (degraded or rate-limited) is showing so the
               error's "Try again" link is the single CTA, not a second competing one (#17). */}
-          {isHydrated && nextCursor && !reachedCap && !isDegraded && !loadError && (
+          {showLoadMoreButton && (
             <div className="mb-4 mt-8 flex flex-col items-center gap-2">
               <p className="text-xs text-on-surface-variant">
                 Showing {allListings.length} of{" "}
                 {total !== null ? `~${total}` : "100+"} listings
               </p>
               <button
+                ref={loadMoreButtonRef}
                 onClick={handleLoadMore}
                 disabled={isLoadingMore}
                 aria-busy={isLoadingMore}
@@ -1354,8 +1394,12 @@ export function SearchResultsClient({
           )}
 
           {/* Cap reached — nudge user to refine */}
-          {reachedCap && nextCursor && (
-            <p className="text-center text-sm text-on-surface-variant mt-6">
+          {showRefineNudge && (
+            <p
+              ref={refineNudgeRef}
+              tabIndex={-1}
+              className="text-center text-sm text-on-surface-variant mt-6"
+            >
               Showing {allListings.length} results. Try adjusting your filters
               or zooming into a specific area to find more relevant listings.
             </p>
@@ -1387,13 +1431,15 @@ export function SearchResultsClient({
               the complete set there is intentionally no terminal message; this is a
               deliberate, e2e-asserted UX decision (pagination-core 4.2), so audit
               finding #28 was reverted to respect it. */}
-          {!nextCursor &&
-            allListings.length > 0 &&
-            extraListings.length > 0 && (
-              <p className="text-center text-sm text-on-surface-variant mt-8">
-                You&apos;ve seen all {allListings.length} results
-              </p>
-            )}
+          {showSeenAllMessage && (
+            <p
+              ref={seenAllMessageRef}
+              tabIndex={-1}
+              className="text-center text-sm text-on-surface-variant mt-8"
+            >
+              You&apos;ve seen all {allListings.length} results
+            </p>
+          )}
 
           {/* Expansion suggestions for sparse results (1-5 listings) */}
           {total !== null && total > 0 && total <= 5 && (

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -295,11 +295,121 @@ async function handleCacheInvalidate(
   }
 }
 
+function coerceSourceVersion(value: bigint | number | string): bigint {
+  return typeof value === "bigint" ? value : BigInt(value);
+}
+
+/**
+ * Re-point an affected unit's inventories to its post-mutation identity epoch and
+ * rebuild the unit's projections there.
+ *
+ * recordIdentityMutation() bumps physical_units.unit_identity_epoch to the new
+ * epoch but leaves listing_inventories.unit_identity_epoch_written_at — and the
+ * projection rows keyed off it — at the old epoch. rebuildUnitPublicProjection
+ * aggregates strictly at a single epoch (`WHERE unit_identity_epoch_written_at =
+ * <epoch>`), so without this step the unit's public projection would aggregate
+ * zero inventories at the new epoch and the old-epoch inventory/unit projection
+ * rows would orphan (P2-8).
+ *
+ * Idempotent + epoch-safe:
+ *   - Re-reads the unit's current epoch instead of trusting the event payload; a
+ *     stale event (unit already advanced to a newer epoch, e.g. a later mutation)
+ *     is skipped so the authoritative event for the current epoch owns the
+ *     re-point. A retry of the current-epoch event re-runs harmlessly.
+ *   - The listing_inventories UPDATE only touches rows still stranded at an older
+ *     epoch, so a retry after success is a no-op (no repeated version churn).
+ *   - source_version is deliberately NOT bumped here: it mirrors the host listing
+ *     version (see canonical-inventory.ts's toBigIntVersion), and bumping it
+ *     out-of-band would make a later host edit look stale. The projection CAS
+ *     accepts an equal version (`source_version <= EXCLUDED.source_version`), so
+ *     the rebuild lands without desynchronising the host-version counter.
+ */
+async function reprojectUnitAfterIdentityMutation(
+  tx: TransactionClient,
+  unitId: string,
+  eventEpoch: number
+): Promise<void> {
+  const unitRows = await tx.$queryRaw<
+    { unit_identity_epoch: number | string }[]
+  >`
+    SELECT unit_identity_epoch
+    FROM physical_units
+    WHERE id = ${unitId}
+    LIMIT 1
+  `;
+  const currentEpoch = unitRows[0]
+    ? Number(unitRows[0].unit_identity_epoch)
+    : null;
+
+  // Unit gone, or a newer mutation already advanced it past this event's epoch:
+  // the event is stale for this unit and the current-epoch event owns the
+  // re-point. Skipping keeps retries and out-of-order delivery safe.
+  if (currentEpoch === null || currentEpoch !== eventEpoch) {
+    return;
+  }
+
+  // (a) Re-point the unit's inventories still stranded at an older epoch. Gating
+  //     on `< currentEpoch` makes a retry a no-op (rows already at the new epoch
+  //     are untouched, so row_version does not churn).
+  await tx.$executeRaw`
+    UPDATE listing_inventories
+    SET unit_identity_epoch_written_at = ${currentEpoch},
+        row_version = row_version + 1,
+        updated_at = NOW()
+    WHERE unit_id = ${unitId}
+      AND unit_identity_epoch_written_at < ${currentEpoch}
+  `;
+
+  // (b) Rebuild each inventory's search projection at the new epoch — same path
+  //     as INVENTORY_UPSERTED. Hidden/missing inventories are skipped inside the
+  //     rebuild (their projection rows were already tombstoned).
+  const inventoryRows = await tx.$queryRaw<
+    { id: string; source_version: bigint | number | string }[]
+  >`
+    SELECT id, source_version
+    FROM listing_inventories
+    WHERE unit_id = ${unitId}
+  `;
+
+  for (const inventory of inventoryRows) {
+    await rebuildInventorySearchProjection(tx, {
+      unitId,
+      inventoryId: inventory.id,
+      sourceVersion: coerceSourceVersion(inventory.source_version),
+      unitIdentityEpoch: currentEpoch,
+    });
+  }
+
+  // (c) Drop any inventory projection rows still stranded at an older epoch for
+  //     this unit (defensive — re-pointed rows now sit at currentEpoch).
+  await tx.$executeRaw`
+    DELETE FROM inventory_search_projection
+    WHERE unit_id = ${unitId}
+      AND unit_identity_epoch_written_at < ${currentEpoch}
+  `;
+
+  // Rebuild the unit public projection at the new epoch (takes the per-unit
+  // advisory lock and aggregates the re-pointed inventory rows).
+  await rebuildUnitPublicProjection(tx, unitId, currentEpoch);
+
+  // (c) Remove the orphaned old-epoch unit projection row(s). unit_public_projection
+  //     is keyed by (unit_id, unit_identity_epoch), so the new-epoch rebuild above
+  //     inserts a fresh row and leaves the pre-mutation row behind.
+  await tx.$executeRaw`
+    DELETE FROM unit_public_projection
+    WHERE unit_id = ${unitId}
+      AND unit_identity_epoch < ${currentEpoch}
+  `;
+}
+
 async function handleIdentityMutation(
   tx: TransactionClient,
   event: OutboxRow
 ): Promise<HandlerResult> {
-  // Phase 02: Identity mutations fan out cache invalidations to every affected unit.
+  // Phase 02: Identity mutations fan out cache invalidations to every affected
+  // unit and re-point that unit's inventories/projections to the new identity
+  // epoch (recordIdentityMutation bumped the unit epoch but left the projection
+  // rows at the old epoch — see reprojectUnitAfterIdentityMutation).
   try {
     if (features.pauseIdentityReconcile) {
       return {
@@ -321,6 +431,14 @@ async function handleIdentityMutation(
     const projectionEpoch = currentProjectionEpoch();
 
     for (const unitId of affectedUnitIds) {
+      // Re-point inventories + rebuild projections at the unit's current epoch
+      // before invalidating caches, so cache consumers observe the rebuilt rows.
+      await reprojectUnitAfterIdentityMutation(
+        tx,
+        unitId,
+        event.unitIdentityEpoch
+      );
+
       const ciId = randomUUID();
       await tx.$executeRaw`
         INSERT INTO cache_invalidations (id, unit_id, projection_epoch, unit_identity_epoch, reason, enqueued_at)

--- a/src/lib/search-params.ts
+++ b/src/lib/search-params.ts
@@ -130,6 +130,13 @@ export interface RawSearchParams {
   bookingMode?: string | string[];
   minAvailableSlots?: string | string[];
   minSlots?: string | string[];
+  // Occupants aliases — capacity synonyms honored by the projection admission
+  // path; resolved here into minAvailableSlots so the SearchDoc filter and the
+  // query hash see the same canonical capacity value (P2-4).
+  occupants?: string | string[];
+  guests?: string | string[];
+  requestedOccupants?: string | string[];
+  requested_occupants?: string | string[];
   minLat?: string | string[];
   maxLat?: string | string[];
   minLng?: string | string[];
@@ -865,7 +872,15 @@ export function parseSearchParams(raw: RawSearchParams): ParsedSearchParams {
       householdGender: getFirstValue(raw.householdGender),
       bookingMode: getFirstValue(raw.bookingMode),
       bounds,
-      minAvailableSlots: getFirstValue(raw.minAvailableSlots),
+      // Occupants aliases resolve to the canonical capacity value (P2-4).
+      // Precedence mirrors the projection admission read; minSlots stays the
+      // final fallback via normalizeSearchFilters (minAvailableSlots ?? minSlots).
+      minAvailableSlots:
+        getFirstValue(raw.requested_occupants) ??
+        getFirstValue(raw.requestedOccupants) ??
+        getFirstValue(raw.occupants) ??
+        getFirstValue(raw.guests) ??
+        getFirstValue(raw.minAvailableSlots),
       minSlots: getFirstValue(raw.minSlots),
       nearMatches: getFirstValue(raw.nearMatches),
       sort: getFirstValue(raw.sort),

--- a/src/lib/search/cursor.ts
+++ b/src/lib/search/cursor.ts
@@ -72,6 +72,15 @@ export interface SearchPaginationSnapshot {
   responseVersion: string;
   projectionVersion: number;
   embeddingVersion: string | null;
+  /**
+   * Bare filter query hash the cursor was minted under (P2-20). Binds the keyset
+   * cursor to its filter set so a cursor from query A cannot be replayed against
+   * query B's WHERE (same sort), which would silently duplicate/skip rows.
+   * Optional for backward compat: cursors minted before this field shipped decode
+   * without it and are treated as stale (rejected on first use, mirroring the
+   * snapshot-cursor queryHash check).
+   */
+  qh?: string;
 }
 
 export interface SnapshotCursorV3 {
@@ -142,6 +151,7 @@ const SearchPaginationSnapshotSchema = z
     responseVersion: z.string().min(1),
     projectionVersion: z.number().int().nonnegative(),
     embeddingVersion: z.string().nullable(),
+    qh: z.string().min(1).optional(),
   })
   .strict();
 

--- a/src/lib/search/projection-search.ts
+++ b/src/lib/search/projection-search.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildPhase04SearchSpec,
   getPhase04SearchSpecHash,
+  PHASE04_MAX_GAP_DAYS,
   type SearchAdmissionError,
   type SearchSpec,
 } from "@/lib/search/search-spec";
@@ -44,9 +45,9 @@ import {
 } from "./transform";
 import { toPublicSearchListings } from "./public-listing-payload";
 import {
-  buildPublicAvailability,
+  resolvePublicAvailability,
   STALE_THRESHOLD_DAYS,
-  type PublicAvailability,
+  type ResolvedPublicAvailability,
 } from "./public-availability";
 import {
   isPhase04ForceClustersOnlyActive,
@@ -113,6 +114,9 @@ interface ProjectionUnitRow {
   displaySubtitle: string | null;
   heroImageUrl: string | null;
   hostIdentityStatus: HostIdentityStatus;
+  representativeStatus: string;
+  representativeStatusReason: string | null;
+  lastConfirmedAt: Date | null;
   projectionEpoch: bigint;
   sourceVersion: bigint;
 }
@@ -134,6 +138,9 @@ interface RawProjectionUnitRow {
   display_subtitle: string | null;
   hero_image_url: string | null;
   host_identity_status?: string | null;
+  representative_status?: string | null;
+  representative_status_reason?: string | null;
+  last_confirmed_at?: Date | string | null;
   projection_epoch: bigint | number | string;
   source_version: bigint | number | string;
 }
@@ -202,6 +209,15 @@ function normalizeProjectionRow(row: RawProjectionUnitRow): ProjectionUnitRow {
     displaySubtitle: row.display_subtitle,
     heroImageUrl: row.hero_image_url,
     hostIdentityStatus: normalizeHostIdentityStatus(row.host_identity_status),
+    representativeStatus:
+      typeof row.representative_status === "string" && row.representative_status
+        ? row.representative_status
+        : "ACTIVE",
+    representativeStatusReason:
+      typeof row.representative_status_reason === "string"
+        ? row.representative_status_reason
+        : null,
+    lastConfirmedAt: parseDate(row.last_confirmed_at ?? null),
     projectionEpoch: BigInt(row.projection_epoch ?? 1),
     sourceVersion: BigInt(row.source_version ?? 1),
   };
@@ -262,13 +278,22 @@ function parseUnitKeys(unitKeys: string[]): ParsedUnitKey[] {
 
 function buildPublicAvailabilityForRow(
   row: ProjectionUnitRow
-): PublicAvailability {
-  return buildPublicAvailability({
+): ResolvedPublicAvailability {
+  // Resolve the full freshness/status read-model (freshnessBucket, publicStatus,
+  // searchEligible, staleAt, …) the same way the SearchDoc engine does, so the
+  // projection (dev/preview) and SearchDoc (prod) paths render identical
+  // freshness UI (P2-11). Every projection row already satisfies l.status =
+  // 'ACTIVE' via the eligibility WHERE; lastConfirmedAt drives the bucket.
+  return resolvePublicAvailability({
+    id: row.representativeInventoryId,
+    status: row.representativeStatus,
+    statusReason: row.representativeStatusReason,
     openSlots: row.matchingInventoryCount,
     availableSlots: row.matchingInventoryCount,
     totalSlots: row.matchingInventoryCount,
     moveInDate: row.earliestAvailableFrom ?? undefined,
     minStayMonths: 1,
+    lastConfirmedAt: row.lastConfirmedAt ?? undefined,
   });
 }
 
@@ -467,11 +492,14 @@ async function queryProjectionUnitRows(
     spec.filterParams.genderPreference &&
     spec.filterParams.genderPreference !== "any"
   ) {
+    // Strict equality matches the SearchDoc engine (cross-engine parity): a row
+    // with an unspecified (NULL) gender preference does NOT match a specific
+    // filter, so membership can't flip when only the sort changes engines.
     where.push(
-      `(isp.gender_preference IS NULL OR isp.gender_preference = ${addParam(
+      `isp.gender_preference = ${addParam(
         params,
         spec.filterParams.genderPreference
-      )})`
+      )}`
     );
   }
   if (
@@ -479,16 +507,22 @@ async function queryProjectionUnitRows(
     spec.filterParams.householdGender !== "any"
   ) {
     where.push(
-      `(isp.household_gender IS NULL OR isp.household_gender = ${addParam(
+      `isp.household_gender = ${addParam(
         params,
         spec.filterParams.householdGender
-      )})`
+      )}`
     );
   }
 
   if (spec.filterParams.moveInDate) {
     const moveIn = addParam(params, spec.filterParams.moveInDate);
-    const gapDays = addParam(params, spec.maxGapDays);
+    // SearchDoc parity: the default move-in match is exact (available on/before
+    // the requested date). search-spec.ts collapses an absent max_gap_days to
+    // PHASE04_MAX_GAP_DAYS, so treat that sentinel default as a 0-day gap; an
+    // explicitly supplied (sub-cap) max_gap_days is honored as a near-match window.
+    const effectiveGapDays =
+      spec.maxGapDays >= PHASE04_MAX_GAP_DAYS ? 0 : spec.maxGapDays;
+    const gapDays = addParam(params, effectiveGapDays);
     where.push(
       `isp.available_from <= (${moveIn}::DATE + (${gapDays}::INTEGER * INTERVAL '1 day'))`
     );
@@ -553,6 +587,9 @@ async function queryProjectionUnitRows(
       upp.display_subtitle,
       upp.hero_image_url,
       (array_agg(CASE WHEN u."isVerified" THEN 'verified' ELSE 'unverified' END ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS host_identity_status,
+      (array_agg(l.status ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS representative_status,
+      (array_agg(l."statusReason" ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS representative_status_reason,
+      (array_agg(l."lastConfirmedAt" ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS last_confirmed_at,
       GREATEST(upp.projection_epoch, MAX(isp.projection_epoch)) AS projection_epoch,
       GREATEST(upp.source_version, MAX(isp.source_version)) AS source_version
     FROM inventory_search_projection isp
@@ -671,6 +708,9 @@ async function fetchProjectionRowsByUnitKeys(
       upp.display_subtitle,
       upp.hero_image_url,
       (array_agg(CASE WHEN u."isVerified" THEN 'verified' ELSE 'unverified' END ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS host_identity_status,
+      (array_agg(l.status ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS representative_status,
+      (array_agg(l."statusReason" ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS representative_status_reason,
+      (array_agg(l."lastConfirmedAt" ORDER BY isp.price ASC, isp.available_from ASC, isp.inventory_id ASC))[1] AS last_confirmed_at,
       GREATEST(upp.projection_epoch, MAX(isp.projection_epoch)) AS projection_epoch,
       GREATEST(upp.source_version, MAX(isp.source_version)) AS source_version
     FROM unit_public_projection upp
@@ -963,6 +1003,13 @@ export async function executeProjectionSearchV2(input: {
     };
   }
   const spec = specResult.spec;
+  // KNOWN SEAM (review P1-5, deferred pre-cutover gate): this spec hash folds
+  // version tokens (projectionEpoch/embeddingVersion/rankerProfileVersion/
+  // unitIdentityEpochFloor) and is used BOTH as the snapshot/cursor staleness
+  // fence AND as meta.queryHash. The client computes the bare filters hash, so
+  // if phase04 projection reads ship together with the unified V2 client, the
+  // meta hash must be split from the fence hash (bare hash in meta; spec hash
+  // stays inside the cursor/snapshot) before cutover.
   const queryHash = getPhase04SearchSpecHash(spec);
   const eligibility = getProjectionReadEligibility(input.parsed);
   if (!eligibility.supported) {

--- a/src/lib/search/public-availability.ts
+++ b/src/lib/search/public-availability.ts
@@ -43,6 +43,19 @@ export interface ResolvedPublicAvailability
   isPubliclyAvailable: boolean;
 }
 
+/**
+ * The exact availability shape that may leave the server for anonymous clients.
+ * Equals the seven base {@link PublicAvailability} fields plus the two
+ * UI-consumed display fields (`freshnessBucket`, `publicStatus`). Every internal
+ * lifecycle/eligibility field on {@link ResolvedPublicAvailability} — `staleAt`,
+ * `autoPauseAt`, `searchEligible`, `isValid`, `isPubliclyAvailable`,
+ * `effectiveAvailableSlots` — is intentionally excluded from the public payload.
+ */
+export interface PublicAvailabilityPayload extends PublicAvailability {
+  freshnessBucket?: FreshnessBucket;
+  publicStatus?: PublicStatus;
+}
+
 export interface PublicSearchEligibilityInput {
   needsMigrationReview?: boolean | null;
   statusReason?: string | null;
@@ -268,6 +281,41 @@ export function buildPublicAvailability(
     minStayMonths: Math.max(1, toSafeCount(input.minStayMonths, 1)),
     lastConfirmedAt: toIsoString(input.lastConfirmedAt),
   };
+}
+
+type PublicAvailabilityPayloadInput = PublicAvailability &
+  Partial<Pick<FreshnessReadModel, "freshnessBucket" | "publicStatus">>;
+
+/**
+ * Field-pick the public availability boundary shape for serialization to
+ * anonymous clients. Accepts either the narrow seven-field
+ * {@link PublicAvailability} or a fully {@link ResolvedPublicAvailability} and
+ * returns only the fields safe to expose: the seven base fields plus
+ * `freshnessBucket`/`publicStatus` when present. All other resolved fields
+ * (`staleAt`, `autoPauseAt`, `searchEligible`, `isValid`, `isPubliclyAvailable`,
+ * `effectiveAvailableSlots`) are dropped so they never widen a public payload.
+ */
+export function toPublicAvailabilityPayload(
+  availability: PublicAvailabilityPayloadInput
+): PublicAvailabilityPayload {
+  const payload: PublicAvailabilityPayload = {
+    availabilitySource: availability.availabilitySource,
+    openSlots: availability.openSlots,
+    totalSlots: availability.totalSlots,
+    availableFrom: availability.availableFrom,
+    availableUntil: availability.availableUntil,
+    minStayMonths: availability.minStayMonths,
+    lastConfirmedAt: availability.lastConfirmedAt,
+  };
+
+  if (availability.freshnessBucket !== undefined) {
+    payload.freshnessBucket = availability.freshnessBucket;
+  }
+  if (availability.publicStatus !== undefined) {
+    payload.publicStatus = availability.publicStatus;
+  }
+
+  return payload;
 }
 
 function isFutureOrSameDay(

--- a/src/lib/search/public-listing-payload.ts
+++ b/src/lib/search/public-listing-payload.ts
@@ -10,7 +10,8 @@ import type {
 import { toPublicCoordinates } from "@/lib/search/public-coordinates";
 import {
   buildPublicAvailability,
-  type PublicAvailability,
+  toPublicAvailabilityPayload,
+  type PublicAvailabilityPayload,
 } from "@/lib/search/public-availability";
 
 export const PUBLIC_GROUP_KEY_PREFIX = "pg1_";
@@ -117,19 +118,19 @@ export function toPublicGroupMetadata(
 
 function normalizePublicAvailability(
   listing: ListingData | MapListingData
-): PublicAvailability {
-  return (
+): PublicAvailabilityPayload {
+  return toPublicAvailabilityPayload(
     listing.publicAvailability ??
-    buildPublicAvailability({
-      availabilitySource: listing.availabilitySource,
-      openSlots: listing.openSlots,
-      availableSlots: listing.availableSlots,
-      totalSlots: listing.totalSlots,
-      moveInDate: listing.moveInDate,
-      availableUntil: listing.availableUntil,
-      minStayMonths: listing.minStayMonths,
-      lastConfirmedAt: listing.lastConfirmedAt,
-    })
+      buildPublicAvailability({
+        availabilitySource: listing.availabilitySource,
+        openSlots: listing.openSlots,
+        availableSlots: listing.availableSlots,
+        totalSlots: listing.totalSlots,
+        moveInDate: listing.moveInDate,
+        availableUntil: listing.availableUntil,
+        minStayMonths: listing.minStayMonths,
+        lastConfirmedAt: listing.lastConfirmedAt,
+      })
   );
 }
 
@@ -187,6 +188,7 @@ export function toPublicSearchListings(
 export function toPublicMapListing(listing: MapListingData): MapListingData {
   const publicCoordinates = toPublicCoordinates(listing.location);
   const publicGroupMetadata = toPublicGroupMetadata(listing);
+  const publicAvailability = normalizePublicAvailability(listing);
 
   return {
     ...listing,
@@ -195,6 +197,7 @@ export function toPublicMapListing(listing: MapListingData): MapListingData {
       lat: publicCoordinates.lat,
       lng: publicCoordinates.lng,
     },
+    publicAvailability,
     groupKey: publicGroupMetadata.groupKey,
     groupSummary: publicGroupMetadata.groupSummary,
     groupContext: publicGroupMetadata.groupContext,

--- a/src/lib/search/query-snapshots.ts
+++ b/src/lib/search/query-snapshots.ts
@@ -149,3 +149,19 @@ export async function loadValidQuerySnapshot(
 
   return { ok: true, snapshot };
 }
+
+/**
+ * Reap query snapshots whose TTL has elapsed (P2-19). Snapshots are written per
+ * first-page projection / snapshot-contract search with a short TTL and are only
+ * ever read by id with an expiry check (`loadValidQuerySnapshot`), so expired
+ * rows are dead weight. The daily-maintenance cron calls this to bound table
+ * growth. Deletes rows with `expiresAt < now`; unexpired rows are kept.
+ */
+export async function deleteExpiredQuerySnapshots(
+  now: Date = new Date()
+): Promise<number> {
+  const result = await prisma.querySnapshot.deleteMany({
+    where: { expiresAt: { lt: now } },
+  });
+  return result.count;
+}

--- a/src/lib/search/search-doc-queries.ts
+++ b/src/lib/search/search-doc-queries.ts
@@ -55,10 +55,14 @@ import type {
 } from "./cursor";
 import { buildCursorFromRow, encodeKeysetCursor } from "./cursor";
 import {
-  buildPublicAvailability,
   isListingEligibleForPublicSearch,
   resolvePublicAvailability,
 } from "./public-availability";
+import {
+  SEARCH_COUNT_CACHE_TAG,
+  SEARCH_MAP_CACHE_TAG,
+  SEARCH_RESULTS_CACHE_TAG,
+} from "./search-cache";
 import { toPublicCoordinates } from "./public-coordinates";
 import pgvector from "pgvector";
 import { getCachedQueryEmbedding } from "@/lib/embeddings/query-cache";
@@ -286,6 +290,12 @@ function quantizeBound(value: number): number {
 export function buildBaseCacheFields(params: FilterParams) {
   return {
     q: params.query?.toLowerCase().trim() || "",
+    // vibeQuery is user-visible text input. It does not reach the cached
+    // SearchDoc SQL today (semantic path is uncached; soft-vibe rerank runs
+    // outside unstable_cache), but omitting it here would silently collide
+    // distinct vibe searches the day a refactor lets vibeQuery influence the
+    // cached query — so key on it defensively, matching buildSearchQueryHashPrefix8.
+    vibeQuery: params.vibeQuery?.toLowerCase().trim() || "",
     minPrice: params.minPrice ?? "",
     maxPrice: params.maxPrice ?? "",
     amenities: [...(params.amenities || [])].sort().join(","),
@@ -1093,6 +1103,65 @@ export function buildOrderByClause(
 // Limited Count Query (Hybrid Pagination)
 // ============================================
 
+/**
+ * Narrow row shape for dedup-aware counting. Carries exactly the fields the
+ * dedup group key derives from (owner + address + price + title + roomType),
+ * plus the address components used when `normalizedAddress` is absent.
+ */
+interface DedupCountRow {
+  id: string;
+  ownerId: string | null;
+  normalizedAddress: string | null;
+  price: number | string;
+  title: string;
+  roomType: string | null;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+}
+
+function toDedupCountSearchRow(row: DedupCountRow): SearchRowForDedup {
+  return {
+    id: row.id,
+    ownerId: row.ownerId ?? "",
+    title: row.title,
+    price: Number(row.price),
+    roomType: row.roomType ?? null,
+    // Non-key fields — irrelevant to the group key, so left empty/zero.
+    moveInDate: null,
+    availableUntil: null,
+    openSlots: null,
+    totalSlots: 0,
+    normalizedAddress: row.normalizedAddress ?? null,
+    location: {
+      address: row.address ?? null,
+      city: row.city,
+      state: row.state,
+      zip: row.zip ?? null,
+    },
+  };
+}
+
+/**
+ * Count DISTINCT canonical dedup groups among raw rows, reusing the exact
+ * grouping the list path applies (`applyServerDedup`). Input is bounded to
+ * ≤ HYBRID_COUNT_THRESHOLD + 1 rows, so the JS grouping is cheap.
+ */
+export function countDedupCanonicalGroups(rows: DedupCountRow[]): number {
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  const { canonicals } = applyServerDedup(rows.map(toDedupCountSearchRow), {
+    enabled: true,
+    limit: rows.length,
+    lookAhead: SEARCH_DEDUP_LOOK_AHEAD,
+  });
+
+  return canonicals.length;
+}
+
 async function getSearchDocLimitedCountInternal(
   params: FilterParams
 ): Promise<number | null> {
@@ -1108,6 +1177,43 @@ async function getSearchDocLimitedCountInternal(
     conditions,
     SEARCH_DOC_ALLOWED_SQL_LITERALS
   );
+
+  // Dedup-aware total: when dedup is active the rendered page shows canonical
+  // groups, so the reported total must count DISTINCT canonicals — not raw
+  // listings (P2-6). Fetch up to HYBRID_COUNT_THRESHOLD+1 raw rows with the
+  // dedup-key fields and collapse them with the same grouping the list path
+  // uses. Bounded to ≤101 rows, so the JS grouping is cheap. If raw rows exceed
+  // the threshold we still return null ("100+"), matching the non-dedup cap;
+  // this can only over-report precision, never overcount the fixed page.
+  if (features.searchListingDedup) {
+    const dedupCountRows = await queryWithTimeout<DedupCountRow>(
+      `
+        SELECT
+          d.id,
+          l."ownerId" as "ownerId",
+          l."normalizedAddress" as "normalizedAddress",
+          d.price,
+          d.title,
+          d.room_type as "roomType",
+          d.address,
+          d.city,
+          d.state,
+          d.zip
+        FROM listing_search_docs d
+        JOIN "Listing" l ON l.id = d.id
+        JOIN "User" u ON u.id = l."ownerId"
+        WHERE ${whereClause}
+        LIMIT ${HYBRID_COUNT_THRESHOLD + 1}
+      `,
+      queryParams
+    );
+
+    if (dedupCountRows.length > HYBRID_COUNT_THRESHOLD) {
+      return null;
+    }
+
+    return countDedupCanonicalGroups(dedupCountRows);
+  }
 
   // Use subquery with LIMIT 101 to efficiently check if count > threshold
   const limitedCountQuery = `
@@ -1147,7 +1253,9 @@ export async function getSearchDocLimitedCount(
   const cachedFn = unstable_cache(
     async () => getSearchDocLimitedCountInternal(params),
     ["searchdoc-limited-count", cacheKey],
-    { revalidate: 60 }
+    // Tag so invalidateSearchCaches (search-cache.ts) can event-invalidate on
+    // capacity-affecting mutations instead of relying on TTL alone (P2-18).
+    { revalidate: 60, tags: [SEARCH_COUNT_CACHE_TAG] }
   );
 
   return cachedFn();
@@ -1491,7 +1599,9 @@ export async function getSearchDocMapListings(
   const cachedFn = unstable_cache(
     async () => getSearchDocMapListingsInternal(params),
     ["searchdoc-map-listings", cacheKey],
-    { revalidate: 60 }
+    // Tag so invalidateSearchCaches (search-cache.ts) can event-invalidate on
+    // capacity-affecting mutations instead of relying on TTL alone (P2-18).
+    { revalidate: 60, tags: [SEARCH_MAP_CACHE_TAG] }
   );
 
   return cachedFn();
@@ -1755,7 +1865,9 @@ export async function getSearchDocListingsPaginated(
   const cachedFn = unstable_cache(
     async () => getSearchDocListingsPaginatedInternal(params),
     ["searchdoc-listings-paginated", cacheKey],
-    { revalidate: 60 }
+    // Tag so invalidateSearchCaches (search-cache.ts) can event-invalidate on
+    // capacity-affecting mutations instead of relying on TTL alone (P2-18).
+    { revalidate: 60, tags: [SEARCH_RESULTS_CACHE_TAG] }
   );
 
   return cachedFn();
@@ -2402,44 +2514,61 @@ export function mapSemanticRowsToListingData(
 ): ListingData[] {
   return rows
     .filter((row) => hasValidCoordinates(row.lat, row.lng))
-    .map((row) => ({
-      id: row.id,
-      title: row.title,
-      description: row.description,
-      price: Number(row.price),
-      images: row.images,
-      roomType: row.room_type ?? undefined,
-      leaseDuration: row.lease_duration ?? undefined,
-      availableSlots: row.available_slots,
-      totalSlots: row.total_slots,
-      amenities: row.amenities,
-      houseRules: row.house_rules,
-      householdLanguages: row.household_languages,
-      primaryHomeLanguage: row.primary_home_language ?? undefined,
-      genderPreference: row.gender_preference ?? undefined,
-      householdGender: row.household_gender ?? undefined,
-      moveInDate: row.move_in_date ?? undefined,
-      publicAvailability: buildPublicAvailability({
+    .map((row) => {
+      // Mirror the main SearchDoc path's availability resolution so semantic
+      // items carry the full freshness read model (freshnessBucket, publicStatus,
+      // searchEligible) instead of the narrow 7-field shape (P2-11). The semantic
+      // SQL function only selects docs where sd.status = 'ACTIVE', and the doc's
+      // available_slots is the host-managed open-slot count. The function does
+      // not return lastConfirmedAt/availableUntil, so those stay null.
+      const { moveInDate, resolvedAvailability } = resolveRawPublicAvailability({
+        id: row.id,
+        availabilitySource: "HOST_MANAGED",
         availableSlots: row.available_slots,
         totalSlots: row.total_slots,
-        moveInDate: row.move_in_date ?? undefined,
-      }),
-      // ownerId intentionally omitted — @deprecated, S3 security fix (types/listing.ts:28)
-      // Match mapRawListingsToPublic: include rating/review/view/createdAt fields
-      // for ListingCard rendering (star ratings, review counts, recency)
-      avgRating: Number(row.avg_rating) || 0,
-      reviewCount: Number(row.review_count) || 0,
-      viewCount: Number(row.view_count) || 0,
-      createdAt: row.listing_created_at ?? new Date(),
-      hostIdentityStatus: "unknown",
-      location: {
-        // address and zip intentionally omitted — "only included in listing detail, not search" (search-types.ts:37)
-        city: row.city,
-        state: row.state,
-        ...toPublicCoordinates({
-          lat: row.lat!,
-          lng: row.lng!,
-        }),
-      },
-    }));
+        openSlots: row.available_slots,
+        availableUntil: null,
+        lastConfirmedAt: null,
+        moveInDate: row.move_in_date ?? null,
+        status: "ACTIVE",
+        statusReason: null,
+      });
+
+      return {
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        price: Number(row.price),
+        images: row.images,
+        roomType: row.room_type ?? undefined,
+        leaseDuration: row.lease_duration ?? undefined,
+        availableSlots: resolvedAvailability.effectiveAvailableSlots,
+        totalSlots: resolvedAvailability.totalSlots,
+        amenities: row.amenities,
+        houseRules: row.house_rules,
+        householdLanguages: row.household_languages,
+        primaryHomeLanguage: row.primary_home_language ?? undefined,
+        genderPreference: row.gender_preference ?? undefined,
+        householdGender: row.household_gender ?? undefined,
+        moveInDate,
+        publicAvailability: resolvedAvailability,
+        // ownerId intentionally omitted — @deprecated, S3 security fix (types/listing.ts:28)
+        // Match mapRawListingsToPublic: include rating/review/view/createdAt fields
+        // for ListingCard rendering (star ratings, review counts, recency)
+        avgRating: Number(row.avg_rating) || 0,
+        reviewCount: Number(row.review_count) || 0,
+        viewCount: Number(row.view_count) || 0,
+        createdAt: row.listing_created_at ?? new Date(),
+        hostIdentityStatus: "unknown",
+        location: {
+          // address and zip intentionally omitted — "only included in listing detail, not search" (search-types.ts:37)
+          city: row.city,
+          state: row.state,
+          ...toPublicCoordinates({
+            lat: row.lat!,
+            lng: row.lng!,
+          }),
+        },
+      };
+    });
 }

--- a/src/lib/search/search-spec.ts
+++ b/src/lib/search/search-spec.ts
@@ -74,12 +74,27 @@ function parsePositiveFloat(value: string | undefined): number | null {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
-export function buildPhase04SearchSpec(input: {
+/**
+ * Engine-independent admission caps (P2-3).
+ *
+ * The occupants>20 and deep-page>20 rejections are pure cost/perf gates that
+ * must run on EVERY read engine, not just the dev-default projection path —
+ * otherwise a request that 400s in dev (projection ON) runs an expensive scan
+ * in prod (SearchDoc, flag OFF). executeSearchV2 hoists this ahead of the engine
+ * branch; buildPhase04SearchSpec still calls it so the projection count fast-path
+ * (getProjectionSearchCount) keeps rejecting these independently.
+ *
+ * Reads the RAW occupants value (unclamped) so occupants>20 is a hard 400 even
+ * though the parser clamps the canonical capacity filter to <=20.
+ *
+ * NOTE: the bounds-span cap is deliberately NOT hoisted — wide-view default-sort
+ * browse is a supported prod UX on the list path (the map query clamps its own
+ * bounds separately), so the span limit stays projection-only, below.
+ */
+export function evaluateSearchAdmissionCaps(input: {
   parsed: ParsedSearchParams;
   rawParams: RawSearchParams | Record<string, string | string[] | undefined>;
-  pageSize: number;
-  versions: SearchSpecVersionTokens;
-}): { ok: true; spec: SearchSpec } | { ok: false; error: SearchAdmissionError } {
+}): SearchAdmissionError | null {
   const rawOccupants = parsePositiveInt(
     getFirstRaw(input.rawParams, [
       "requested_occupants",
@@ -90,17 +105,37 @@ export function buildPhase04SearchSpec(input: {
       "minAvailableSlots",
     ])
   );
-  const requestedOccupants =
-    rawOccupants ?? input.parsed.filterParams.minAvailableSlots ?? 1;
-  if (requestedOccupants > PHASE04_MAX_OCCUPANTS) {
+  if (rawOccupants !== null && rawOccupants > PHASE04_MAX_OCCUPANTS) {
     return {
-      ok: false,
-      error: {
-        code: "requested_occupants_too_high",
-        message: `requested_occupants must be <= ${PHASE04_MAX_OCCUPANTS}`,
-        status: 400,
-      },
+      code: "requested_occupants_too_high",
+      message: `requested_occupants must be <= ${PHASE04_MAX_OCCUPANTS}`,
+      status: 400,
     };
+  }
+
+  if (input.parsed.requestedPage > PHASE04_DEEP_PAGE_CAP) {
+    return {
+      code: "deep_paging_capped",
+      message: `page must be <= ${PHASE04_DEEP_PAGE_CAP}`,
+      status: 400,
+    };
+  }
+
+  return null;
+}
+
+export function buildPhase04SearchSpec(input: {
+  parsed: ParsedSearchParams;
+  rawParams: RawSearchParams | Record<string, string | string[] | undefined>;
+  pageSize: number;
+  versions: SearchSpecVersionTokens;
+}): { ok: true; spec: SearchSpec } | { ok: false; error: SearchAdmissionError } {
+  const admissionError = evaluateSearchAdmissionCaps({
+    parsed: input.parsed,
+    rawParams: input.rawParams,
+  });
+  if (admissionError) {
+    return { ok: false, error: admissionError };
   }
 
   const maxGapDays =
@@ -132,18 +167,6 @@ export function buildPhase04SearchSpec(input: {
     };
   }
 
-  const page = input.parsed.requestedPage;
-  if (page > PHASE04_DEEP_PAGE_CAP) {
-    return {
-      ok: false,
-      error: {
-        code: "deep_paging_capped",
-        message: `page must be <= ${PHASE04_DEEP_PAGE_CAP}`,
-        status: 400,
-      },
-    };
-  }
-
   const bounds = input.parsed.filterParams.bounds;
   if (bounds) {
     const latSpan = Math.abs(bounds.maxLat - bounds.minLat);
@@ -163,6 +186,13 @@ export function buildPhase04SearchSpec(input: {
     }
   }
 
+  // P2-4: single source of truth — the parser resolves every occupants alias
+  // (occupants/guests/requested_occupants/minSlots) into
+  // filterParams.minAvailableSlots, so the projection SQL, the SearchDoc filter,
+  // and the query hash all read the same canonical capacity value. Pathological
+  // occupants>20 is rejected above via the raw, unclamped admission read.
+  const requestedOccupants = input.parsed.filterParams.minAvailableSlots ?? 1;
+  const page = input.parsed.requestedPage;
   const pageSize = Math.max(1, Math.min(input.pageSize, MAX_PAGE_SIZE));
   return {
     ok: true,

--- a/src/lib/search/search-v2-service.ts
+++ b/src/lib/search/search-v2-service.ts
@@ -85,7 +85,6 @@ import {
   isPhase04ForceListOnlyActive,
   isPhase04ProjectionReadsEnabled,
 } from "@/lib/flags/phase04";
-import { getReadEmbeddingVersion } from "@/lib/embeddings/version";
 import {
   executeProjectionSearchV2,
   hasProjectionFreshnessHoles,
@@ -94,7 +93,10 @@ import {
   getProjectionReadEligibility,
   type ProjectionReadEligibility,
 } from "@/lib/search/projection-read-eligibility";
-import type { SearchAdmissionError } from "@/lib/search/search-spec";
+import {
+  evaluateSearchAdmissionCaps,
+  type SearchAdmissionError,
+} from "@/lib/search/search-spec";
 
 const VIBE_SOFT_FALLBACK_WARNING = "VIBE_SOFT_FALLBACK";
 const SEARCH_PAGINATION_SNAPSHOT_VERSION = `${SEARCH_RESPONSE_VERSION}.searchdoc-keyset`;
@@ -629,18 +631,28 @@ export async function executeSearchV2(
       };
     }
 
+    // P2-3: enforce the engine-independent admission caps (occupants>20,
+    // page>20) BEFORE the engine branch so prod's SearchDoc path rejects the
+    // same pathological requests the dev-default projection path already did.
+    // The routes surface this via their existing admissionError handling.
+    const admissionError = evaluateSearchAdmissionCaps({
+      parsed,
+      rawParams: params.rawParams,
+    });
+    if (admissionError) {
+      return { response: null, paginatedResult: null, admissionError };
+    }
+
     // Get sort option from parsed params (default to recommended)
     const sortOption: SortOption =
       (parsed.filterParams.sort as SortOption) || "recommended";
-    const hashVibeQuery = parsed.filterParams.vibeQuery?.trim();
-    const hashEmbeddingVersion =
-      features.semanticSearch &&
-      hashVibeQuery &&
-      hashVibeQuery.length >= 3 &&
-      sortOption === "recommended"
-        ? getReadEmbeddingVersion()
-        : undefined;
 
+    // P1-5: meta.queryHash is the client-facing contract and MUST be the bare
+    // filters hash (no version tokens). The client discards any response whose
+    // meta.queryHash != the bare hash it computes from the same URL params, so
+    // adding embeddingVersion here made every semantic response get dropped.
+    // Version staleness lives in dedicated meta fields (embeddingVersion,
+    // projectionVersion, …) and, for pagination, inside cursor/snapshot records.
     const queryHash = generateQueryHash({
       query: parsed.filterParams.query,
       vibeQuery: parsed.filterParams.vibeQuery,
@@ -659,9 +671,6 @@ export async function executeSearchV2(
       minAvailableSlots: parsed.filterParams.minAvailableSlots,
       bounds: parsed.filterParams.bounds,
       nearMatches: parsed.filterParams.nearMatches,
-      ...(hashEmbeddingVersion
-        ? { embeddingVersion: hashEmbeddingVersion }
-        : {}),
     });
 
     if (isPhase04ProjectionReadsEnabled()) {
@@ -728,6 +737,9 @@ export async function executeSearchV2(
           responseVersion: SEARCH_PAGINATION_SNAPSHOT_VERSION,
           projectionVersion: SEARCH_DOC_PROJECTION_VERSION,
           embeddingVersion: null,
+          // P2-20: bind the keyset cursor to the bare filter hash so a cursor
+          // minted under one filter set is rejected when replayed under another.
+          qh: queryHash,
         }
       : undefined;
 
@@ -742,6 +754,13 @@ export async function executeSearchV2(
       if (decoded?.type === "snapshot") {
         snapshotCursor = decoded.cursor;
       } else if (useKeyset && decoded?.type === "keyset") {
+        // P2-20: bind V2 keyset cursors to the bare filter hash (`qh`) in
+        // addition to the existing engine/version snapshot checks — a cursor
+        // minted under filter set A replayed under filter set B (same sort) must
+        // not be honored, since B's WHERE + A's boundary duplicates/skips rows.
+        // A cursor minted before `qh` shipped decodes without it (undefined) and
+        // is treated as stale. (Legacy V1 cursors carry no snapshot and are never
+        // minted on this path; they remain tolerated for backward compat.)
         if (
           keysetSnapshot &&
           decoded.cursor.v === 2 &&
@@ -751,7 +770,8 @@ export async function executeSearchV2(
             decoded.cursor.snapshot.projectionVersion !==
               keysetSnapshot.projectionVersion ||
             decoded.cursor.snapshot.embeddingVersion !==
-              keysetSnapshot.embeddingVersion)
+              keysetSnapshot.embeddingVersion ||
+            decoded.cursor.snapshot.qh !== keysetSnapshot.qh)
         ) {
           return {
             response: null,
@@ -963,10 +983,7 @@ export async function executeSearchV2(
         listSettled.value);
     } else {
       logger.sync.error("[SearchV2] List query failed", {
-        error:
-          listSettled.reason instanceof Error
-            ? listSettled.reason.message
-            : "Unknown",
+        error: sanitizeErrorMessage(listSettled.reason),
       });
       return {
         response: null,
@@ -989,10 +1006,7 @@ export async function executeSearchV2(
       }
     } else if (mapSettled?.status === "rejected") {
       logger.sync.error("[SearchV2] Map query failed", {
-        error:
-          mapSettled.reason instanceof Error
-            ? mapSettled.reason.message
-            : "Unknown",
+        error: sanitizeErrorMessage(mapSettled.reason),
       });
       mapListings = [];
       warnings.push("MAP_QUERY_FAILED");

--- a/src/lib/search/transform.ts
+++ b/src/lib/search/transform.ts
@@ -25,7 +25,8 @@ import {
 } from "./types";
 import {
   buildPublicAvailability,
-  type PublicAvailability,
+  toPublicAvailabilityPayload,
+  type PublicAvailabilityPayload,
 } from "./public-availability";
 import { toPublicCoordinates } from "./public-coordinates";
 import { toPublicGroupMetadata } from "./public-listing-payload";
@@ -45,19 +46,19 @@ type AvailabilityLike = Pick<
 
 function getNormalizedPublicAvailability(
   listing: AvailabilityLike
-): PublicAvailability {
-  return (
+): PublicAvailabilityPayload {
+  return toPublicAvailabilityPayload(
     listing.publicAvailability ??
-    buildPublicAvailability({
-      availabilitySource: listing.availabilitySource,
-      openSlots: listing.openSlots,
-      availableSlots: listing.availableSlots,
-      totalSlots: listing.totalSlots,
-      moveInDate: listing.moveInDate,
-      availableUntil: listing.availableUntil,
-      minStayMonths: listing.minStayMonths,
-      lastConfirmedAt: listing.lastConfirmedAt,
-    })
+      buildPublicAvailability({
+        availabilitySource: listing.availabilitySource,
+        openSlots: listing.openSlots,
+        availableSlots: listing.availableSlots,
+        totalSlots: listing.totalSlots,
+        moveInDate: listing.moveInDate,
+        availableUntil: listing.availableUntil,
+        minStayMonths: listing.minStayMonths,
+        lastConfirmedAt: listing.lastConfirmedAt,
+      })
   );
 }
 
@@ -258,9 +259,11 @@ export function transformToPins(
     );
     const publicAvailability = sourceListing
       ? getNormalizedPublicAvailability(sourceListing)
-      : buildPublicAvailability({
-          availableSlots: bestListing.availableSlots,
-        });
+      : toPublicAvailabilityPayload(
+          buildPublicAvailability({
+            availableSlots: bestListing.availableSlots,
+          })
+        );
     const publicCoordinates = toPublicCoordinates({
       lat: group.lat,
       lng: group.lng,

--- a/tasks/multislot-p1p2-todo.md
+++ b/tasks/multislot-p1p2-todo.md
@@ -1,0 +1,37 @@
+# Multislot P1/P2 fix batch — 2026-07-02
+
+Branch: `fix/multislot-p1p2-2026-07-02` · Source: `docs/multislot-review-2026-07-02.md` · 13 parallel agents, disjoint file ownership; lead runs integration (lint/typecheck/full tests) and commits.
+
+Acceptance criteria: every P1 (1-5) and P2 (1-13, 15-21) fixed or explicitly deferred with reason; regression test per fix; lint+typecheck+unit suites green; no cross-agent file conflicts.
+
+| Agent | Findings | Files owned | Status |
+|---|---|---|---|
+| A cron-integrity | P1-1, P2-9, P2-19 | api/cron/refresh-search-docs, daily-maintenance, query-snapshots.ts (search-doc-dirty.ts untouched — clear-side fix lives in cron) | done — 26/26 tests |
+| B count-parity | P1-2 | api/search-count/route.ts | done — 20/20 tests |
+| C listings-admission | P1-3 | api/search/listings/route.ts | done — 3/3 tests (new route suite) |
+| D projection-parity | P1-4, P2-7, P2-11(projection) | projection-search.ts | done — 24/24 tests; price-null P3 deferred (shared-type blast radius) |
+| E searchdoc-owner | P2-6, P2-16, P2-18(tags), P2-11(semantic) | search-doc-queries.ts, search-cache.ts, migration 20260702000000 | done — 95 tests; dead indexes dropped (structural deadness argument; :5434 down, no EXPLAIN) |
+| F listings-api | P2-1, P2-2, P2-18(call) | api/listings/[id]/route.ts, viewer-state/route.ts | done — 27/27 tests |
+| G facets | P2-5 | api/search/facets/route.ts | done — 35/35 tests; kept search-count bucket + added ip:userId identifier |
+| H identity-epoch | P2-8 | outbox/handlers.ts (mutate-unit.ts untouched) | done — 37/37 tests; row_version-only bump (source_version mirrors host version) |
+| J service-layer | P1-5, P2-3, P2-4, P2-10, P2-20 | search-v2-service.ts, search-params.ts, search-spec.ts, cursor.ts, actions.ts | done — 734 tests search area; projection spec-hash split deferred (see seam comment in projection-search.ts) |
+| K ui-focus | P2-15 | SearchResultsClient.tsx | done — 47/47 tests |
+| L payload-pick | P2-12 | transform.ts, public-listing-payload.ts, public-availability.ts | done — 121 tests incl. downstream |
+| M e2e-prod-flags | P2-13 | playwright.config.ts + tests/e2e/prod-flags-* | done — 5-test dedicated project, validated via --list |
+| N docs | P2-21 | docs/host-managed-patch-contract.md | done — rewritten against current code |
+
+Lead integration (2026-07-02): restored original EOLs on unchanged search-doc-queries.ts lines (true diff 171+/42−); wired SEARCH_FACETS_CACHE_TAG into the facets unstable_cache; resolved count↔dedup TODO (getLimitedCount dispatches into the dedup-aware SearchDoc count); added P1-5 pre-cutover seam comment in projection-search.ts; kept D's gap-default workaround (spec-layer relocation not worth re-touching J's fresh search-spec.ts edits — explicit max_gap_days=180 collapses to 0, documented edge).
+
+Key risk decisions (lead):
+- P2-3: admission span limit must CLAMP list bounds (like the map), never 400 — wide-view default-sort browse works in prod today and must not regress. Occupants + deep-page caps can hard-reject.
+- P1-4/P2-7: projection engine aligns to SearchDoc (prod baseline): strict gender equality, gap window only when explicitly requested.
+- P2-16: prefer dropping/replacing dead partial indexes over adding `d.status` to the WHERE unless sync-lag regression is ruled out; EXPLAIN evidence on local :5434.
+- D/E reuse existing public-availability helpers; L is additive-only on shared types.
+- E keeps `invalidateSearchCaches` name/signature stable; F adds its call site.
+
+Verification: per-agent targeted tests → lead: pnpm lint, pnpm typecheck, pnpm test (full), spot-check e2e feasibility.
+
+## Results + verification story
+- All 13 agents completed with disjoint file ownership; zero file conflicts. Every P1 (1-5) and P2 (1-13, 15-21) fixed except two explicitly deferred slices: P1-5's projection-path spec-hash split (pre-cutover gate, seam comment at projection-search.ts spec-hash site) and D's price-null P3 (shared-type blast radius in search-types.ts).
+- Lead integration: EOL restoration on search-doc-queries.ts (spurious 2400-line diff → true 171+/42−), SEARCH_FACETS_CACHE_TAG wired, count↔dedup TODO resolved (flows via getLimitedCount dispatch), P1-5 seam documented.
+- Verification (2026-07-02): `pnpm typecheck` ✓ clean; `pnpm lint` ✓ 0 errors (18 pre-existing warnings); `pnpm test` ✓ 523 suites / 8159 tests passed, 0 failures (8 pre-existing skips). Playwright prod-flags project validated via `--list` (execution requires prod build; run in CI/dedicated pass).

--- a/tests/e2e/helpers/prod-flags-env.ts
+++ b/tests/e2e/helpers/prod-flags-env.ts
@@ -1,0 +1,54 @@
+/**
+ * Prod-effective feature-flag environment for E2E parity testing.
+ *
+ * Context (docs/multislot-review-2026-07-02.md · P2-13, §4 flag matrix):
+ * every CFM `phaseCutoverDefault(env)` flag resolves to ON in dev/preview but
+ * OFF in prod (the default is `NODE_ENV !== "production"` unless the env var is
+ * explicitly set). Dev/preview E2E therefore validate a DIFFERENT system than
+ * prod serves — a different read engine (SearchDoc vs the phase-04 projection),
+ * different result grouping (dedup), and paywall-on vs paywall-off card shapes.
+ *
+ * This map pins every one of those flags to its prod-effective value so a
+ * dedicated Playwright run exercises the engine + card shape prod actually ships.
+ * Explicit "false" for each `phaseCutoverDefault` flag reproduces the prod
+ * default without relying on NODE_ENV; `ENABLE_SEARCH_DOC=true` matches the
+ * documented prod read engine (docs/DEPLOYMENT.md; §4 "confirm set in prod").
+ *
+ * Single source of truth: consumed by playwright.config.ts (injected into the
+ * launched web server's env) and by the prod-flags smoke spec's runtime guard.
+ * Keep every key mapped to the getters in `src/lib/env.ts`.
+ */
+export const PROD_EFFECTIVE_FLAG_ENV: Readonly<Record<string, string>> = {
+  // Read path + card shape — the largest dev/prod gap (P2-13).
+  FEATURE_PHASE04_PROJECTION_READS: "false",
+  FEATURE_SEARCH_LISTING_DEDUP: "false",
+  // Projection write path (dark writes) — prod default OFF, for a faithful snapshot.
+  FEATURE_PHASE02_PROJECTION_WRITES: "false",
+  FEATURE_PHASE03_SEMANTIC_PROJECTION_WRITES: "false",
+  // Contact / paywall / entitlement surface — prod default OFF.
+  ENABLE_CONTACT_FIRST_LISTINGS: "false",
+  ENABLE_CONTACT_PAYWALL: "false",
+  ENABLE_CONTACT_PAYWALL_ENFORCEMENT: "false",
+  ENABLE_SEARCH_ALERT_PAYWALL: "false",
+  ENABLE_ENTITLEMENT_STATE: "false",
+  ENABLE_CONTACT_RESTORATION_AUTOMATION: "false",
+  ENABLE_PRIVATE_FEEDBACK: "false",
+  // Public contract / cache / listing-create surface — prod default OFF.
+  FEATURE_PUBLIC_AUTOCOMPLETE_CONTRACT: "false",
+  FEATURE_PUBLIC_CACHE_COHERENCE: "false",
+  FEATURE_LISTING_CREATE_COLLISION_WARN: "false",
+  FEATURE_MODERATION_WRITE_LOCKS: "false",
+  // Documented prod read engine (SearchDoc, not the legacy LIKE path).
+  ENABLE_SEARCH_DOC: "true",
+} as const;
+
+/**
+ * Runtime signal that the current Playwright process is the prod-flags run.
+ * Set by playwright.config.ts (from `--project=prod-flags-smoke` or the env
+ * var) so the smoke spec can skip itself under any other project/invocation.
+ */
+export const PROD_FLAGS_RUN_ENV = "E2E_PROD_FLAGS";
+
+export function isProdFlagsRun(): boolean {
+  return process.env[PROD_FLAGS_RUN_ENV] === "true";
+}

--- a/tests/e2e/prod-flags-smoke.anon.spec.ts
+++ b/tests/e2e/prod-flags-smoke.anon.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Prod-flag Smoke Suite (Anonymous)
+ *
+ * Addresses docs/multislot-review-2026-07-02.md · P2-13 + Test gap #1:
+ * every dev-default E2E validates the non-prod read engine/card shape, so a
+ * dev/preview sign-off does NOT validate what prod serves. This suite runs the
+ * critical search + listing flows with the PROD-EFFECTIVE feature-flag env
+ * (phase-04 projection reads OFF, dedup OFF, paywalls OFF, SearchDoc engine ON —
+ * see tests/e2e/helpers/prod-flags-env.ts and playwright.config.ts).
+ *
+ * It is a DEDICATED run, not part of the normal suite: the flag env is injected
+ * only when this run is requested, and the spec self-skips otherwise (guard
+ * below) so it can never produce a misleading pass/fail under dev-default flags.
+ *
+ * Run: E2E_PROD_FLAGS=true pnpm exec playwright test --project=prod-flags-smoke
+ */
+
+import {
+  test,
+  expect,
+  SF_BOUNDS,
+  searchResultsContainer,
+  scopedCards,
+} from "./helpers/test-utils";
+import { isProdFlagsRun } from "./helpers/prod-flags-env";
+
+// Seeded San Francisco viewport — the same bounds the P0 smoke uses.
+const boundsQS = `minLat=${SF_BOUNDS.minLat}&maxLat=${SF_BOUNDS.maxLat}&minLng=${SF_BOUNDS.minLng}&maxLng=${SF_BOUNDS.maxLng}`;
+const SEARCH_URL = `/search?${boundsQS}`;
+
+// Valid-or-empty outcome: results, or one of the recognized zero-result headings.
+const zeroResults = (page: Parameters<typeof searchResultsContainer>[0]) =>
+  page.locator(
+    'h2:has-text("No matches found"), h3:has-text("No exact matches")'
+  );
+
+test.describe("Prod-flag Smoke Suite", () => {
+  // Self-guard: only run when this process is the prod-flags run (the config
+  // injects the prod-effective flag env for the launched server in the same
+  // condition). Under any other project/invocation the flags are dev-default,
+  // so skip rather than validate the wrong system.
+  test.beforeEach(() => {
+    test.skip(
+      !isProdFlagsRun(),
+      "Prod-flag smoke runs only under the prod-flags-smoke project with " +
+        "E2E_PROD_FLAGS=true. Run: E2E_PROD_FLAGS=true pnpm exec playwright " +
+        "test --project=prod-flags-smoke"
+    );
+  });
+
+  // PF01: Search page loads with results for a seeded city under prod flags.
+  test("PF01: search page loads with results (SearchDoc engine)", async ({
+    page,
+  }) => {
+    const response = await page.goto(SEARCH_URL);
+    expect(response?.status()).toBe(200);
+
+    const cards = scopedCards(page);
+    await expect(cards.first()).toBeAttached({ timeout: 30_000 });
+    expect(await cards.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  // PF02: Price filter narrows results — every visible price <= cap.
+  test("PF02: price filter applies (maxPrice)", async ({ page }) => {
+    await page.goto(`/search?maxPrice=1000&${boundsQS}`);
+
+    const container = searchResultsContainer(page);
+    const cards = container.locator('[data-testid="listing-card"]');
+    await expect(cards.first()).toBeAttached({ timeout: 30_000 });
+
+    const priceTexts = await container
+      .locator('[data-testid="listing-card"] [data-testid="listing-price"]')
+      .allTextContents();
+
+    for (const priceText of priceTexts) {
+      const numeric = parseInt(priceText.replace(/[^0-9]/g, ""), 10);
+      if (!Number.isNaN(numeric)) {
+        expect(numeric).toBeLessThanOrEqual(1000);
+      }
+    }
+  });
+
+  // PF03: Gender filter applies — reaches a valid state, narrows (or holds) the
+  // result set, and round-trips in the URL. Under prod's SearchDoc engine the
+  // gender filter EXCLUDES unspecified rows (review P1-4), so filtering can only
+  // reduce the set: filtered first-page count <= baseline first-page count.
+  test("PF03: gender filter applies (genderPreference)", async ({ page }) => {
+    await page.goto(SEARCH_URL);
+    const baselineCards = scopedCards(page);
+    await expect(baselineCards.first()).toBeAttached({ timeout: 30_000 });
+    const baselineCount = await baselineCards.count();
+
+    await page.goto(`/search?genderPreference=FEMALE_ONLY&${boundsQS}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const cards = scopedCards(page);
+    await expect(cards.or(zeroResults(page)).first()).toBeAttached({
+      timeout: 30_000,
+    });
+
+    // URL preserves the applied filter (shareability contract).
+    expect(page.url()).toContain("genderPreference=FEMALE_ONLY");
+
+    // Filtering only removes rows — never adds them.
+    const filteredCount = await cards.count();
+    expect(filteredCount).toBeLessThanOrEqual(baselineCount);
+  });
+
+  // PF04: Listing detail opens from a card.
+  test("PF04: listing detail opens from a card", async ({ page }) => {
+    await page.goto(SEARCH_URL);
+
+    const cards = scopedCards(page);
+    await expect(cards.first()).toBeAttached({ timeout: 30_000 });
+
+    const firstLink = cards.first().locator('a[href^="/listings/"]').first();
+    const href = await firstLink.getAttribute("href");
+    expect(href).toBeTruthy();
+    expect(href).toMatch(/^\/listings\//);
+
+    // Direct navigation is more reliable than click for SSR apps (mirrors P0 S07).
+    await page.goto(href!);
+    await expect(page).toHaveURL(/\/listings\//);
+  });
+
+  // PF05: Cards do NOT show the dev-only dedup grouping UI. `group-dates-trigger`
+  // renders only when the card carries a dedup `groupSummary`, which only the
+  // `searchListingDedup` engine emits (ListingCard.tsx). With dedup prod-OFF it
+  // must be absent — the concrete card-shape divergence P2-13 calls out.
+  test("PF05: no dev-only dedup grouping UI on cards", async ({ page }) => {
+    await page.goto(SEARCH_URL);
+
+    const container = searchResultsContainer(page);
+    const cards = container.locator('[data-testid="listing-card"]');
+    await expect(cards.first()).toBeAttached({ timeout: 30_000 });
+
+    await expect(
+      container.locator('[data-testid="group-dates-trigger"]')
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **all 5 P1s and 19 P2s** from the multislot (CFM) search + listings deep review (`docs/multislot-review-2026-07-02.md`, included in this PR). Executed as 13 parallel fix agents with strictly disjoint file ownership, then a lead integration pass.

### P1 fixes
| Finding | Fix |
|---|---|
| P1-1 lost dirty-mark race | `clearDirtyFlags` deletes via unnest-paired `(listing_id, observed marked_at)` with `marked_at <=` — concurrent re-marks survive and reprocess next run |
| P1-2 count ≠ list | `search-count` uses the same sort-gated projection eligibility + `hasProjectionFreshnessHoles` guard as the list; SearchDoc fallback inherits dedup-aware totals |
| P1-3 swallowed admission errors | `/api/search/listings` propagates `admissionError` (400) / `snapshotExpired` (409) instead of throwing into the V1 fallback |
| P1-4 gender NULL flap | Projection engine now uses strict equality (SearchDoc parity) for gender/household-gender |
| P1-5 hash contract | Bare filters hash is the universal client-facing `meta.queryHash` on all prod surfaces; `?occupants=`/`?guests=` canonicalized in the parser; redundant `actions.ts` hash override removed. Projection-path spec-hash split **deferred as a pre-cutover gate** (seam comment at the spec-hash site — that hash doubles as the tested snapshot staleness fence) |

### P2 fixes (highlights)
- **Privacy/abuse**: viewer-state redacts hidden/moderated listings byte-identically to not-found; facets cache key quantized to the shared ~100m step + ip:userId rate-limit identity; `publicAvailability` serialization narrowed to the 9-field contract (internal lifecycle fields no longer leak)
- **Write-path integrity**: PATCH address-change threads validated coords into canonical sync; identity MERGE/SPLIT re-points inventories and rebuilds projections at the new epoch (idempotent, epoch-safe, host `source_version` deliberately preserved); missing-doc rescan backstop; QuerySnapshot reaper in daily-maintenance
- **Engine parity**: move-in gap default = exact match (explicit `max_gap_days` still honored; edge: explicit 180 collapses to 0); occupants/deep-page admission caps on all engine paths (bounds-span deliberately NOT rejected — wide-view browse is supported UX); dedup-aware totals; projection + semantic rows now carry resolved availability (freshness UI renders identically dev/prod)
- **Caching**: `tags` wired on all 4 `unstable_cache` surfaces + `invalidateSearchCaches()` fired on availability PATCH (event invalidation was dead code); keyset cursors bound to the filter hash (optional `qh`, V1 tolerated)
- **DB**: migration `20260702000000` drops 3 dead partial indexes (predicated on doc columns the hot WHERE never references — structurally unusable). Rollback: recreate statements included in the migration comment. Data safety: pre-launch dummy data; plain DROP INDEX, no lock risk
- **A11y**: load-more terminal transition moves focus to the results-end message only when the button held focus (WCAG 2.4.3)
- **Process**: dedicated `prod-flags-smoke` Playwright project pinning prod-effective flags (`E2E_PROD_FLAGS=true pnpm exec playwright test --project=prod-flags-smoke`; needs a prod build); `host-managed-patch-contract.md` rewritten against current code

### Known deferrals
- P1-5 projection-path spec-hash split (latent behind two prod-off flags; must land before flipping `phase04ProjectionReads` + unified V2 client together)
- Projection `price ?? 0` null-passthrough (P3): requires widening `ListingData.price` in `search-types.ts` app-wide

### Verification
- `pnpm typecheck` ✓ clean
- `pnpm lint` ✓ 0 errors (18 pre-existing warnings)
- `pnpm test` ✓ **523 suites / 8159 tests passed, 0 failures** (8 pre-existing skips)
- Note for reviewers: `search-doc-queries.ts` line endings were preserved on unchanged lines (true diff 171+/42−)

🤖 Generated with [Claude Code](https://claude.com/claude-code)