### PR TITLE
feat(cron): keep seed-owned listings inside the 21-day freshness window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -258,6 +258,8 @@ NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
 # ENABLE_BOOKING_AUDIT=true          # requires SOFT_HOLDS=on
 # ENABLE_CONTACT_FIRST_LISTINGS=true # listing detail becomes contact-first; new bookings/holds blocked
 # ENABLE_FRESHNESS_NOTIFICATIONS=off # daily host freshness reminder/warning cron; values: on|off
+# ENABLE_SEED_FRESHNESS_REFRESH=true # demo/staging ONLY: daily-maintenance re-stamps lastConfirmedAt for seed-owned listings so search never empties after 21 days; values: true|false
+# SEED_FRESHNESS_OWNER_DOMAINS=roomshare.dev # comma-separated owner email domains treated as seed accounts
 
 # --- AI / Embeddings ---
 # GEMINI_API_KEY=your-gemini-api-key

--- a/src/__tests__/api/cron/daily-maintenance.test.ts
+++ b/src/__tests__/api/cron/daily-maintenance.test.ts
@@ -40,6 +40,10 @@ jest.mock("@/lib/outbox/retention", () => ({
   cleanupConsumedCacheInvalidationsOnce: jest.fn(),
 }));
 
+jest.mock("@/lib/listings/seed-freshness", () => ({
+  refreshSeedListingFreshness: jest.fn(),
+}));
+
 jest.mock("next/headers", () => ({
   headers: jest.fn(async () => new Headers({ host: "localhost:3000" })),
 }));
@@ -60,6 +64,7 @@ jest.mock("next/server", () => ({
 import { GET } from "@/app/api/cron/daily-maintenance/route";
 import { validateCronAuth } from "@/lib/cron-auth";
 import { features } from "@/lib/env";
+import { refreshSeedListingFreshness } from "@/lib/listings/seed-freshness";
 import {
   cleanupConsumedCacheInvalidationsOnce,
   cleanupTerminalOutboxEventsOnce,
@@ -86,6 +91,11 @@ describe("GET /api/cron/daily-maintenance", () => {
     Object.defineProperty(features, "freshnessNotifications", {
       value: true,
       writable: true,
+    });
+    Object.defineProperty(features, "seedFreshnessRefresh", {
+      value: false,
+      writable: true,
+      configurable: true,
     });
     (prisma.rateLimitEntry.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
     (prisma.idempotencyKey.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
@@ -141,6 +151,76 @@ describe("GET /api/cron/daily-maintenance", () => {
         expect.objectContaining({
           task: "freshness-reminders",
           success: true,
+        }),
+      ])
+    );
+  });
+
+  it("re-stamps seed listing freshness inside the daily window when enabled", async () => {
+    jest.setSystemTime(new Date("2026-04-17T09:03:00.000Z"));
+    Object.defineProperty(features, "seedFreshnessRefresh", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    (refreshSeedListingFreshness as jest.Mock).mockResolvedValue({
+      refreshed: 15,
+    });
+
+    const response = await GET(createRequest() as any);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(refreshSeedListingFreshness).toHaveBeenCalledTimes(1);
+    expect(payload.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task: "refresh-seed-listing-freshness",
+          success: true,
+          detail: { refreshed: 15 },
+        }),
+      ])
+    );
+  });
+
+  it("marks the seed-freshness task skipped when the flag is off (default)", async () => {
+    jest.setSystemTime(new Date("2026-04-17T09:03:00.000Z"));
+
+    const response = await GET(createRequest() as any);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(refreshSeedListingFreshness).not.toHaveBeenCalled();
+    expect(payload.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task: "refresh-seed-listing-freshness",
+          skipped: true,
+          detail: { skipped: true, reason: "feature_disabled" },
+        }),
+      ])
+    );
+  });
+
+  it("marks the seed-freshness task skipped outside the daily window", async () => {
+    jest.setSystemTime(new Date("2026-04-17T15:00:00.000Z"));
+    Object.defineProperty(features, "seedFreshnessRefresh", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const response = await GET(createRequest() as any);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(refreshSeedListingFreshness).not.toHaveBeenCalled();
+    expect(payload.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task: "refresh-seed-listing-freshness",
+          skipped: true,
+          detail: { skipped: true, reason: "outside_daily_window" },
         }),
       ])
     );

--- a/src/__tests__/lib/listings/seed-freshness.test.ts
+++ b/src/__tests__/lib/listings/seed-freshness.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ *
+ * refreshSeedListingFreshness — keeps seed-owned listings inside the 21-day
+ * host-managed freshness window on demo deployments (see seed-freshness.ts).
+ */
+
+const mockFindMany = jest.fn();
+const mockUpdateMany = jest.fn();
+const mockTransaction = jest.fn();
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: (cb: (tx: unknown) => Promise<unknown>) =>
+      mockTransaction(cb),
+  },
+}));
+
+const mockMarkListingsDirtyInTx = jest.fn();
+jest.mock("@/lib/search/search-doc-dirty", () => ({
+  markListingsDirtyInTx: (...args: unknown[]) =>
+    mockMarkListingsDirtyInTx(...args),
+}));
+
+import {
+  getSeedOwnerDomains,
+  refreshSeedListingFreshness,
+} from "@/lib/listings/seed-freshness";
+
+const tx = {
+  listing: { findMany: mockFindMany, updateMany: mockUpdateMany },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.SEED_FRESHNESS_OWNER_DOMAINS;
+  mockTransaction.mockImplementation((cb) => cb(tx));
+});
+
+describe("getSeedOwnerDomains", () => {
+  it("defaults to roomshare.dev", () => {
+    expect(getSeedOwnerDomains()).toEqual(["roomshare.dev"]);
+  });
+
+  it("parses a comma-separated, whitespace-tolerant, lowercased allowlist", () => {
+    process.env.SEED_FRESHNESS_OWNER_DOMAINS = " Roomshare.dev , demo.Test ,";
+    expect(getSeedOwnerDomains()).toEqual(["roomshare.dev", "demo.test"]);
+  });
+});
+
+describe("refreshSeedListingFreshness", () => {
+  it("re-stamps only stale ACTIVE seed-owned listings and marks them dirty in the same tx", async () => {
+    mockFindMany.mockResolvedValue([{ id: "l1" }, { id: "l2" }]);
+    mockUpdateMany.mockResolvedValue({ count: 2 });
+
+    const result = await refreshSeedListingFreshness();
+
+    expect(result).toEqual({ refreshed: 2 });
+    const where = mockFindMany.mock.calls[0][0].where;
+    expect(where.status).toBe("ACTIVE");
+    expect(where.lastConfirmedAt.lt).toBeInstanceOf(Date);
+    // ~14-day threshold (allow scheduling jitter of a minute)
+    const ageMs = Date.now() - where.lastConfirmedAt.lt.getTime();
+    expect(ageMs).toBeGreaterThan(13.9 * 24 * 60 * 60 * 1000);
+    expect(ageMs).toBeLessThan(14.1 * 24 * 60 * 60 * 1000);
+    expect(where.owner.OR).toEqual([
+      { email: { endsWith: "@roomshare.dev", mode: "insensitive" } },
+    ]);
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["l1", "l2"] } },
+      data: { lastConfirmedAt: expect.any(Date) },
+    });
+    expect(mockMarkListingsDirtyInTx).toHaveBeenCalledWith(
+      tx,
+      ["l1", "l2"],
+      "listing_updated"
+    );
+  });
+
+  it("is a no-op when nothing is stale", async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const result = await refreshSeedListingFreshness();
+
+    expect(result).toEqual({ refreshed: 0 });
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(mockMarkListingsDirtyInTx).not.toHaveBeenCalled();
+  });
+
+  it("builds one endsWith filter per allowlisted domain", async () => {
+    process.env.SEED_FRESHNESS_OWNER_DOMAINS = "roomshare.dev,demo.test";
+    mockFindMany.mockResolvedValue([]);
+
+    await refreshSeedListingFreshness();
+
+    expect(mockFindMany.mock.calls[0][0].where.owner.OR).toEqual([
+      { email: { endsWith: "@roomshare.dev", mode: "insensitive" } },
+      { email: { endsWith: "@demo.test", mode: "insensitive" } },
+    ]);
+  });
+
+  it("refuses to run with an empty domain allowlist", async () => {
+    process.env.SEED_FRESHNESS_OWNER_DOMAINS = " , ";
+
+    const result = await refreshSeedListingFreshness();
+
+    expect(result).toEqual({ refreshed: 0 });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cron/daily-maintenance/route.ts
+++ b/src/app/api/cron/daily-maintenance/route.ts
@@ -45,6 +45,7 @@ import {
 } from "@/lib/outbox/retention";
 import { cleanupExpiredVerificationDocumentsOnce } from "@/lib/verification/retention";
 import { deleteExpiredQuerySnapshots } from "@/lib/search/query-snapshots";
+import { refreshSeedListingFreshness } from "@/lib/listings/seed-freshness";
 
 interface TaskResult {
   task: string;
@@ -261,6 +262,22 @@ export async function GET(request: NextRequest) {
       return { deleted };
     });
 
+    if (features.seedFreshnessRefresh) {
+      await runTask(results, "refresh-seed-listing-freshness", async () => {
+        const result = await withRetry(() => refreshSeedListingFreshness(), {
+          context: "refresh-seed-listing-freshness",
+        });
+
+        return { refreshed: result.refreshed };
+      });
+    } else {
+      markSkippedTask(
+        results,
+        "refresh-seed-listing-freshness",
+        "feature_disabled"
+      );
+    }
+
     await runTask(results, "cleanup-typing-status", async () => {
       const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
       const result = await withRetry(
@@ -330,6 +347,11 @@ export async function GET(request: NextRequest) {
     markSkippedTask(
       results,
       "cleanup-query-snapshots",
+      "outside_daily_window"
+    );
+    markSkippedTask(
+      results,
+      "refresh-seed-listing-freshness",
       "outside_daily_window"
     );
     markSkippedTask(results, "cleanup-typing-status", "outside_daily_window");

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -792,6 +792,12 @@ export const features = {
   get staleAutoPause() {
     return process.env.ENABLE_STALE_AUTO_PAUSE === "on";
   },
+  // Demo/staging only: keep seed-owned listings inside the 21-day freshness
+  // window so search never silently empties on deployments running seed data.
+  // Explicit opt-in; never defaults on (real hosts must confirm themselves).
+  get seedFreshnessRefresh() {
+    return process.env.ENABLE_SEED_FRESHNESS_REFRESH === "true";
+  },
   get searchListingDedup() {
     return phaseCutoverDefault(process.env.FEATURE_SEARCH_LISTING_DEDUP);
   },

--- a/src/lib/listings/seed-freshness.ts
+++ b/src/lib/listings/seed-freshness.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@/lib/prisma";
+import { markListingsDirtyInTx } from "@/lib/search/search-doc-dirty";
+
+/**
+ * Keep seed/demo listings from aging out of the 21-day host-managed freshness
+ * window (`lastConfirmedAt`) that gates public search eligibility.
+ *
+ * Real hosts confirm availability themselves; seed data has no host, so on a
+ * demo deployment the entire inventory silently disappears from search 21 days
+ * after seeding (observed in prod on 2026-07-01). This task re-stamps
+ * `lastConfirmedAt` for listings owned by allowlisted seed-account domains
+ * once they get within range of the cutoff.
+ *
+ * Scope guards:
+ * - Only owners whose email domain is in SEED_FRESHNESS_OWNER_DOMAINS
+ *   (default: roomshare.dev) — real hosts are never touched.
+ * - Only ACTIVE listings already older than the refresh threshold.
+ * - Explicit opt-in via ENABLE_SEED_FRESHNESS_REFRESH=true (see env.ts);
+ *   intended for demo/staging deployments running on seed data only.
+ */
+const REFRESH_AFTER_DAYS = 14;
+
+export function getSeedOwnerDomains(): string[] {
+  const raw = process.env.SEED_FRESHNESS_OWNER_DOMAINS || "roomshare.dev";
+  return raw
+    .split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export async function refreshSeedListingFreshness(): Promise<{
+  refreshed: number;
+}> {
+  const domains = getSeedOwnerDomains();
+  if (domains.length === 0) {
+    return { refreshed: 0 };
+  }
+
+  const cutoff = new Date(Date.now() - REFRESH_AFTER_DAYS * 24 * 60 * 60 * 1000);
+
+  const refreshed = await prisma.$transaction(async (tx) => {
+    const stale = await tx.listing.findMany({
+      where: {
+        status: "ACTIVE",
+        lastConfirmedAt: { lt: cutoff },
+        owner: {
+          OR: domains.map((domain) => ({
+            email: { endsWith: `@${domain}`, mode: "insensitive" as const },
+          })),
+        },
+      },
+      select: { id: true },
+    });
+
+    if (stale.length === 0) {
+      return 0;
+    }
+
+    const ids = stale.map((listing) => listing.id);
+    await tx.listing.updateMany({
+      where: { id: { in: ids } },
+      data: { lastConfirmedAt: new Date() },
+    });
+    await markListingsDirtyInTx(tx, ids, "listing_updated");
+
+    return ids.length;
+  });
+
+  return { refreshed };
+}


### PR DESCRIPTION
## Why

Prod search silently emptied on ~2026-07-01: the Jun-10 seed crossed the 21-day `lastConfirmedAt` freshness eligibility cutoff, leaving the demo deployment with **zero searchable listings**. Discovered while running the prod-flags smoke for PR #172.

## What

A new opt-in daily-maintenance task `refresh-seed-listing-freshness`:
- Gated by `ENABLE_SEED_FRESHNESS_REFRESH=true` (never defaults on; getter in `env.ts`)
- Targets only ACTIVE listings owned by allowlisted seed-account email domains (`SEED_FRESHNESS_OWNER_DOMAINS`, default `roomshare.dev`) whose `lastConfirmedAt` is older than 14 days — real hosts are never touched
- Re-stamps `lastConfirmedAt = NOW()` and marks search docs dirty in the same transaction
- Standard `runTask`/`withRetry` + `markSkippedTask` wiring (feature_disabled / outside_daily_window)

## Ops to activate (after merge)

1. `vercel env add ENABLE_SEED_FRESHNESS_REFRESH` → `true` (production)
2. One-time immediate fix (data already stale, cron threshold is 14d so it will also catch it on next window):
   `UPDATE "Listing" SET "lastConfirmedAt" = NOW() WHERE status = 'ACTIVE';` on prod Neon

## Verification

- 15 targeted tests green (domain allowlist parsing, tx dirty-marking, no-op paths, empty-allowlist refusal, cron gating + window skip)
- `pnpm typecheck` clean, `pnpm lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)